### PR TITLE
Use cla_common==0.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.2.7#egg=cla_common==0.2.7
+git+https://github.com/ministryofjustice/cla_common.git@0.3.0#egg=cla_common==0.3.0
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

Updates `cla_common` requirement to latest tagged release: `0.3.0`

## Any other changes that would benefit highlighting?

Newest version of `cla_common`, fixes versioning error in old release
No code changes applicable to cla_backend
This will require changes in PR 494 merged before tests pass.