### PR TITLE
LGA-384 uW cron

### DIFF
--- a/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
+++ b/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         if self.should_run_housekeeping(**options):
             self.check_for_missing_outcome_codes()
         else:
-            self.stdout.write('Not doing housekeeping because running on secondary instance')
+            logger.info('Skip check_for_missing_outcome_codes because running on secondary instance')
 
     @staticmethod
     def check_for_missing_outcome_codes():
@@ -29,9 +29,9 @@ class Command(BaseCommand):
 
         if cases_to_re_denorm.exists():
             case_references = cases_to_re_denorm.values_list('reference', flat=True)
-            logger.warning('LGA-275 investigation. Cases found with outcome code missing; '
-                           'value expected to be denormalized from log. Number of cases: {}\nReferences: {}'
-                           .format(len(case_references), case_references))
+            logger.error('LGA-275 investigation. Cases found with outcome code missing; '
+                         'value expected to be denormalized from log. Number of cases: {}\nReferences: {}'
+                         .format(len(case_references), case_references))
         else:
             logger.info('LGA-275 No cases found missing denormalized outcome codes')
 

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -269,6 +269,12 @@ LOGGING = {
             'formatter': 'simple',
             'stream': sys.stdout
         },
+        'sentry': {
+            'level': 'ERROR',
+            'class': 'raven.handlers.logging.SentryHandler',
+            'formatter': 'simple',
+            'dsn': os.environ.get('RAVEN_CONFIG_DSN'),
+        },
     },
     'loggers': {
         'django.request': {

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -266,7 +266,7 @@ LOGGING = {
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
-            'formatter': 'logstash',
+            'formatter': 'simple',
             'stream': sys.stdout
         },
     },

--- a/cla_backend/settings/docker.py
+++ b/cla_backend/settings/docker.py
@@ -22,6 +22,6 @@ ADMINS = (
 MANAGERS = ADMINS
 
 LOGGING['loggers'][''] = {
-    'handlers': ['console'],
+    'handlers': ['console', 'sentry'],
     'level': "DEBUG",
 }

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -11,12 +11,9 @@ processes = 2
 chdir = /home/app/django
 env = DJANGO_SETTINGS_MODULE=cla_backend.settings
 module = cla_backend.wsgi:application
-req-logger = file:/var/log/wsgi/request.log
-logger = file:/var/log/wsgi/error.log
 post-buffering = 1
 harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
-
 cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 45 12 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+cron = 10 13 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -19,4 +19,4 @@ buffer-size=32768
 post-buffering-bufsize=32768
 
 cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 30 11 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+cron = 45 12 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -18,4 +18,5 @@ harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
 
-cron = 0  5 -1 -1 0 python /home/app/django/manage.py housekeeping
+cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
+cron = 30 11 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -16,4 +16,4 @@ harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
 cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 20 10 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+cron = 15 2 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -16,4 +16,4 @@ harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
 cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 50 16 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+cron = 20 10 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -15,5 +15,7 @@ post-buffering = 1
 harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
-cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 15 2 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+# Cronjobs moved to container for logging compatibility
+# https://github.com/ministryofjustice/cla_backend-deploy/commit/5f81cde78924bbf2dc554b23240c619dcfebd8f2
+cron2=minute=0,hour=5,unique=1 python /home/app/django/manage.py housekeeping
+cron2=minute=15,hour=2,unique=1,harakiri=30 python /home/app/django/manage.py monitor_missing_outcome_codes

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -16,4 +16,4 @@ harakiri = 20
 buffer-size=32768
 post-buffering-bufsize=32768
 cron = 0 5 -1 -1 0 python /home/app/django/manage.py housekeeping
-cron = 10 13 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes
+cron = 50 16 -1 -1 -1 python /home/app/django/manage.py monitor_missing_outcome_codes


### PR DESCRIPTION
## What does this pull request do?

Move invocation of `monitor_missing_outcome_codes` script to uW, inside the container
Reconfigure uW to log to stdout
Add Sentry as a log handler, set to error level
Adjust logging in monitor_missing_outcome_codes

## Any other changes that would benefit highlighting?

Use simple formatter for console logging to avoid nested logstash