### PR TITLE
Outcome code for family 2

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -650,6 +650,52 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         except (serializers.ValidationError, Exception) as e:
             self.fail("{}".format(e))
 
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_for_family_outcome_code_F_PLACE_HOLDER_2_is_valid(self):
+        data = [
+            [
+                u"3333333",
+                u"0001",
+                u"2B222B",
+                u"A N Other",
+                u"Corgi",
+                u"02/01/2014",
+                u"E",
+                u"M",
+                u"1",
+                u"",
+                u"",
+                u"SW1A 1AA",
+                u"X",
+                u"FAMA",
+                u"FADV",
+                u"FA",
+                u"F_PLACE_HOLDER_2",
+                u"",
+                u"01/09/2018",
+                u"01/10/2018",
+                u"18",
+                u"99.5",
+                u"",
+                u"ILL",
+                u"0",
+                u"0",
+                u"FAFA",
+                u"N",
+                u"",
+                u"",
+                u"NAR",
+                u"",
+                u"DK",
+                u"TA",
+            ]
+        ]
+        validator = v.ProviderCSVValidator(data)
+        try:
+            validator.validate()
+        except (serializers.ValidationError, Exception) as e:
+            self.fail("{}".format(e))
+
 
 class DependsOnDecoratorTestCase(unittest.TestCase):
     def test_method_called(self):

--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -651,7 +651,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             self.fail("{}".format(e))
 
     @override_settings(CONTRACT_2018_ENABLED=True)
-    def test_validator_for_family_outcome_code_F_PLACE_HOLDER_2_is_valid(self):
+    def test_validator_for_family_outcome_code_FAB_is_valid(self):
         data = [
             [
                 u"3333333",
@@ -670,7 +670,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
                 u"FAMA",
                 u"FADV",
                 u"FA",
-                u"F_PLACE_HOLDER_2",
+                u"FAB",
                 u"",
                 u"01/09/2018",
                 u"01/10/2018",

--- a/cla_backend/apps/legalaid/utils/csvupload/contracts.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/contracts.py
@@ -103,7 +103,6 @@ family_category_spec = {
         u"FY",
         u"FZ",
         u"FS",
-        u"F_PLACE_HOLDER_2",
     },
     "MATTER_TYPE1": {
         u"FAMA",
@@ -245,6 +244,8 @@ contract_2018_category_spec = {
     u"housing": deepcopy(housing_category_spec),
     u"welfare": deepcopy(welfare_category_spec),
 }
+
+contract_2018_category_spec["family"]["OUTCOME_CODES"].update({u"FAB"})
 
 
 def get_all_values_across_categories(key, applicable_contract):

--- a/cla_backend/apps/legalaid/utils/csvupload/contracts.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/contracts.py
@@ -103,6 +103,7 @@ family_category_spec = {
         u"FY",
         u"FZ",
         u"FS",
+        u"F_PLACE_HOLDER_2",
     },
     "MATTER_TYPE1": {
         u"FAMA",


### PR DESCRIPTION
## What does this pull request do?
[LGA-239: New family outcome code 2 ](https://dsdmoj.atlassian.net/browse/LGA-239)

This pull request creates a new outcome code for family code FAB and places it inside the 2018 category spec, so that means that it will only be updated when the 2018 contract is put in motion. It also creates a tests that ensures that when this new code is included in a CSV file, and uploaded into the Case Handling System, it is able to be validated by the ProviderCSVValidator class.

## Any other changes that would benefit highlighting?

Intentionally left blank.
