### PR TITLE
Fix unicode issue in the case handling system

### DIFF
--- a/cla_backend/apps/legalaid/views.py
+++ b/cla_backend/apps/legalaid/views.py
@@ -479,7 +479,7 @@ class FullCaseViewSet(
                 )
             )
             for _ in range(number_of_placeholders):
-                params.append('%{}%'.format(search_term))
+                params.append(u'%{}%'.format(search_term))
 
         subquery = ' INTERSECT '.join(unions)
 


### PR DESCRIPTION
## What does this pull request do?

This pull request fixes an error where anything entered into the search bar in the case handling system that was not an ASCII character, such as the fancy apostrophe in Mark O’Brien or when searching with the "£" sign, would result in a 500 error code and display the error message below. 
_UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 1: ordinal not in range(128)_
This was fixed by simply add 'u' where the search string was being formatted so that it was able to handle  non-ASCII characters such as these. 

## Any other changes that would benefit highlighting?

Intentionally left blank.
