### PR TITLE
Run housekeeping on a regular schedule on the first instance

### DIFF
--- a/cla_backend/apps/cla_butler/management/commands/housekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/housekeeping.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.core.management.base import BaseCommand
 
+from cla_butler.stack import (
+    is_first_instance, InstanceNotInAsgException, StackException
+)
 from cla_butler.tasks import DeleteOldData
 
 
@@ -8,5 +11,29 @@ class Command(BaseCommand):
 
     help = 'Deletes public diagnosis that are more than a day old'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            dest='force',
+            help='Force running of housekeeping task',
+        )
+
     def handle(self, *args, **options):
-        DeleteOldData().run()
+        if self.should_run_housekeeping(**options):
+            DeleteOldData().run()
+        else:
+            self.stdout.write('Not doing housekeeping because running on secondary instance')
+
+    def should_run_housekeeping(self, **options):
+        if options['force']:
+            return True
+
+        try:
+            return is_first_instance()
+        except InstanceNotInAsgException:
+            self.stderr.write('EC2 instance not in an ASG')
+            return True
+        except StackException:
+            self.stderr.write('Not running on EC2 instance')
+            return True

--- a/cla_backend/apps/cla_butler/stack.py
+++ b/cla_backend/apps/cla_butler/stack.py
@@ -1,0 +1,56 @@
+import boto3
+from botocore.exceptions import ClientError
+import requests
+
+
+class StackException(Exception):
+    pass
+
+
+class StackInterrogationException(StackException):
+    pass
+
+
+class InstanceNotInAsgException(StackException):
+    pass
+
+
+def is_first_instance():
+    """
+    Returns True if the current instance is the first instance in the ASG group,
+    sorted by instance_id.
+    """
+    try:
+        # get instance id and aws region
+        instance_details = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
+                                        timeout=5).json()
+        instance_id = instance_details['instanceId']
+        instance_region = instance_details['region']
+    except (requests.RequestException, ValueError, KeyError) as e:
+        raise StackInterrogationException(e)
+
+    try:
+        # get instance's autoscaling group
+        autoscaling_client = boto3.client('autoscaling', region_name=instance_region)
+        response = autoscaling_client.describe_auto_scaling_instances(InstanceIds=[instance_id])
+        assert len(response['AutoScalingInstances']) == 1
+        autoscaling_group = response['AutoScalingInstances'][0]['AutoScalingGroupName']
+    except ClientError as e:
+        raise StackInterrogationException(e)
+    except AssertionError:
+        raise InstanceNotInAsgException()
+
+    try:
+        # list in-service instances in autoscaling group
+        # instances being launched or terminated should not be considered
+        response = autoscaling_client.describe_auto_scaling_groups(AutoScalingGroupNames=[autoscaling_group])
+        assert len(response['AutoScalingGroups']) == 1
+        autoscaling_group_instance_ids = sorted(
+            instance['InstanceId']
+            for instance in response['AutoScalingGroups'][0]['Instances']
+            if instance['LifecycleState'] == 'InService'
+        )
+    except (ClientError, AssertionError) as e:
+        raise StackInterrogationException(e)
+
+    return autoscaling_group_instance_ids and autoscaling_group_instance_ids[0] == instance_id

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -17,3 +17,5 @@ post-buffering = 1
 harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
+
+cron = 0  5 -1 -1 0 python /home/app/django/manage.py housekeeping

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,3 +47,6 @@ pyminizip==0.2.1
 
 #Irat healthcheck and ping package
 git+https://github.com/ministryofjustice/django-moj-irat.git@4d54b86b1cb574fe787ba0fb8a992cf352f8eba6
+
+# stack interrogation
+boto3>=1.5,<2


### PR DESCRIPTION
Interrogate stack metadata to determine if running on the first instance of the ASG,
and if so perform housekeeping.

Also cease backing up deleted data to disk as it is unsustainable.