### PR TITLE
Add validation rules to csv upload

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -211,7 +211,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
              u'02/01/2014', u'E', u'M', u'1', u'', u'', u'SW1A 1AA',
              u'X', u'EPRO', u'ESOS', u'', u'', u'', u'',
              u'', u'18', u'99.5', u'', u'ILL', u'0', u'0',
-             u'DVCA',
+             u'FINI',
              u'N', u'', u'', u'', u'', u'DK', u'TA'],
             ])
 
@@ -297,7 +297,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         cleaned_data['Eligibility Code'] = u'S'
         cleaned_data['Determination'] = True
 
-        cleaned_data['Time Spent'] = 9
+        cleaned_data['Time Spent'] = 12
         validator._validate_time_spent(cleaned_data, u'welfare')
         cleaned_data['Time Spent'] = 999
 
@@ -307,6 +307,11 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
 
         with self.assertRaisesRegexp(serializers.ValidationError,
                                      "[u'Time spent (999) must not be greater than 18 minutes']"):
+            validator._validate_time_spent(cleaned_data, u'welfare')
+
+        cleaned_data['Time Spent'] = 9
+        with self.assertRaisesRegexp(serializers.ValidationError,
+                                     "[u'Time spent (9) must be in 6 minute intervals']"):
             validator._validate_time_spent(cleaned_data, u'welfare')
 
     def test_validation_exemption_code_or_cla_ref_required(self):


### PR DESCRIPTION
 - Date Closed' cannot be from the current month
 - 'Time Spent' - has to be in 6 minute increments. If Determination code is present, it has to be in 6 minute increments up to 18 minutes. In Education/Housing/Debt/Family it has to be in 6 minute increments up to 18 minutes. In Discrimination it has to be in 6 minute increments up to 42 minutes.
 - 'Determination' - when DVCA is entered it has to be a Family case.