### PR TITLE
Fix Sentry errors

### DIFF
--- a/cla_backend/apps/checker/tests/api/test_eligibility_check_api.py
+++ b/cla_backend/apps/checker/tests/api/test_eligibility_check_api.py
@@ -1,3 +1,5 @@
+import uuid
+from core.tests.mommy_utils import make_recipe
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -38,3 +40,29 @@ class EligibilityCheckTestCase(
         self.assertEqual(data['dependants_old'], check.dependants_old)
         self.assertPersonEqual(data['you'], check.you)
         self.assertPersonEqual(data['partner'], check.partner, partner=True)
+
+    def test_case_ref_api(self):
+        case = make_recipe('legalaid.case')
+
+        case.eligibility_check = self.resource
+        case.save()
+
+        case_ref_url = u'%s%s' % (self.detail_url, u'case_ref/')
+
+        response = self.client.get(
+            case_ref_url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        case_ref_url = case_ref_url.replace(
+            unicode(self.resource_lookup_value),
+            unicode(uuid.uuid1()))
+
+        response = self.client.get(
+            case_ref_url,
+            HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/cla_backend/apps/checker/views.py
+++ b/cla_backend/apps/checker/views.py
@@ -1,8 +1,9 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets, mixins
-from rest_framework.decorators import action
+from rest_framework.decorators import action, link
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response as DRFResponse
 
@@ -70,6 +71,15 @@ class EligibilityCheckViewSet(
             'is_eligible': response,
             'reasons': reasons
         })
+
+    @link()
+    def case_ref(self, request, *args, **kwargs):
+        try:
+            return DRFResponse({
+                'reference': self.get_object().case.reference,
+            })
+        except AttributeError:
+            raise Http404
 
 
 class NestedModelMixin(object):

--- a/cla_backend/apps/timer/models.py
+++ b/cla_backend/apps/timer/models.py
@@ -25,7 +25,10 @@ class Timer(TimeStampedModel):
     @classmethod
     def start(cls, user):
         statsd.incr('timer.start')
-        return cls.objects.create(created_by=user)
+        timer, created = cls.objects.get_or_create(
+            created_by=user, cancelled=False, stopped__isnull=True,
+            defaults={'created_by': user})
+        return timer
 
     def is_stopped(self):
         return self.stopped


### PR DESCRIPTION
- add getter for case ref from eligibility check on puyblic checker api
 - aims to fix error of broken requests from public when saving a case