### PR TITLE
Add a test and new code EXEM to the contract_2018_determination_codes

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -691,6 +691,16 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         self._test_generated_2018_contract_row_validates(override=test_values)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_exem_determination_code_is_valid(self):
+        test_values = {
+            "Matter Type 1": u"EPRO",
+            "Matter Type 2": u"ESOS",
+            "Stage Reached": u"EA",
+            "Determination": u"EXEM",
+        }
+        self._test_generated_2018_contract_row_validates(override=test_values)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
     def test_validator_housing_outcome_code_haa_is_valid(self):
         test_values = {
             "Matter Type 1": u"HRNT",

--- a/cla_backend/apps/legalaid/utils/csvupload/contracts.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/contracts.py
@@ -12,7 +12,7 @@ CONTRACT_THIRTEEN_END_DATE = datetime(year=2018, month=9, day=1)
 CONTRACT_EIGHTEEN_START_DATE = CONTRACT_THIRTEEN_END_DATE
 
 contract_2013_determination_codes = {u"OOSC", u"OSPF", u"CHNM", u"FINI", u"DVCA"}
-contract_2018_determination_codes = copy(contract_2013_determination_codes) | {"FAFA"}
+contract_2018_determination_codes = copy(contract_2013_determination_codes) | {"FAFA", "EXEM"}
 
 debt_category_spec = {
     "OUTCOME_CODES": {u"DA", u"DC", u"DD", u"DG", u"DH", u"DI", u"DU", u"DV", u"DW", u"DX", u"DY", u"DZ"},


### PR DESCRIPTION
## What does this pull request do?
[New determination code EXEM](https://dsdmoj.atlassian.net/browse/LGA-179)
This pull request creates a new determination code, EXEM and places it inside the 2018 category spec so that means that it will only be updated when the 2018 contract is put in motion.

## Any other changes that would benefit highlighting?

Intentionally left blank.
