### PR TITLE
reasons for contacting can now be stored in DB

### DIFF
--- a/cla_backend/apps/checker/admin.py
+++ b/cla_backend/apps/checker/admin.py
@@ -1,3 +1,11 @@
 from django.contrib import admin
+from checker.models import ReasonForContacting
 
-# Register your models here.
+
+class ReasonForContactingAdmin(admin.ModelAdmin):
+    list_display = ('created', 'reason_categories', 'case')
+    date_hierarchy = 'created'
+    readonly_fields = ('reason_categories', 'other_reasons', 'case', 'user_agent', 'referrer')
+
+
+admin.site.register(ReasonForContacting, ReasonForContactingAdmin)

--- a/cla_backend/apps/checker/migrations/0001_initial.py
+++ b/cla_backend/apps/checker/migrations/0001_initial.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+import model_utils.fields
+import uuidfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('legalaid', '0003_eod_details'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ReasonForContacting',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('reference', uuidfield.fields.UUIDField(unique=True, max_length=32, editable=False, blank=True)),
+                ('other_reasons', models.TextField(blank=True)),
+                ('referrer', models.CharField(max_length=255, blank=True)),
+                ('user_agent', models.CharField(max_length=255, blank=True)),
+                ('case', models.ForeignKey(blank=True, to='legalaid.Case', null=True)),
+            ],
+            options={
+                'ordering': ('-created',),
+                'verbose_name_plural': 'reasons for contacting',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='ReasonForContactingCategory',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('category', models.CharField(max_length=20, choices=[(b'CANT_ANSWER', 'I don\u2019t know how to answer a question'), (b'MISSING_PAPERWORK', 'I don\u2019t have the paperwork I need'), (b'PREFER_SPEAKING', 'I\u2019d prefer to speak to someone'), (b'DIFFICULTY_ONLINE', 'I have trouble using online services'), (b'HOW_SERVICE_HELPS', 'I don\u2019t understand how this service can help me'), (b'AREA_NOT_COVERED', 'My problem area isn\u2019t covered'), (b'PNS', 'I\u2019d prefer not to say'), (b'OTHER', 'Another reason')])),
+                ('reason_for_contacting', models.ForeignKey(related_name='reasons', to='checker.ReasonForContacting')),
+            ],
+            options={
+                'verbose_name': 'category',
+                'verbose_name_plural': 'categories',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/cla_backend/apps/checker/models.py
+++ b/cla_backend/apps/checker/models.py
@@ -47,6 +47,19 @@ class ReasonForContacting(TimeStampedModel):
             category['percentage'] *= percentage_total
         return dict(categories=categories, total_count=total_count)
 
+    @classmethod
+    def get_top_referrers(cls, count=5):
+        total_count = cls.objects.count()
+        percentage_total = 100.0 / total_count if total_count else 0.0
+        data = cls.objects.values('referrer').annotate(count=models.Count('referrer')).order_by('-count', 'referrer')
+        return [
+            {
+                'referrer': item['referrer'],
+                'percentage': item['count'] * percentage_total,
+            }
+            for item in data
+        ]
+
     @property
     def reason_categories(self):
         if self.reasons.count():

--- a/cla_backend/apps/checker/models.py
+++ b/cla_backend/apps/checker/models.py
@@ -1,3 +1,79 @@
 from django.db import models
+from model_utils.models import TimeStampedModel
+from uuidfield import UUIDField
 
-# Create your models here.
+from cla_common.constants import REASONS_FOR_CONTACTING
+
+
+class ReasonForContacting(TimeStampedModel):
+    reference = UUIDField(auto=True, unique=True)
+    other_reasons = models.TextField(blank=True)
+    referrer = models.CharField(max_length=255, blank=True)
+    user_agent = models.CharField(max_length=255, blank=True)
+
+    case = models.ForeignKey('legalaid.Case', blank=True, null=True)
+
+    class Meta(object):
+        verbose_name_plural = 'reasons for contacting'
+        ordering = ('-created',)
+
+    @classmethod
+    def get_category_stats(cls):
+        total_count = cls.objects.count()
+        # count categories
+        data = ReasonForContactingCategory.objects.values_list('category').\
+            annotate(count=models.Count('category')).order_by()
+        data = dict(data)
+        # known categories, preserving order
+        categories = [
+            {
+                'key': choice[0],
+                'description': choice[1],
+                'percentage': data[choice[0]] if choice[0] in data else 0,
+            }
+            for choice in REASONS_FOR_CONTACTING.CHOICES
+        ]
+        # unknown categories (perhaps have been removed)
+        for category, count in data.iteritems():
+            if category not in REASONS_FOR_CONTACTING.CHOICES_DICT:
+                categories.append({
+                    'key': category,
+                    'description': category,
+                    'percentage': count,
+                })
+        # calculate percentage of all responses that chose each option
+        percentage_total = 100.0 / total_count if total_count else 0.0
+        for category in categories:
+            category['percentage'] *= percentage_total
+        return dict(categories=categories, total_count=total_count)
+
+    @property
+    def reason_categories(self):
+        if self.reasons.count():
+            return u', '.join(map(unicode, self.reasons.all()))
+        return u'(No categories specified)'
+
+    def __unicode__(self):
+        reason_count = self.reasons.count()
+        description = u'%d reasons' % reason_count if reason_count else u'No reasons specified'
+        if self.case:
+            return description + u' (Case: %s)' % self.case.reference
+        return description
+
+
+class ReasonForContactingCategory(models.Model):
+    reason_for_contacting = models.ForeignKey(ReasonForContacting,
+                                              related_name='reasons',
+                                              on_delete=models.CASCADE)
+    category = models.CharField(max_length=20,
+                                choices=REASONS_FOR_CONTACTING.CHOICES)
+
+    class Meta(object):
+        verbose_name = 'category'
+        verbose_name_plural = 'categories'
+
+    def __unicode__(self):
+        try:
+            return REASONS_FOR_CONTACTING.CHOICES_DICT[self.category]
+        except KeyError:
+            return self.category

--- a/cla_backend/apps/checker/serializers.py
+++ b/cla_backend/apps/checker/serializers.py
@@ -1,6 +1,7 @@
-from rest_framework import serializers
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
+from rest_framework import serializers
+
 from diagnosis.graph import get_graph
 from diagnosis.serializers import DiagnosisSerializer
 
@@ -11,6 +12,7 @@ from legalaid.serializers import UUIDSerializer, \
     DeductionsSerializerBase, PersonSerializerBase, \
     AdaptationDetailsSerializerBase, ThirdPartyDetailsSerializerBase
 
+from checker.models import ReasonForContacting, ReasonForContactingCategory
 
 checker_graph = SimpleLazyObject(lambda: get_graph(
     file_name=settings.CHECKER_DIAGNOSIS_FILE_NAME))
@@ -152,3 +154,22 @@ class CaseSerializer(CaseSerializerBase):
 class CheckerDiagnosisSerializer(DiagnosisSerializer):
     def _get_graph(self):
         return checker_graph
+
+
+class ReasonForContactingCategorySerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = ReasonForContactingCategory
+        fields = ('category',)
+
+
+class ReasonForContactingSerializer(serializers.ModelSerializer):
+    reasons = ReasonForContactingCategorySerializer(
+        many=True, allow_add_remove=True, required=False
+    )
+    case = serializers.SlugRelatedField(slug_field='reference', read_only=False,
+                                        required=False)
+
+    class Meta(object):
+        model = ReasonForContacting
+        fields = ('reference', 'reasons', 'other_reasons', 'case',
+                  'referrer', 'user_agent',)

--- a/cla_backend/apps/checker/tests/api/test_reasons_for_contacting_api.py
+++ b/cla_backend/apps/checker/tests/api/test_reasons_for_contacting_api.py
@@ -1,0 +1,58 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from cla_common.constants import REASONS_FOR_CONTACTING
+from checker.models import ReasonForContacting
+from core.tests.mommy_utils import make_recipe
+from core.tests.test_base import SimpleResourceAPIMixin
+from legalaid.tests.views.test_base import CLACheckerAuthBaseApiTestMixin
+
+
+class ReasonsForContactingTestCase(SimpleResourceAPIMixin, CLACheckerAuthBaseApiTestMixin, APITestCase):
+    LOOKUP_KEY = 'reference'
+    API_URL_BASE_NAME = 'reasons_for_contacting'
+    RESOURCE_RECIPE = 'checker.reasonforcontacting'
+
+    def setUp(self):
+        super(ReasonsForContactingTestCase, self).setUp()
+        # give it a category as it's not auto-generated
+        make_recipe('checker.reasonforcontacting_category', reason_for_contacting=self.resource)
+
+    def test_retrieval_disallowed(self):
+        self._test_get_not_allowed(self.list_url)
+        self._test_get_not_allowed(self.detail_url)
+
+    def test_create_model(self):
+        resource = {
+            'reasons': [{'category': REASONS_FOR_CONTACTING.OTHER}],
+            'other_reasons': 'lorem ipsum',
+        }
+        response = self.client.post(
+            self.list_url, data=resource, format='json',
+            # HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data['reference'])
+        self.assertIsNone(response.data['case'])
+
+    def test_can_add_case_ref(self):
+        self.assertIsNone(self.resource.case)
+        eligible_case = make_recipe('legalaid.eligible_case')
+        response = self.client.patch(
+            self.detail_url, data={'case': eligible_case.reference}, format='json',
+            # HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['case'], eligible_case.reference)
+        self.assertEqual(response.data['reference'], str(self.resource.reference))
+
+    def test_stats(self):
+        # only considers shared resource created during setup
+        stats = ReasonForContacting.get_category_stats()
+        self.assertEqual(stats['total_count'], 1)
+
+        ideal_categories = dict((choice, 0.0) for choice in REASONS_FOR_CONTACTING.CHOICES_DICT)
+        ideal_categories[self.resource.reasons.first().category] = 100.0
+        categories = dict((stat['key'], stat['percentage']) for stat in stats['categories'])
+
+        self.assertDictEqual(categories, ideal_categories)

--- a/cla_backend/apps/checker/tests/mommy_recipes.py
+++ b/cla_backend/apps/checker/tests/mommy_recipes.py
@@ -1,0 +1,8 @@
+from model_mommy.recipe import Recipe, foreign_key
+
+from ..models import ReasonForContacting, ReasonForContactingCategory
+
+reasonforcontacting = Recipe(ReasonForContacting,
+                             _fill_optional=['user_agent', 'referrer'])
+reasonforcontacting_category = Recipe(ReasonForContactingCategory,
+                                      reason_for_contacting=foreign_key(reasonforcontacting))

--- a/cla_backend/apps/checker/urls.py
+++ b/cla_backend/apps/checker/urls.py
@@ -10,9 +10,8 @@ router.register(r'category', views.CategoryViewSet)
 router.register(r'case', views.CaseViewSet)
 router.register(r'organisation', views.ArticleViewSet)
 router.register(r'eligibility_check', views.EligibilityCheckViewSet, base_name='eligibility_check')
+router.register(r'reasons_for_contacting', views.ReasonForContactingViewSet, base_name='reasons_for_contacting')
 
 urlpatterns = patterns('',
     url(r'^', include(router.urls)),
 )
-
-

--- a/cla_backend/apps/checker/views.py
+++ b/cla_backend/apps/checker/views.py
@@ -19,8 +19,10 @@ from legalaid.views import BaseCategoryViewSet, BaseEligibilityCheckViewSet, \
     BaseCaseLogMixin
 from cla_common.constants import CASE_SOURCE
 
+from .models import ReasonForContacting
 from .serializers import EligibilityCheckSerializer, \
-    PropertySerializer, CaseSerializer, CheckerDiagnosisSerializer
+    PropertySerializer, CaseSerializer, CheckerDiagnosisSerializer, \
+    ReasonForContactingSerializer
 from .forms import WebCallMeBackForm
 
 
@@ -169,3 +171,21 @@ class DiagnosisViewSet(
         except ImproperlyConfigured:
             pass
         return super(DiagnosisModelMixin, self).pre_save(obj, *args, **kwargs)
+
+
+class ReasonForContactingViewSet(
+    PublicAPIViewSetMixin,
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    viewsets.GenericViewSet
+):
+    model = ReasonForContacting
+    serializer_class = ReasonForContactingSerializer
+    lookup_field = 'reference'
+
+    def pre_save(self, obj):
+        # delete all existing reasons and use those from request as replacement set if provided
+        if obj.pk and 'reasons' in self.request.DATA:
+            obj.reasons.all().delete()
+
+        super(ReasonForContactingViewSet, self).pre_save(obj)

--- a/cla_backend/apps/core/fixtures/initial_groups.json
+++ b/cla_backend/apps/core/fixtures/initial_groups.json
@@ -50,7 +50,8 @@
                 ["delete_tag", "guidance", "tag"],
                 ["add_telephonenumber", "knowledgebase", "telephonenumber"],
                 ["change_telephonenumber", "knowledgebase", "telephonenumber"],
-                ["delete_telephonenumber", "knowledgebase", "telephonenumber"]
+                ["delete_telephonenumber", "knowledgebase", "telephonenumber"],
+                ["change_reasonforcontacting", "checker", "reasonforcontacting"]
             ]
         }
     },

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -620,6 +620,12 @@ class Case(TimeStampedModel, ModelDiffMixin):
     complaint_flag = models.BooleanField(default=False)
     eod_details = models.ForeignKey(EODDetails, blank=True, null=True)
 
+    class Meta(object):
+        ordering = ('-created',)
+
+    def __unicode__(self):
+        return self.reference
+
     def _set_reference_if_necessary(self):
         max_retries = 10
         tries = 0
@@ -630,7 +636,6 @@ class Case(TimeStampedModel, ModelDiffMixin):
                 tries = tries + 1
 
             self.reference = reference
-
 
     def _set_search_field(self):
         if self.reference:

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -218,13 +218,6 @@ class EODDetailsSerializerBase(serializers.ModelSerializer):
         model = EODDetails
         fields = ()
 
-    def save(self, **kwargs):
-        # delete all existing EOD categories and use those from request as replacement set
-        if isinstance(self.object, EODDetails) and self.object.pk:
-            self.object.categories.all().delete()
-
-        return super(EODDetailsSerializerBase, self).save(**kwargs)
-
 
 class EligibilityCheckSerializerBase(ClaModelSerializer):
     property_set = PropertySerializerBase(

--- a/cla_backend/apps/legalaid/views.py
+++ b/cla_backend/apps/legalaid/views.py
@@ -303,6 +303,13 @@ class BaseEODDetailsViewSet(
     lookup_field = 'reference'
     PARENT_FIELD = 'eod_details'
 
+    def pre_save(self, obj):
+        # delete all existing EOD categories and use those from request as replacement set
+        if isinstance(obj, EODDetails) and obj.pk:
+            obj.categories.all().delete()
+
+        super(BaseEODDetailsViewSet, self).pre_save(obj)
+
 
 class BaseCaseOrderingFilter(OrderingFilter):
     default_modified = 'modified'

--- a/cla_backend/templates/admin/checker/reasonforcontacting/change_list.html
+++ b/cla_backend/templates/admin/checker/reasonforcontacting/change_list.html
@@ -4,10 +4,10 @@
 
   {{ block.super }}
 
-  <div class="module">
-    {% with category_stats=opts.model.get_category_stats %}
+  <div class="module" style="overflow:hidden">
 
-      <table>
+    {% with category_stats=opts.model.get_category_stats %}
+      <table style="float:left">
         <thead>
           <tr>
             <th colspan="2">
@@ -24,8 +24,28 @@
           {% endfor %}
         </tbody>
       </table>
-
     {% endwith %}
+
+    {% with top_referrers=opts.model.get_top_referrers %}
+      <table style="float:left;margin-left:30px">
+        <thead>
+          <tr>
+            <th colspan="2">
+              <h2>Top referrers:</h2>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for top_referrer in top_referrers %}
+            <tr>
+              <td>{{ top_referrer.referrer }}</td>
+              <td>{{ top_referrer.percentage|stringformat:'.0f%%' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endwith %}
+
   </div>
 
 {% endblock %}

--- a/cla_backend/templates/admin/checker/reasonforcontacting/change_list.html
+++ b/cla_backend/templates/admin/checker/reasonforcontacting/change_list.html
@@ -1,0 +1,31 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools %}
+
+  {{ block.super }}
+
+  <div class="module">
+    {% with category_stats=opts.model.get_category_stats %}
+
+      <table>
+        <thead>
+          <tr>
+            <th colspan="2">
+              <h2>Percentage of {{ category_stats.total_count }} responses choosing:</h2>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for category in category_stats.categories %}
+            <tr>
+              <td>{{ category.description }}</td>
+              <td>{{ category.percentage|stringformat:'.0f%%' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+    {% endwith %}
+  </div>
+
+{% endblock %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==1.4.1
 git+git://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+git://github.com/ministryofjustice/cla_common.git@0.2.3#egg=cla_common==0.2.3
+git+git://github.com/ministryofjustice/cla_common.git@0.2.4#egg=cla_common==0.2.4
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
in public site, when a user drops out of the scope/means test flow, they are presented with a form to find out why they want to get in touch. the form was previously sent to zendesk
[Fixes #96775836]
depends on [cla_common#31](https://github.com/ministryofjustice/cla_common/pull/31)