### PR TITLE
re-added 'state' field which had been commented out

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -85,7 +85,7 @@ class EligibilityCheckSerializer(EligibilityCheckSerializerBase):
             'is_you_or_your_partner_over_60',
             'has_partner',
             'on_passported_benefits',
-            # 'state'  #TODO not sure why we need this here?
+            'state'
         )
 
 

--- a/cla_backend/apps/call_centre/tests/test_callcentre_api.py
+++ b/cla_backend/apps/call_centre/tests/test_callcentre_api.py
@@ -643,7 +643,8 @@ class EligibilityCheckTests(CLAOperatorAuthBaseApiTestMixin, APITestCase):
              'partner',
              'has_partner',
              'on_passported_benefits',
-             'is_you_or_your_partner_over_60'
+             'is_you_or_your_partner_over_60',
+             'state'
             ]
         )
 


### PR DESCRIPTION
'state' flag was removed by Marco but I'm not sure why?  This patch adds it back in and enables a test for it.

commit db51c3e242e6a581aa6ad80917283753c4b78a72
Author: Marco Fucci info@marcofucci.com
Date:   Wed Apr 16 14:53:44 2014 +0100

```
implemented close case endpoint
```

diff --git a/cla_backend/apps/call_centre/serializers.py b/cla_backend/apps/call_centre/serializers.py
index 8f6c3a7..65248e6 100644
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -84,7 +84,7 @@ class EligibilityCheckSerializer(EligibilityCheckSerializerBase):
             'is_you_or_your_partner_over_60',
             'has_partner',
             'on_passported_benefits',
-            'state'
-            # 'state'  #TODO not sure why we need this here?
