### PR TITLE
Fix bugs with running of housekeeping task

### DIFF
--- a/cla_backend/apps/cla_butler/management/commands/housekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/housekeeping.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
             self.stdout.write('Not doing housekeeping because running on secondary instance')
 
     def should_run_housekeeping(self, **options):
-        if options['force']:
+        if options.get('force', False):
             return True
 
         try:


### PR DESCRIPTION
Temporarily remove AWS credentials from environment in order to
use the default IAM role for the instance instead of the S3 storage
user.