### PR TITLE
LGA-380 Reduced Xmas Working Hours

### DIFF
--- a/cla_backend/apps/legalaid/tests/test_utils.py
+++ b/cla_backend/apps/legalaid/tests/test_utils.py
@@ -1,0 +1,43 @@
+from datetime import date, datetime, time
+
+from django.test import TestCase
+from legalaid.utils.sla import is_in_business_hours
+
+from cla_common.call_centre_availability import OpeningHours
+from django.conf import settings
+
+
+class SlaCustomBusinessHoursTestCase(TestCase):
+    operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
+
+    xmas_eve = date(year=2018, month=12, day=24)
+    xmas_eve_before_hours = datetime.combine(xmas_eve, time(hour=8, minute=59))
+    xmas_eve_noon = datetime.combine(xmas_eve, time(hour=12))
+    xmas_eve_last_minute = datetime.combine(xmas_eve, time(hour=17, minute=29))
+    xmas_eve_after_hours = datetime.combine(xmas_eve, time(hour=18))
+
+    new_years_eve = date(year=2018, month=12, day=31)
+    new_years_eve_before_hours = datetime.combine(new_years_eve, time(hour=8, minute=59))
+    new_years_eve_noon = datetime.combine(new_years_eve, time(hour=12))
+    new_years_eve_last_minute = datetime.combine(new_years_eve, time(hour=17, minute=29))
+    new_years_eve_after_hours = datetime.combine(new_years_eve, time(hour=18))
+
+    def test_custom_business_hours(self):
+        self.assertFalse(is_in_business_hours(self.xmas_eve_before_hours))
+        self.assertTrue(is_in_business_hours(self.xmas_eve_noon))
+        self.assertTrue(is_in_business_hours(self.xmas_eve_last_minute))
+        self.assertFalse(is_in_business_hours(self.xmas_eve_after_hours))
+
+        self.assertFalse(is_in_business_hours(self.new_years_eve_before_hours))
+        self.assertTrue(is_in_business_hours(self.new_years_eve_noon))
+        self.assertTrue(is_in_business_hours(self.new_years_eve_last_minute))
+        self.assertFalse(is_in_business_hours(self.new_years_eve_after_hours))
+
+    def test_custom_day_timeslots(self):
+        slots = self.operator_hours.time_slots(self.xmas_eve)
+        self.assertEquals(min(slots), datetime(2018, 12, 24, 9, 0))
+        self.assertEquals(max(slots), datetime(2018, 12, 24, 17, 0))
+
+        slots = self.operator_hours.time_slots(self.new_years_eve)
+        self.assertEquals(min(slots), datetime(2018, 12, 31, 9, 0))
+        self.assertEquals(max(slots), datetime(2018, 12, 31, 17, 0))

--- a/cla_backend/apps/legalaid/utils/sla.py
+++ b/cla_backend/apps/legalaid/utils/sla.py
@@ -16,7 +16,8 @@ def is_in_business_hours(dt):
 
 
 def get_remainder_from_end_of_day(day, dt_until):
-    available_slots = time_slots(day)
+    opening_hours = OpeningHours(**settings.OPERATOR_HOURS)
+    available_slots = opening_hours.time_slots(day)
     remainder = timedelta(minutes=SLOT_INTERVAL_MINS)
     if available_slots:
         end_of_day = available_slots[-1] + timedelta(minutes=SLOT_INTERVAL_MINS)
@@ -31,8 +32,9 @@ def get_next_business_day(start_date):
 
 
 def get_sla_time(start_time, minutes_delta):
+    operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
     next_business_day = get_next_business_day(start_time.date())
-    start_of_next_business_day = time_slots(next_business_day.date())[0]
+    start_of_next_business_day = operator_hours.time_slots(next_business_day.date())[0]
     start_of_next_business_day = timezone.make_aware(start_of_next_business_day,
         timezone.get_default_timezone())
 

--- a/cla_backend/apps/legalaid/utils/sla.py
+++ b/cla_backend/apps/legalaid/utils/sla.py
@@ -3,21 +3,21 @@ from datetime import timedelta
 from django.utils import timezone
 from django.conf import settings
 
-from cla_common.call_centre_availability import SLOT_INTERVAL_MINS, \
-    OpeningHours, available_days, time_slots, on_sunday, on_bank_holiday
+from cla_common.call_centre_availability import SLOT_INTERVAL_MINS, OpeningHours, \
+    available_days, on_sunday, on_bank_holiday
+
+
+operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
 
 
 def is_in_business_hours(dt):
     if not dt.tzinfo:
         dt = timezone.make_aware(dt, timezone.get_default_timezone())
-
-    OPERATOR_HOURS = OpeningHours(**settings.OPERATOR_HOURS)
-    return dt in OPERATOR_HOURS
+    return dt in operator_hours
 
 
 def get_remainder_from_end_of_day(day, dt_until):
-    opening_hours = OpeningHours(**settings.OPERATOR_HOURS)
-    available_slots = opening_hours.time_slots(day)
+    available_slots = operator_hours.time_slots(day)
     remainder = timedelta(minutes=SLOT_INTERVAL_MINS)
     if available_slots:
         end_of_day = available_slots[-1] + timedelta(minutes=SLOT_INTERVAL_MINS)
@@ -32,7 +32,6 @@ def get_next_business_day(start_date):
 
 
 def get_sla_time(start_time, minutes_delta):
-    operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
     next_business_day = get_next_business_day(start_time.date())
     start_of_next_business_day = operator_hours.time_slots(next_business_day.date())[0]
     start_of_next_business_day = timezone.make_aware(start_of_next_business_day,

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -354,7 +354,9 @@ NON_ROTA_OPENING_HOURS = OpeningHours(**NON_ROTA_HOURS)
 
 OPERATOR_HOURS = {
     'weekday': (datetime.time(9, 0), datetime.time(20, 0)),
-    'saturday': (datetime.time(9, 0), datetime.time(12, 30))
+    'saturday': (datetime.time(9, 0), datetime.time(12, 30)),
+    '2018-12-24': (datetime.time(9, 0), datetime.time(17, 30)),
+    '2018-12-31': (datetime.time(9, 0), datetime.time(17, 30)),
 }
 
 OBIEE_IP_PERMISSIONS = (


### PR DESCRIPTION
Add custom operator hour tests
Use OpeningHours.time_slots

## What does this pull request do?

Set custom working hours for Christmas Eve and New Year's Eve 2018.

## Any other changes that would benefit highlighting?

Switch to use the `time_slots` method of the `OpeningHours` class that respects custom working hours.

(`cla_common` needs some careful tending to)
