### PR TITLE
Use custom reports backend for test DB in Jenkins

### DIFF
--- a/cla_backend/settings/jenkins.py
+++ b/cla_backend/settings/jenkins.py
@@ -18,7 +18,7 @@ JENKINS_TASKS = (
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'cla_backend.apps.reports.db.backend',
         'NAME': os.environ.get('DB_USERNAME', ''),
         'TEST_NAME': 'test_cla_backend%s' % os.environ.get('BACKEND_TEST_DB_SUFFIX', ''),
         'USER': os.environ.get('DB_USERNAME', ''),


### PR DESCRIPTION
As Django test runner does not support replica DBs (MIRROR setting
just redirects to use the other connection), change the default
connection to use the custom engine when running in jenkins.

Tests fail during BST due to the connection not being UTC if using
the default postgres engine.