### PR TITLE
complaints updates

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -185,6 +185,8 @@ class CaseSerializer(CaseSerializerFull):
     billable_time = serializers.IntegerField(read_only=True)
     rejected = serializers.SerializerMethodField('is_rejected')
 
+    complaint_count = serializers.IntegerField(source='complaint_count', read_only=True)
+
     def is_rejected(self, case):
         try:
             return case.rejected == 1
@@ -205,6 +207,7 @@ class CaseSerializer(CaseSerializerFull):
             'ecf_statement', 'case_count',
             'requires_action_at', 'callback_attempt', 'source',
             'complaint_flag', 'eod_details', 'call_started',
+            'complaint_count',
         )
 
 
@@ -241,9 +244,8 @@ class CreateCaseSerializer(CaseSerializer):
     """
     personal_details = UUIDSerializer(slug_field='reference', required=False)
 
-    # class Meta(object):
-    #     model = Case
-    #     fields = ('reference', 'personal_details')
+    class Meta(CaseSerializer.Meta):
+        fields = tuple(set(CaseSerializer.Meta.fields) - {'complaint_count'})
 
 
 class ProviderSerializer(ProviderSerializerBase):

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -219,6 +219,11 @@ class CreateCaseTestCase(BaseCaseTestCase):
 
 
 class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
+    @property
+    def response_keys(self):
+        return super(UpdateCaseTestCase, self).response_keys + \
+               ['complaint_count']
+
     def test_patch_operator_notes_allowed(self):
         """
         Test that provider cannot post provider notes

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -188,6 +188,22 @@ class CaseViewSet(
                 source=CASE_SOURCE.PHONE
             )
 
+        if this_operator.is_cla_superuser_or_manager:
+            qs = qs.extra(select={
+                'complaint_count': '''
+                    SELECT COUNT(complaints_complaint.id)
+                    FROM complaints_complaint
+                    JOIN legalaid_eoddetails
+                        ON complaints_complaint.eod_id = legalaid_eoddetails.id
+                    WHERE legalaid_case.id = legalaid_eoddetails.case_id
+                        AND complaints_complaint.resolved IS NULL
+                '''
+            })
+        else:
+            qs = qs.extra(select={
+                'complaint_count': 'SELECT NULL'
+            })
+
         return qs
 
     def get_serializer_class(self):

--- a/cla_backend/apps/complaints/forms.py
+++ b/cla_backend/apps/complaints/forms.py
@@ -55,5 +55,9 @@ class ComplaintLogForm(EventSpecificLogForm):
         if self.cleaned_data.get('event_code') == 'COMPLAINT_CLOSED':
             self.complaint.resolved = self.cleaned_data.get('resolved')
             self.complaint.save()
-            self.complaint.eod.case.complaint_flag = False
-            self.complaint.eod.case.save()
+            eod = self.complaint.eod
+            case = eod.case
+            siblings = eod.complaint_set.exclude(id=self.complaint.id)
+            unresolved = siblings.filter(resolved__isnull=True)
+            case.complaint_flag = unresolved.exists()
+            case.save()


### PR DESCRIPTION
• a single case (i.e. its one-to-one EOD) can have multiple open complaints
• cases API reports the open complaint count