### PR TITLE
LGA-434 - Alert when cla_backend is close to running out of disk space

### DIFF
--- a/cla_backend/apps/status/healthchecks.py
+++ b/cla_backend/apps/status/healthchecks.py
@@ -1,0 +1,12 @@
+import os
+
+
+def check_disk():
+    stat = os.statvfs(os.getcwd())
+    available_mb = (stat.f_bavail * stat.f_frsize) / (1024.0 ** 2)
+    total_mb = (stat.f_blocks * stat.f_frsize) / (1024.0 ** 2)
+
+    available_percent = available_mb / total_mb * 100
+    status = available_percent > 2.0
+
+    return status

--- a/cla_backend/apps/status/tests/healthchecks_tests.py
+++ b/cla_backend/apps/status/tests/healthchecks_tests.py
@@ -1,0 +1,29 @@
+import unittest
+import mock
+from moj_irat.healthchecks import registry
+from status import healthchecks
+
+
+class HealthChecksTestCase(unittest.TestCase):
+    def test_healthcheck_is_registered(self):
+        registry.load_healthchecks()
+        expected_names = "check_disk"
+        healthcheck_names = [healthcheck.__name__ for healthcheck in registry._registry]
+        self.assertIn(expected_names, healthcheck_names)
+
+    @mock.patch("os.statvfs")
+    def test_disk_space_check_passes_when_more_than_2_percent_space_is_available(self, stat_mock):
+        stat_mock.return_value.f_bavail = 3 * 1024
+        stat_mock.return_value.f_blocks = 100 * 1024
+        stat_mock.return_value.f_frsize = 1024
+
+        self.assertTrue(healthchecks.check_disk())
+
+    @mock.patch("os.statvfs")
+    def test_disk_space_check_fails_when_less_than_2_percent_space_is_available(self, stat_mock):
+        stat_mock.return_value.f_bavail = 2 * 1024
+        stat_mock.return_value.f_blocks = 100 * 1024
+        stat_mock.return_value.f_frsize = 1024
+
+        result = healthchecks.check_disk()
+        self.assertFalse(result)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -13,7 +13,7 @@ root = lambda *x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
 sys.path.insert(0, root("apps"))
 sys.path.insert(0, root("libs"))
 
-HEALTHCHECKS = ["moj_irat.healthchecks.database_healthcheck"]
+HEALTHCHECKS = ["moj_irat.healthchecks.database_healthcheck", "status.healthchecks.check_disk"]
 
 AUTODISCOVER_HEALTHCHECKS = True
 


### PR DESCRIPTION
## What does this pull request do?

Send notification to #cla-alerts slack channel when disk space available is below 2% on any of the cla_backend servers

## Any other changes that would benefit highlighting?
the disk space health checks have been added to the list of health checks carried out using the moj_irat library. 

Currently the Elastic Load Balancers carry the health checks trigger the relevant cloud watch alarms, these then send a notification to the SNS topics which in turn trigger an AWS Lambda. There are two SNS topics one for low priority and another for high priority notifications.

The current lambdas were sending the alerts to the #high-priority-alerts or #low-priority-alerts slack channel. These were not modified as I am not currently sure where else they are used.

Outside of this PR, a new SNS topic CloudWatchToSlackCLAHealthChecks was created along with a new AWS lamda CloudWatchToSlackCLAHealthChecks which when triggered will send the alert to #cla-alerts
