### PR TITLE
Update custom business hour tests

### DIFF
--- a/cla_backend/apps/legalaid/tests/test_utils.py
+++ b/cla_backend/apps/legalaid/tests/test_utils.py
@@ -1,22 +1,21 @@
 from datetime import date, datetime, time
 
 from django.test import TestCase
-from legalaid.utils.sla import is_in_business_hours
+from legalaid.utils.sla import is_in_business_hours, operator_hours
 
-from cla_common.call_centre_availability import OpeningHours
-from django.conf import settings
+# from cla_common.call_centre_availability import OpeningHours
 
 
 class SlaCustomBusinessHoursTestCase(TestCase):
-    operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
+    next_year = date.today().year + 1
 
-    xmas_eve = date(year=2018, month=12, day=24)
+    xmas_eve = date(year=next_year, month=12, day=24)
     xmas_eve_before_hours = datetime.combine(xmas_eve, time(hour=8, minute=59))
     xmas_eve_noon = datetime.combine(xmas_eve, time(hour=12))
     xmas_eve_last_minute = datetime.combine(xmas_eve, time(hour=17, minute=29))
     xmas_eve_after_hours = datetime.combine(xmas_eve, time(hour=18))
 
-    new_years_eve = date(year=2018, month=12, day=31)
+    new_years_eve = date(year=next_year, month=12, day=31)
     new_years_eve_before_hours = datetime.combine(new_years_eve, time(hour=8, minute=59))
     new_years_eve_noon = datetime.combine(new_years_eve, time(hour=12))
     new_years_eve_last_minute = datetime.combine(new_years_eve, time(hour=17, minute=29))
@@ -34,10 +33,10 @@ class SlaCustomBusinessHoursTestCase(TestCase):
         self.assertFalse(is_in_business_hours(self.new_years_eve_after_hours))
 
     def test_custom_day_timeslots(self):
-        slots = self.operator_hours.time_slots(self.xmas_eve)
-        self.assertEquals(min(slots), datetime(2018, 12, 24, 9, 0))
-        self.assertEquals(max(slots), datetime(2018, 12, 24, 17, 0))
+        slots = operator_hours.time_slots(self.xmas_eve)
+        self.assertEquals(min(slots), datetime(self.next_year, 12, 24, 9, 0))
+        self.assertEquals(max(slots), datetime(self.next_year, 12, 24, 17, 0))
 
-        slots = self.operator_hours.time_slots(self.new_years_eve)
-        self.assertEquals(min(slots), datetime(2018, 12, 31, 9, 0))
-        self.assertEquals(max(slots), datetime(2018, 12, 31, 17, 0))
+        slots = operator_hours.time_slots(self.new_years_eve)
+        self.assertEquals(min(slots), datetime(self.next_year, 12, 31, 9, 0))
+        self.assertEquals(max(slots), datetime(self.next_year, 12, 31, 17, 0))

--- a/cla_backend/settings/circle.py
+++ b/cla_backend/settings/circle.py
@@ -1,26 +1,14 @@
 import os
 from .testing import *
 
-DEBUG = False
-TEMPLATE_DEBUG = DEBUG
-
 ADMINS = (
     ('CLA', 'cla-alerts@digital.justice.gov.uk'),
 )
 
 MANAGERS = ADMINS
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'cla_backend.apps.reports.db.backend',
-        'NAME': os.environ.get('DB_NAME', 'circle_test'),
-        'USER': os.environ.get('DB_USER', 'root'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'localhost'),
-        'PORT': os.environ.get('DB_PORT', ''),
-    }
-}
-
-ALLOWED_HOSTS = [
-    '*'
-]
+DATABASES['default']['NAME'] = os.environ.get('DB_NAME', 'circle_test')
+DATABASES['default']['USER'] = os.environ.get('DB_USER', 'root')
+DATABASES['default']['PASSWORD'] = os.environ.get('DB_PASSWORD', '')
+DATABASES['default']['HOST'] = os.environ.get('DB_HOST', 'localhost')
+DATABASES['default']['PORT'] = os.environ.get('DB_PORT', '')

--- a/cla_backend/settings/circle.py
+++ b/cla_backend/settings/circle.py
@@ -7,8 +7,13 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATABASES['default']['NAME'] = os.environ.get('DB_NAME', 'circle_test')
-DATABASES['default']['USER'] = os.environ.get('DB_USER', 'root')
-DATABASES['default']['PASSWORD'] = os.environ.get('DB_PASSWORD', '')
-DATABASES['default']['HOST'] = os.environ.get('DB_HOST', 'localhost')
-DATABASES['default']['PORT'] = os.environ.get('DB_PORT', '')
+DATABASES = {
+    'default': {
+        'ENGINE': 'cla_backend.apps.reports.db.backend',
+        'NAME': os.environ.get('DB_NAME', 'circle_test'),
+        'USER': os.environ.get('DB_USER', 'root'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+        'HOST': os.environ.get('DB_HOST', 'localhost'),
+        'PORT': os.environ.get('DB_PORT', ''),
+    }
+}

--- a/cla_backend/settings/testing.py
+++ b/cla_backend/settings/testing.py
@@ -1,10 +1,13 @@
+from datetime import date, time
 from .base import *
+
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
 
 TEST_APPS = (
     'django_pdb',
 )
-
-#INSTALLED_APPS += TEST_APPS
 
 TEST_MODE = True
 
@@ -14,6 +17,21 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['login'] = '10000000000/sec'
 
 TEST_RUNNER = 'core.testing.CLADiscoverRunner'
 
+DATABASES['default']['ENGINE'] = 'cla_backend.apps.reports.db.backend'
+
+ALLOWED_HOSTS = [
+    '*'
+]
+
+next_year = date.today().year + 1
+
+OPERATOR_HOURS = {
+    'weekday': (time(9, 0), time(20, 0)),
+    'saturday': (time(9, 0), time(12, 30)),
+    '{}-12-24'.format(next_year): (time(9, 0), time(17, 30)),
+    '{}-12-31'.format(next_year): (time(9, 0), time(17, 30)),
+}
+
 
 class DisableMigrations(object):
     def __contains__(self, item):
@@ -21,5 +39,6 @@ class DisableMigrations(object):
 
     def __getitem__(self, item):
         return "notmigrations"
+
 
 MIGRATION_MODULES = DisableMigrations()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.2.7#egg=cla_common==0.2.7
+git+https://github.com/ministryofjustice/cla_common.git@0.3.0#egg=cla_common==0.3.0
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

Updates our custom business hour tests to always test future dates (a year ahead), while a larger refactor of the messy SLA classes in pending.

## Any other changes that would benefit highlighting?

Updates cla_common to 0.3.0
Refactors settings from circle settings to parent testing settings
