### PR TITLE
handle moving through means test wihtout visiting the benefits page.

### DIFF
--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -239,9 +239,9 @@ class EligibilityCheck(TimeStampedModel, ValidateModelMixin, ModelDiffMixin):
         self.save()
 
     def to_case_data(self):
-        def compose_dict(model=self, props=[]):
-            if not model:
-                return None
+        def compose_dict(model=self, props=None):
+            if not props: props = []
+            if not model: return None
 
             obj = {}
             for prop in props:
@@ -263,9 +263,11 @@ class EligibilityCheck(TimeStampedModel, ValidateModelMixin, ModelDiffMixin):
 
         d['facts'] = compose_dict(props=[
             'dependants_old', 'dependants_young', 'has_partner',
-            'is_you_or_your_partner_over_60', 'on_passported_benefits',
-            'on_nass_benefits'
+            'is_you_or_your_partner_over_60',
         ])
+
+        d['facts']['on_passported_benefits'] = self.on_passported_benefits
+        d['facts']['on_nass_benefits'] = self.on_nass_benefits
 
         if self.you:
             you_props = {

--- a/cla_backend/apps/legalaid/tests/test_models.py
+++ b/cla_backend/apps/legalaid/tests/test_models.py
@@ -88,6 +88,7 @@ class EligibilityCheckTestCase(TestCase):
             dependants_young=3, dependants_old=2,
             is_you_or_your_partner_over_60=True,
             on_passported_benefits=True,
+            on_nass_benefits=False,
             has_partner=False,
         )
 
@@ -101,6 +102,7 @@ class EligibilityCheckTestCase(TestCase):
                     'dependants_old': 2,
                     'is_you_or_your_partner_over_60':True,
                     'on_passported_benefits':True,
+                    'on_nass_benefits': False,
                     'has_partner': False,
                     'is_partner_opponent': False,
                 },
@@ -182,6 +184,7 @@ class EligibilityCheckTestCase(TestCase):
             dependants_young=3, dependants_old=2,
             is_you_or_your_partner_over_60=True,
             on_passported_benefits=True,
+            on_nass_benefits=False,
             has_partner=True,
         )
 
@@ -193,6 +196,7 @@ class EligibilityCheckTestCase(TestCase):
                 'dependants_old': 2,
                 'is_you_or_your_partner_over_60':True,
                 'on_passported_benefits': True,
+                'on_nass_benefits': False,
                 'has_partner': True,
                 'is_partner_opponent': False,
             },


### PR DESCRIPTION
error caused because on_nass_benefits is a NullBooleanField
