### PR TITLE
Add Celery

### DIFF
--- a/cla_backend/__init__.py
+++ b/cla_backend/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app

--- a/cla_backend/apps/reports/tasks.py
+++ b/cla_backend/apps/reports/tasks.py
@@ -1,0 +1,30 @@
+import os
+from contextlib import closing
+
+from celery import shared_task
+
+from reports.utils import OBIEEExporter, email_obiee_export
+
+
+@shared_task(bind=True)
+def obiee_export(self, diversity_keyphrase, dt_from, dt_to):
+    """
+    Export a full dump of the db for OBIEE export and email it to
+    the address specified in the environment as OBIEE_EMAIL_TO.
+    It can be a comma separated list of email addresses
+
+    :param diversity_keyphrase: the paraphrase required to unlock the encrypted
+    diversity fields
+    :type diversity_keyphrase: str or unicode
+    :param dt_from: the date to start the export from
+    :type dt_from: datetime.datetime
+    :param dt_to: end date for the export
+    :type dt_to: datetime.datetime
+    """
+    temp_path = os.path.join('/tmp/', self.request.id)
+    os.mkdir(temp_path)
+    with closing(OBIEEExporter(temp_path, diversity_keyphrase,
+                  dt_from, dt_to)) as exporter:
+        zip_path = exporter.export()
+
+        email_obiee_export(zip_path, dt_from, dt_to)

--- a/cla_backend/celery.py
+++ b/cla_backend/celery.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+from django.conf import settings
+from raven.contrib.celery import register_logger_signal, register_signal
+# set the default Django settings module for the 'celery' program.
+from raven.scripts.runner import send_test_message
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cla_backend.settings')
+app = Celery('cla_backend')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+client = None
+if hasattr(settings, 'RAVEN_CONFIG'):
+    from raven.contrib.django.models import client
+    register_logger_signal(client)
+    register_signal(client)
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))
+
+@app.task()
+def sentry_test_task():
+    if client:
+        send_test_message(client, {})

--- a/cla_backend/settings/.example.local.py
+++ b/cla_backend/settings/.example.local.py
@@ -24,3 +24,7 @@ LOGGING = {
         },
     }
 }
+
+# don't bother with celery locally
+CELERY_ALWAYS_EAGER = True
+

--- a/docker/celery.service
+++ b/docker/celery.service
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p /var/run/celery/
+mkdir -p /var/log/celery/
+
+cd /home/app/django
+exec celery -A cla_backend worker -l info -c 1 --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,3 +38,5 @@ django-docopt-command==0.2.0
 
 # Fork PgFulltext - PR added
 git+git://github.com/ministryofjustice/djorm-ext-pgfulltext.git@0.1.0#egg=djorm_pgfulltext==0.1.0
+celery==3.1.17
+boto==2.38.0


### PR DESCRIPTION
adding celery because we have a log running db export task we don't want to run during a request,
this celery confguration falls back to running the task in procress if celery broker is not set up so local development isn't annoying.

I have also created a sentry test task so we can see that celery errors get to sentry.