### PR TITLE
Circle CI badge refers to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CLA Backend
 
 
-[![CircleCI](https://circleci.com/gh/ministryofjustice/cla_backend/tree/develop.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cla_backend/tree/develop)
+[![CircleCI](https://circleci.com/gh/ministryofjustice/cla_backend/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cla_backend/tree/master)
     
 Backend API for the Civil Legal Aid Tool.
 


### PR DESCRIPTION
## What does this pull request do?

The develop branch doesn't exist anymore. This pull request updates the badge to refer to `master` branch.

## Any other changes that would benefit highlighting?

Nothing.
