### PR TITLE
changed design of the API

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -194,6 +194,7 @@ class FeedbackSerializer(FeedbackSerializerBase):
 
     class Meta(FeedbackSerializerBase.Meta):
         fields = (
+            'reference',
             'created_by',
             'case',
             'comment',
@@ -201,5 +202,5 @@ class FeedbackSerializer(FeedbackSerializerBase):
             'resolved',
             'provider',
             'created',
-            'modified'
+            'modified',
         )

--- a/cla_backend/apps/call_centre/tests/api/test_feedback_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_feedback_api.py
@@ -1,0 +1,67 @@
+from cla_common.constants import REQUIRES_ACTION_BY
+from cla_provider.tests.api.test_feedback_api import FeedbackAPIMixin
+from core.tests.mommy_utils import make_recipe
+from core.tests.test_base import NestedSimpleResourceAPIMixin, \
+    SimpleResourceAPIMixin
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from legalaid.tests.views.test_base import CLAOperatorAuthBaseApiTestMixin
+
+
+
+
+class FeedbackAPITestCase(
+    SimpleResourceAPIMixin, CLAOperatorAuthBaseApiTestMixin, APITestCase
+):
+    RESOURCE_RECIPE = 'cla_provider.feedback'
+    LOOKUP_KEY = 'reference'
+    API_URL_BASE_NAME = 'feedback'
+
+    @property
+    def response_keys(self):
+        return [
+            "reference",
+            "provider",
+            "case",
+            "created_by",
+            "comment",
+            "justified",
+            "resolved",
+            "created",
+            "modified"
+        ]
+
+    def test_patch_comment_allowed(self):
+        data = {
+            'comment': self.resource.comment+u'test'
+        }
+        resp = self.client.patch(
+            self.detail_url,
+            data=data,
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization())
+
+        self.assertResponseKeys(resp)
+        self.assertEqual(resp.data['comment'], self.resource.comment)
+
+    def test_patch_other_fields_allowed(self):
+        data = {
+            'justified': not self.resource.justified,
+            'resolved': not self.resource.resolved
+        }
+        resp = self.client.patch(
+            self.detail_url,
+            data=data,
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization())
+
+        self.assertResponseKeys(resp)
+        self.assertEqual(resp.data['justified'], not self.resource.justified)
+        self.assertEqual(resp.data['resolved'], not self.resource.resolved)
+
+    def test_methods_not_allowed(self):
+        self._test_delete_not_allowed(self.detail_url)
+        self._test_post_not_allowed(self.detail_url)
+        self._test_post_not_allowed(self.list_url)
+        self._test_patch_not_allowed(self.list_url)

--- a/cla_backend/apps/call_centre/urls.py
+++ b/cla_backend/apps/call_centre/urls.py
@@ -22,6 +22,8 @@ router.register(r'adaptations', views.AdaptationDetailsMetadataViewSet,
         base_name='adaptations-metadata')
 router.register(r'mattertype', views.MatterTypeViewSet)
 router.register(r'mediacode', views.MediaCodeViewSet)
+router.register(r'feedback', views.FeedbackViewSet)
+
 
 timer_router = core_routers.SingletonRouter()
 timer_router.register(r'timer', views.TimerViewSet, base_name='timer')
@@ -32,7 +34,6 @@ case_one2one_router.register(r'personal_details', views.PersonalDetailsViewSet)
 case_one2one_router.register(r'adaptation_details', views.AdaptationDetailsViewSet)
 case_one2one_router.register(r'thirdparty_details', views.ThirdPartyDetailsViewSet)
 case_one2one_router.register(r'diagnosis', views.DiagnosisViewSet, base_name='diagnosis')
-case_one2one_router.register(r'feedback', views.FeedbackViewSet)
 
 case_one2many_router = NestedSimpleRouter(router, r'case', lookup='case')
 case_one2many_router.register(r'logs', views.LogViewSet)

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response as DRFResponse
 from rest_framework.filters import OrderingFilter, DjangoFilterBackend, \
     SearchFilter
 
-from cla_provider.models import Provider, OutOfHoursRota, Staff
+from cla_provider.models import Provider, OutOfHoursRota, Staff, Feedback
 from cla_eventlog import event_registry
 from cla_eventlog.views import BaseEventViewSet, BaseLogViewSet
 from cla_provider.helpers import ProviderAllocationHelper, notify_case_assigned
@@ -337,6 +337,12 @@ class LogViewSet(CallCentrePermissionsViewSetMixin, BaseLogViewSet):
     serializer_class = LogSerializer
 
 
-class FeedbackViewSet(CallCentrePermissionsViewSetMixin, BaseFeedbackViewSet):
+class FeedbackViewSet(CallCentrePermissionsViewSetMixin,
+                      mixins.ListModelMixin,
+                      mixins.UpdateModelMixin,
+                      mixins.RetrieveModelMixin,
+                      viewsets.GenericViewSet):
+    model = Feedback
+    lookup_field = 'reference'
     serializer_class = FeedbackSerializer
 

--- a/cla_backend/apps/cla_provider/migrations/0003_auto__add_feedback.py
+++ b/cla_backend/apps/cla_provider/migrations/0003_auto__add_feedback.py
@@ -26,6 +26,7 @@ class Migration(SchemaMigration):
         db.delete_table(u'cla_provider_feedback')
 
 
+
     models = {
         u'auth.group': {
             'Meta': {'object_name': 'Group'},

--- a/cla_backend/apps/cla_provider/migrations/0004_auto__add_feedback.py
+++ b/cla_backend/apps/cla_provider/migrations/0004_auto__add_feedback.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting model 'Feedback'
+        db.delete_table(u'cla_provider_feedback')
+
+        # Adding model 'Feedback'
+        db.create_table(u'cla_provider_feedback', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('model_utils.fields.AutoCreatedField')(default=datetime.datetime.now)),
+            ('modified', self.gf('model_utils.fields.AutoLastModifiedField')(default=datetime.datetime.now)),
+            ('reference', self.gf('uuidfield.fields.UUIDField')(unique=True, max_length=32, blank=True)),
+            ('case', self.gf('django.db.models.fields.related.ForeignKey')(related_name='provider_feedback', to=orm['legalaid.Case'])),
+            ('created_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['cla_provider.Staff'])),
+            ('comment', self.gf('django.db.models.fields.TextField')()),
+            ('justified', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('resolved', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('issue', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal(u'cla_provider', ['Feedback'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Feedback'
+        db.delete_table(u'cla_provider_feedback')
+
+        db.create_table(u'cla_provider_feedback', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('model_utils.fields.AutoCreatedField')(default=datetime.datetime.now)),
+            ('modified', self.gf('model_utils.fields.AutoLastModifiedField')(default=datetime.datetime.now)),
+            ('created_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['cla_provider.Staff'])),
+            ('comment', self.gf('django.db.models.fields.TextField')()),
+            ('justified', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('resolved', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'cla_provider', ['Feedback'])
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cla_provider.feedback': {
+            'Meta': {'object_name': 'Feedback'},
+            'case': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'provider_feedback'", 'to': u"orm['legalaid.Case']"}),
+            'comment': ('django.db.models.fields.TextField', [], {}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Staff']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'justified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'resolved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'cla_provider.outofhoursrota': {
+            'Meta': {'object_name': 'OutOfHoursRota'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']"}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'cla_provider.provider': {
+            'Meta': {'object_name': 'Provider'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'email_address': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'law_category': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['legalaid.Category']", 'through': u"orm['cla_provider.ProviderAllocation']", 'symmetrical': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'opening_hours': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'short_code': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone_backdoor': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone_frontdoor': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        u'cla_provider.providerallocation': {
+            'Meta': {'object_name': 'ProviderAllocation'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']"}),
+            'weighted_distribution': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'cla_provider.staff': {
+            'Meta': {'object_name': 'Staff'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_manager': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']"}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'diagnosis.diagnosistraversal': {
+            'Meta': {'object_name': 'DiagnosisTraversal'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']", 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'current_node_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'nodes': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'UNKNOWN'", 'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        u'knowledgebase.article': {
+            'Meta': {'object_name': 'Article'},
+            'accessibility': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'article_category': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['knowledgebase.ArticleCategory']", 'through': u"orm['knowledgebase.ArticleCategoryMatrix']", 'symmetrical': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'geographic_coverage': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'helpline': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'how_to_use': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'opening_hours': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'resource_type': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'type_of_service': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'website': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'when_to_use': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'knowledgebase.articlecategory': {
+            'Meta': {'object_name': 'ArticleCategory'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'knowledgebase.articlecategorymatrix': {
+            'Meta': {'object_name': 'ArticleCategoryMatrix'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.Article']"}),
+            'article_category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.ArticleCategory']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'preferred_signpost': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'legalaid.adaptationdetails': {
+            'Meta': {'object_name': 'AdaptationDetails'},
+            'bsl_webcam': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'callback_preference': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'minicom': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'skype_webcam': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'text_relay': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'legalaid.case': {
+            'Meta': {'object_name': 'Case'},
+            'adaptation_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.AdaptationDetails']", 'null': 'True', 'blank': 'True'}),
+            'alternative_help_articles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['knowledgebase.Article']", 'null': 'True', 'through': u"orm['legalaid.CaseKnowledgebaseAssignment']", 'blank': 'True'}),
+            'billable_time': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'diagnosis': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['diagnosis.DiagnosisTraversal']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'ecf_statement': ('django.db.models.fields.CharField', [], {'max_length': '35', 'null': 'True', 'blank': 'True'}),
+            'eligibility_check': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['legalaid.EligibilityCheck']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'exempt_user': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'exempt_user_reason': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'laa_reference': ('django.db.models.fields.BigIntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'level': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            'locked_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'locked_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'case_locked'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'matter_type1': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': u"orm['legalaid.MatterType']"}),
+            'matter_type2': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': u"orm['legalaid.MatterType']"}),
+            'media_code': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.MediaCode']", 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'outcome_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'personal_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.PersonalDetails']", 'null': 'True', 'blank': 'True'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']", 'null': 'True', 'blank': 'True'}),
+            'provider_notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'reference': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'requires_action_by': ('django.db.models.fields.CharField', [], {'default': "'operator'", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'thirdparty_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.ThirdPartyDetails']", 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.caseknowledgebaseassignment': {
+            'Meta': {'object_name': 'CaseKnowledgebaseAssignment'},
+            'alternative_help_article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.Article']"}),
+            'assigned_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'case': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Case']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.category': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Category'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'ecf_available': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mandatory': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'raw_description': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'legalaid.deductions': {
+            'Meta': {'object_name': 'Deductions'},
+            'childcare': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'childcare_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'childcare_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'criminal_legalaid_contributions': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'income_tax': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'income_tax_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'income_tax_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'maintenance': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'maintenance_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'maintenance_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'mortgage': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'mortgage_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'mortgage_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'national_insurance': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'national_insurance_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'national_insurance_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rent': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'rent_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'rent_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.eligibilitycheck': {
+            'Meta': {'object_name': 'EligibilityCheck'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']", 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'dependants_old': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'dependants_young': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'disputed_savings': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Savings']", 'null': 'True', 'blank': 'True'}),
+            'has_partner': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_you_or_your_partner_over_60': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'on_nass_benefits': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'on_passported_benefits': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'partner'", 'null': 'True', 'to': u"orm['legalaid.Person']"}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'unknown'", 'max_length': '50'}),
+            'you': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'you'", 'null': 'True', 'to': u"orm['legalaid.Person']"}),
+            'your_problem_notes': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'legalaid.income': {
+            'Meta': {'object_name': 'Income'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'earnings': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'earnings_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'earnings_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'other_income': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'other_income_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'other_income_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'self_employed': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.mattertype': {
+            'Meta': {'unique_together': "(('code', 'level'),)", 'object_name': 'MatterType'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']"}),
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.mediacode': {
+            'Meta': {'object_name': 'MediaCode'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.MediaCodeGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        u'legalaid.mediacodegroup': {
+            'Meta': {'object_name': 'MediaCodeGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        u'legalaid.person': {
+            'Meta': {'object_name': 'Person'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deductions': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Deductions']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'income': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Income']", 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'savings': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Savings']", 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.personaldetails': {
+            'Meta': {'object_name': 'PersonalDetails'},
+            'contact_for_research': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'date_of_birth': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '400', 'null': 'True', 'blank': 'True'}),
+            'home_phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'ni_number': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'postcode': ('django.db.models.fields.CharField', [], {'max_length': '12', 'null': 'True', 'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'safe_to_contact': ('django.db.models.fields.CharField', [], {'default': "'SAFE'", 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'vulnerable_user': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.savings': {
+            'Meta': {'object_name': 'Savings'},
+            'asset_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'bank_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'credit_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'investment_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.thirdpartydetails': {
+            'Meta': {'object_name': 'ThirdPartyDetails'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'no_contact_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'organisation_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'pass_phrase': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'personal_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.PersonalDetails']"}),
+            'personal_relationship': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'personal_relationship_note': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'spoke_to': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['cla_provider']

--- a/cla_backend/apps/cla_provider/models.py
+++ b/cla_backend/apps/cla_provider/models.py
@@ -1,3 +1,4 @@
+from cla_common.constants import FEEDBACK_ISSUE
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
@@ -5,6 +6,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 
 from model_utils.models import TimeStampedModel
+from uuidfield import UUIDField
 
 
 class ProviderManager(models.Manager):
@@ -105,10 +107,15 @@ class OutOfHoursRota(TimeStampedModel):
                 _(u"Overlapping rota allocation not allowed"))
 
 class Feedback(TimeStampedModel):
+    reference = UUIDField(auto=True, unique=True)
+    case = models.ForeignKey('legalaid.Case', related_name='provider_feedback')
+
     created_by = models.ForeignKey(Staff)
     comment = models.TextField()
 
     justified = models.BooleanField(default=False)
     resolved = models.BooleanField(default=False)
 
-    # issue = models.CharField(choices=FEEDBACK_ISSUE, max_length=25)
+    issue = models.CharField(choices=FEEDBACK_ISSUE, max_length=100)
+
+

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -171,6 +171,7 @@ class FeedbackSerializer(FeedbackSerializerBase):
     comment = serializers.CharField(max_length=1024, required=False)
     class Meta(FeedbackSerializerBase.Meta):
         fields = (
+            'reference',
             'provider',
             'case',
             'created_by',

--- a/cla_backend/apps/cla_provider/tests/api/test_feedback_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_feedback_api.py
@@ -1,5 +1,7 @@
 from cla_common.constants import REQUIRES_ACTION_BY
+from core.tests.mommy_utils import make_recipe
 from core.tests.test_base import NestedSimpleResourceAPIMixin
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 from legalaid.tests.views.test_base import CLAProviderAuthBaseApiTestMixin
@@ -11,7 +13,8 @@ class FeedbackAPIMixin(NestedSimpleResourceAPIMixin):
     API_URL_BASE_NAME = 'feedback'
     PARENT_LOOKUP_KEY = 'reference'
     PARENT_RESOURCE_RECIPE = 'legalaid.case'
-    PK_FIELD = 'provider_feedback'
+    PK_FIELD = 'case'
+    ONE_TO_ONE_RESOURCE = False
 
 
     def make_resource(self, **kwargs):
@@ -28,6 +31,13 @@ class FeedbackAPIMixin(NestedSimpleResourceAPIMixin):
         })
         return super(FeedbackAPIMixin, self).make_parent_resource(**kwargs)
 
+    def test_methods_not_authorized(self):
+        self._test_get_not_authorized(self.list_url, self.invalid_token)
+
+
+class FeedbackAPITestCase(
+    FeedbackAPIMixin, CLAProviderAuthBaseApiTestMixin, APITestCase
+):
     def test_patch_comment_allowed(self):
         comment = "test"
         response = self.client.patch(
@@ -35,8 +45,24 @@ class FeedbackAPIMixin(NestedSimpleResourceAPIMixin):
             data={"comment": comment},
             format='json',
             HTTP_AUTHORIZATION=self.get_http_authorization())
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['comment'], comment)
+
+    def test_create_adds_current_user_as_created_by(self):
+        created = self._create(data={'comment':'qqq'}, url=self.list_url)
+        self.assertEqual(created.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(created.data['created_by'], self.user.username)
+
+    def test_get_404_if_not_access_to_case(self):
+        other_provider = make_recipe('cla_provider.provider')
+
+        self.parent_resource.provider = other_provider
+        self.parent_resource.save()
+
+        response = self.client.get(
+            self.list_url, HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_patch_other_fields_not_allowed(self):
         data = {
@@ -51,14 +77,3 @@ class FeedbackAPIMixin(NestedSimpleResourceAPIMixin):
 
         self.assertEqual(resp.data['justified'], self.resource.justified)
         self.assertEqual(resp.data['resolved'], self.resource.resolved)
-
-    def test_create_adds_current_user_as_created_by(self):
-        created = self._create(data={'comment':'qqq'})
-        self.assertEqual(created.status_code, 201)
-        self.assertEqual(created.data['created_by'], self.user.username)
-
-
-class FeedbackAPITestCase(
-    FeedbackAPIMixin, CLAProviderAuthBaseApiTestMixin, APITestCase
-):
-    pass

--- a/cla_backend/apps/cla_provider/urls.py
+++ b/cla_backend/apps/cla_provider/urls.py
@@ -26,9 +26,10 @@ case_one2one_router.register(r'personal_details', views.PersonalDetailsViewSet)
 case_one2one_router.register(r'adaptation_details', views.AdaptationDetailsViewSet)
 case_one2one_router.register(r'thirdparty_details', views.ThirdPartyDetailsViewSet)
 case_one2one_router.register(r'diagnosis', views.DiagnosisViewSet, base_name='diagnosis')
-case_one2one_router.register(r'feedback', views.FeedbackViewSet)
 
 case_one2many_router = NestedSimpleRouter(router, r'case', lookup='case')
+
+case_one2many_router.register(r'feedback', views.FeedbackViewSet)
 case_one2many_router.register(r'logs', views.LogViewSet)
 
 urlpatterns = patterns('',

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -157,5 +157,6 @@ class FeedbackViewSet(CLAProviderPermissionViewSetMixin,
 
     def pre_save(self, obj):
         if not obj.pk:
+            obj.case = self.get_parent_object()
             obj.created_by = Staff.objects.get(user=self.request.user)
         super(FeedbackViewSet, self).pre_save(obj)

--- a/cla_backend/apps/core/drf/mixins.py
+++ b/cla_backend/apps/core/drf/mixins.py
@@ -60,7 +60,7 @@ class NestedGenericModelMixin(object):
         :return: parent_obj after saving it
         """
         if not self.is_one_to_one_nested():
-            return
+            return super(NestedGenericModelMixin, self).post_save(obj, created=created)
 
         if created:
             parent_obj = self.get_parent_object_or_none()

--- a/cla_backend/apps/core/tests/test_base.py
+++ b/cla_backend/apps/core/tests/test_base.py
@@ -204,9 +204,17 @@ class NestedSimpleResourceAPIMixin(SimpleResourceAPIMixin):
         )
 
     def get_detail_url(self, resource_lookup_value, suffix='detail'):
+        if self.ONE_TO_ONE_RESOURCE:
+            params = {self.LOOKUP_KEY: unicode(resource_lookup_value)}
+        else:
+            params = {
+                self.LOOKUP_KEY: unicode(resource_lookup_value),
+                self.PARENT_LOOKUP_KEY: unicode(getattr(self.resource, self.PARENT_LOOKUP_KEY))
+            }
+
         return reverse(
             '%s:%s-%s' % (self.API_URL_NAMESPACE, self.API_URL_BASE_NAME, suffix),
-            args=(), kwargs={self.LOOKUP_KEY: unicode(resource_lookup_value)}
+            args=(), kwargs=params
         )
 
     def setup_resources(self):

--- a/cla_backend/apps/legalaid/migrations/0025_auto__del_field_case_provider_feedback.py
+++ b/cla_backend/apps/legalaid/migrations/0025_auto__del_field_case_provider_feedback.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Case.provider_feedback'
+        db.delete_column(u'legalaid_case', 'provider_feedback_id')
+
+
+    def backwards(self, orm):
+        # Adding field 'Case.provider_feedback'
+        db.add_column(u'legalaid_case', 'provider_feedback',
+                      self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cla_provider.Feedback'], unique=True, null=True, blank=True),
+                      keep_default=False)
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cla_provider.provider': {
+            'Meta': {'object_name': 'Provider'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'email_address': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'law_category': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['legalaid.Category']", 'through': u"orm['cla_provider.ProviderAllocation']", 'symmetrical': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'opening_hours': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'short_code': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone_backdoor': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone_frontdoor': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        u'cla_provider.providerallocation': {
+            'Meta': {'object_name': 'ProviderAllocation'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']"}),
+            'weighted_distribution': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'diagnosis.diagnosistraversal': {
+            'Meta': {'object_name': 'DiagnosisTraversal'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']", 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'current_node_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'nodes': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'UNKNOWN'", 'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        u'knowledgebase.article': {
+            'Meta': {'object_name': 'Article'},
+            'accessibility': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'article_category': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['knowledgebase.ArticleCategory']", 'through': u"orm['knowledgebase.ArticleCategoryMatrix']", 'symmetrical': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'geographic_coverage': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'helpline': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'how_to_use': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'opening_hours': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'resource_type': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'type_of_service': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'website': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'when_to_use': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'knowledgebase.articlecategory': {
+            'Meta': {'object_name': 'ArticleCategory'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'knowledgebase.articlecategorymatrix': {
+            'Meta': {'object_name': 'ArticleCategoryMatrix'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.Article']"}),
+            'article_category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.ArticleCategory']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'preferred_signpost': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'legalaid.adaptationdetails': {
+            'Meta': {'object_name': 'AdaptationDetails'},
+            'bsl_webcam': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'callback_preference': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'minicom': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'skype_webcam': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'text_relay': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'legalaid.case': {
+            'Meta': {'object_name': 'Case'},
+            'adaptation_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.AdaptationDetails']", 'null': 'True', 'blank': 'True'}),
+            'alternative_help_articles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['knowledgebase.Article']", 'null': 'True', 'through': u"orm['legalaid.CaseKnowledgebaseAssignment']", 'blank': 'True'}),
+            'billable_time': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'diagnosis': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['diagnosis.DiagnosisTraversal']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'ecf_statement': ('django.db.models.fields.CharField', [], {'max_length': '35', 'null': 'True', 'blank': 'True'}),
+            'eligibility_check': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['legalaid.EligibilityCheck']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'exempt_user': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'exempt_user_reason': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'laa_reference': ('django.db.models.fields.BigIntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'level': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            'locked_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'locked_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'case_locked'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'matter_type1': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': u"orm['legalaid.MatterType']"}),
+            'matter_type2': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': u"orm['legalaid.MatterType']"}),
+            'media_code': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.MediaCode']", 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'outcome_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'personal_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.PersonalDetails']", 'null': 'True', 'blank': 'True'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cla_provider.Provider']", 'null': 'True', 'blank': 'True'}),
+            'provider_notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'reference': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'requires_action_by': ('django.db.models.fields.CharField', [], {'default': "'operator'", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'thirdparty_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.ThirdPartyDetails']", 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.caseknowledgebaseassignment': {
+            'Meta': {'object_name': 'CaseKnowledgebaseAssignment'},
+            'alternative_help_article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['knowledgebase.Article']"}),
+            'assigned_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'case': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Case']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.category': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Category'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'ecf_available': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mandatory': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'raw_description': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'legalaid.deductions': {
+            'Meta': {'object_name': 'Deductions'},
+            'childcare': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'childcare_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'childcare_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'criminal_legalaid_contributions': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'income_tax': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'income_tax_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'income_tax_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'maintenance': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'maintenance_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'maintenance_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'mortgage': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'mortgage_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'mortgage_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'national_insurance': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'national_insurance_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'national_insurance_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rent': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'rent_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'rent_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.eligibilitycheck': {
+            'Meta': {'object_name': 'EligibilityCheck'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']", 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'dependants_old': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'dependants_young': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'disputed_savings': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Savings']", 'null': 'True', 'blank': 'True'}),
+            'has_partner': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_you_or_your_partner_over_60': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'on_nass_benefits': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'on_passported_benefits': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'partner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'partner'", 'null': 'True', 'to': u"orm['legalaid.Person']"}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'unknown'", 'max_length': '50'}),
+            'you': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'you'", 'null': 'True', 'to': u"orm['legalaid.Person']"}),
+            'your_problem_notes': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'legalaid.income': {
+            'Meta': {'object_name': 'Income'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'earnings': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'earnings_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'earnings_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'other_income': ('cla_common.money_interval.fields.MoneyIntervalField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'other_income_interval_period': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'other_income_per_interval_value': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'self_employed': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.mattertype': {
+            'Meta': {'unique_together': "(('code', 'level'),)", 'object_name': 'MatterType'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Category']"}),
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.mediacode': {
+            'Meta': {'object_name': 'MediaCode'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.MediaCodeGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        u'legalaid.mediacodegroup': {
+            'Meta': {'object_name': 'MediaCodeGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        u'legalaid.person': {
+            'Meta': {'object_name': 'Person'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deductions': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Deductions']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'income': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Income']", 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'savings': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.Savings']", 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.personaldetails': {
+            'Meta': {'object_name': 'PersonalDetails'},
+            'contact_for_research': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'date_of_birth': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '400', 'null': 'True', 'blank': 'True'}),
+            'home_phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'ni_number': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'postcode': ('django.db.models.fields.CharField', [], {'max_length': '12', 'null': 'True', 'blank': 'True'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'safe_to_contact': ('django.db.models.fields.CharField', [], {'default': "'SAFE'", 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'vulnerable_user': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.property': {
+            'Meta': {'object_name': 'Property'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'disputed': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'eligibility_check': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.EligibilityCheck']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'main': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'mortgage_left': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'share': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'value': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'})
+        },
+        u'legalaid.savings': {
+            'Meta': {'object_name': 'Savings'},
+            'asset_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'bank_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'credit_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'investment_balance': ('legalaid.fields.MoneyField', [], {'default': 'None', 'max_value': '9999999999', 'min_value': '0', 'null': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'legalaid.thirdpartydetails': {
+            'Meta': {'object_name': 'ThirdPartyDetails'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'no_contact_reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'organisation_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'pass_phrase': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'personal_details': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['legalaid.PersonalDetails']"}),
+            'personal_relationship': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'personal_relationship_note': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'reference': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'blank': 'True'}),
+            'spoke_to': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['legalaid']

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -450,9 +450,6 @@ class Case(TimeStampedModel):
     ecf_statement = models.CharField(blank=True, null=True, max_length=35, choices=ECF_STATEMENT)
 
 
-    # feedback
-    provider_feedback = models.OneToOneField('cla_provider.Feedback', null=True, blank=True)
-
     def _set_reference_if_necessary(self):
         if not self.reference:
             # TODO make it better

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -34,6 +34,7 @@ class OutOfHoursRotaSerializerBase(ClaModelSerializer):
         model = OutOfHoursRota
 
 class FeedbackSerializerBase(serializers.ModelSerializer):
+    eligibility_check = UUIDSerializer(slug_field='reference', read_only=True)
     created_by = serializers.CharField(source='created_by.user.username', read_only=True)
     case = serializers.SlugRelatedField(slug_field='reference', read_only=True)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ Markdown==2.4.1
 bleach==1.4
 django-oauth2-provider==0.2.6.1
 
-git+git://github.com/ministryofjustice/cla_common.git@0.1.38#egg=cla_common==0.1.38
+git+git://github.com/ministryofjustice/cla_common.git@0.1.39#egg=cla_common==0.1.39
 django-extended-choices==0.3.0
 django-filter==0.7
 jsonpatch==1.7


### PR DESCRIPTION
made feedback one2many on case
updated nested model mixin to support this
updated tests
made feedback for call_centre flat (removed nestedresorcemixin) because opeator managers want to see all feedback, not feedback per case in a single screen

add tests for making sure call_centre can't create or edit comments of a feedback item
add tests making sure call_centre can change resolved/accepted status
