### PR TITLE
Use pip version 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv env
+            pip install pip==18.1
       - restore_cache:
           keys:
             - pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}
@@ -107,7 +108,6 @@ jobs:
           name: Install dependencies
           command: |
             source env/bin/activate
-            pip install pip==18.1
             pip install --requirement requirements.txt --requirement requirements/testing.txt
       - save_cache:
           key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv env
+            source env/bin/activate
             pip install pip==18.1
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
           name: Install dependencies
           command: |
             source env/bin/activate
+            pip install pip==18.1
             pip install --requirement requirements.txt --requirement requirements/testing.txt
       - save_cache:
           key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN rm -f /etc/nginx/sites-enabled/default && \
     chown www-data:www-data /etc/nginx/conf.d/htpassword
 
 # Pip install Python packages
-RUN pip install -U setuptools pip wheel
+RUN pip install -U setuptools pip==18.1 wheel
 RUN pip install GitPython uwsgi requests
 
 RUN mkdir -p /var/log/wsgi && \


### PR DESCRIPTION
## What does this pull request do?

In CircleCI, the test jobs are currently failing

https://www.python.org/dev/peps/pep-0517/ causes problems with cla_common and pip 19 uses it by default.

Using --no-use-pep517 does not work with pip install -r requirements.txt. The workaround is to downgrade to the previous version of pip.

## Any other changes that would benefit highlighting?

We can upgrade to the next pip version if cla_common is made compatible with https://www.python.org/dev/peps/pep-0517/.

Same as https://github.com/ministryofjustice/cla_public/pull/800
