### PR TITLE
Add modern Python code quality tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Update pip to the latest version:
 
 Install python dependencies:
 
-    pip install -r requirements/local.txt
+    pip install -r requirements/dev.txt
 
 Create the database inside postgres. Type `psql -d template1` to enter postgres, then enter:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Start the server:
 
 See the list of users in `/admin/auth/user/`. Passwords are the same as the usernames.
 
+
+## Coding
+
+This project uses Black for strict code formatting, with a pre-commit hook for enforcement. Black requires Python 3,
+so must be installed outside this project's virtualenv for now. See the 
+[Installation docs](https://black.readthedocs.io/en/stable/installation_and_usage.html)
+
+
 ## Dev
 
 Each time you start a new terminal instance you will need to run the following commands to get the server running again:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 119
+verbose = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.tx
+  | env
+  | scripts
+  | build
+)/
+'''

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,3 @@
 django-extensions==1.4.9
 Werkzeug==0.9.6
 django-debug-toolbar==1.2.2
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@
 django-extensions==1.4.9
 Werkzeug==0.9.6
 django-debug-toolbar==1.2.2
+flake8==3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 119
+max-complexity = 10
+ignore = E501
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist


### PR DESCRIPTION
## What does this pull request do?

Introduce configs for flake8 and Black. flake8 monitors style and complexity violations while Black is a strict and opinionated Python formatter.

## Any other changes that would benefit highlighting?

Make mention in README
Rename local.txt requirements to dev.txt