### PR TITLE
Override case ordering to always order by modified date as secondary order

### DIFF
--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -30,7 +30,7 @@ from legalaid.views import BaseUserViewSet, \
     BaseMatterTypeViewSet, BaseMediaCodeViewSet, FullPersonalDetailsViewSet, \
     BaseThirdPartyDetailsViewSet, BaseAdaptationDetailsViewSet, \
     BaseAdaptationDetailsMetadataViewSet, FullCaseViewSet, \
-    BaseCaseNotesHistoryViewSet
+    BaseCaseNotesHistoryViewSet, CaseOrderingFilter
 
 from cla_common.constants import REQUIRES_ACTION_BY
 from knowledgebase.views import BaseArticleViewSet, BaseArticleCategoryViewSet
@@ -127,7 +127,7 @@ class CaseViewSet(
     )
 
     filter_backends = (
-        OrderingFilter,
+        CaseOrderingFilter,
         SearchFilter,
     )
 

--- a/cla_backend/apps/legalaid/views.py
+++ b/cla_backend/apps/legalaid/views.py
@@ -288,6 +288,32 @@ class BaseAdaptationDetailsMetadataViewSet(
         self.http_method_not_allowed(request)
 
 
+class CaseOrderingFilter(OrderingFilter):
+
+    def filter_queryset(self, request, queryset, view):
+        ordering = self.get_ordering(request)
+
+        if ordering:
+            ordering = self.remove_invalid_fields(queryset, ordering, view)
+
+            if isinstance(ordering, basestring):
+                if ',' in ordering:
+                    ordering = ordering.split(',')
+                else:
+                    ordering = [ordering]
+
+            if 'modified' not in ordering and '-modified' not in ordering:
+                ordering.append('-modified')
+
+        if not ordering:
+            ordering = self.get_default_ordering(view)
+
+        if ordering:
+            return queryset.order_by(*ordering)
+
+        return queryset
+
+
 class FullCaseViewSet(
     DetailSerializerMixin,
     mixins.UpdateModelMixin,
@@ -304,7 +330,7 @@ class FullCaseViewSet(
     pagination_serializer_class = RelativeUrlPaginationSerializer
 
     filter_backends = (
-        OrderingFilter,
+        CaseOrderingFilter,
         SearchFilter,
     )
 


### PR DESCRIPTION
(unless modified date is primary order)
