### PR TITLE
Fix parsing of dob field that is already a dict

### DIFF
--- a/cla_backend/apps/core/drf/fields.py
+++ b/cla_backend/apps/core/drf/fields.py
@@ -27,7 +27,7 @@ class ThreePartDateField(serializers.WritableField):
         _('Date field has wrong format. Use { "day": 25, "month": 12, "year": 2012 }')
     }
 
-    def from_native(self, value):
+    def from_native(self, value):  # noqa: C901
         """
         Parse json data and return a date object
         """
@@ -41,25 +41,25 @@ class ThreePartDateField(serializers.WritableField):
             except ValueError:
                 msg = self.error_messages["invalid"]
                 raise serializers.ValidationError(msg)
-            else:
-                day = value.get("day")
-                month = value.get("month")
-                year = value.get("year")
+        if value:
+            day = value.get("day")
+            month = value.get("month")
+            year = value.get("year")
 
-                date_components = all([day, month, year])
-                if date_components:
-                    try:
-                        dt_object = datetime.date(int(year), int(month), int(day))
-                    except ValueError as ve:
-                        raise serializers.ValidationError(ve)
+            date_components = all([day, month, year])
+            if date_components:
+                try:
+                    dt_object = datetime.date(int(year), int(month), int(day))
+                except ValueError as ve:
+                    raise serializers.ValidationError(ve)
 
-                    if int(year) < 1900:
-                        raise serializers.ValidationError("year must be >= 1900")
-                    return dt_object
-                elif not date_components:
-                    return None
-                msg = self.error_messages["invalid"]
-                raise serializers.ValidationError(msg)
+                if int(year) < 1900:
+                    raise serializers.ValidationError("year must be >= 1900")
+                return dt_object
+            elif not date_components:
+                return None
+            msg = self.error_messages["invalid"]
+            raise serializers.ValidationError(msg)
 
     def to_native(self, value):
         """

--- a/cla_backend/apps/legalaid/tests/views/mixins/personal_details_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/personal_details_api.py
@@ -110,7 +110,23 @@ class PersonalDetailsAPIMixin(NestedSimpleResourceAPIMixin):
         data = self._get_default_post_data()
         check = make_recipe("legalaid.personal_details", **data)
 
+        data["dob"] = {"year": 1988, "month": 10, "day": 10}
         response = self._create(data=data)
+        try:
+            year, month, day = (
+                int(response.data["dob"]["year"]),
+                int(response.data["dob"]["month"]),
+                int(response.data["dob"]["day"]),
+            )
+        except TypeError:
+            self.fail("Date of birth doesn't have year, month or day")
+        except ValueError:
+            self.fail("Date of birth year, month and day need to be integers")
+
+        self.assertEquals(year, data["dob"]["year"])
+        self.assertEquals(month, data["dob"]["month"])
+        self.assertEquals(day, data["dob"]["day"])
+
         # check initial state is correct
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
## What does this pull request do?

Date of birth field can be sent as a dict. This undos changes that are only expecting a JSON string only.
Added tests for date of birth parsing

## Any other changes that would benefit highlighting?
The previous deployment was rolled back because the date of birth field was not being parsed correctly due to the code changes only expecting a string. This fix puts back the dict parsing that was there previously
