### PR TITLE
LGA-263 Validate determination code present with DF fixed fee code

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -921,6 +921,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"HA",
             "Fixed Fee Code": u"DF",
             "Fixed Fee Amount": u"130",
+            "Determination": u"CHNM",
         }
         self._test_generated_contract_row_validates(override=test_values)
 
@@ -995,6 +996,28 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
                 u"please review the eligibility code.".format(eligibility_code)
             )
             self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_df_fixed_fee_has_determination_code(self):
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Fixed Fee Code": u"DF",
+            "Determination": u"FINI",
+        }
+        self._test_generated_contract_row_validates(override=test_values)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_df_fixed_fee_missing_determination_code(self):
+        test_values = {
+            "Eligibility Code": u"V",
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Code": u"DF",
+        }
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with Determination Code entered"
+        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
 
 class DependsOnDecoratorTestCase(unittest.TestCase):

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -546,6 +546,15 @@ class ProviderCSVValidator(object):
         if determination == u"DVCA" and category != u"family":
             raise serializers.ValidationError("Category (%s) must be Family if Determination is DVCA" % category)
 
+    @staticmethod
+    def _validate_determination_fixed_fee_has_determination_code(cleaned_data):
+        fixed_fee_code_is_df = cleaned_data.get("Fixed Fee Code") == "DF"
+        determination_code_unspecified = not cleaned_data.get("Determination")
+        if fixed_fee_code_is_df and determination_code_unspecified:
+            raise serializers.ValidationError(
+                "The Fixed Fee code you have entered is not valid with Determination Code entered"
+            )
+
     def _validate_fee_code_is_na(self, cleaned_data):
         if cleaned_data.get("Fixed Fee Code") != "NA":
             raise serializers.ValidationError(
@@ -625,6 +634,7 @@ class ProviderCSVValidator(object):
                     self._validate_mt1_fee_codes,
                     self._validate_fee_code_is_not_na,
                     self._validate_eligibility_code_2018,
+                    self._validate_determination_fixed_fee_has_determination_code,
                 ]
             elif applicable_contract in [CONTRACT_THIRTEEN, CONTRACT_EIGHTEEN_DISCRIMINATION]:
                 return [self._validate_fee_code_is_na, self._validate_eligibility_code_2013]


### PR DESCRIPTION
## What does this pull request do?

- Validate that Determination Fee (DF) fixed fee codes only claimed on cases with a determination code.

## Any other changes that would benefit highlighting?

Intentionally left blank.