### PR TITLE
LGA-265 LGA-266 Validate HF and LF fixed fee codes

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -853,7 +853,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"DB",
             "Fixed Fee Amount": u"65",
             "Fixed Fee Code": u"LF",
-            "Time Spent": u"66",
+            "Time Spent": u"132",
         }
         self._test_generated_contract_row_validates(override=test_values)
 
@@ -867,11 +867,11 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"LF",
             "Time Spent": u"133",
         }
-        expected_error = u"Row: 1 - Time spent must be less than 133 minutes for LF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
-    def test_validator_higher_fixed_fee_time_spent(self):
+    def test_validator_higher_fixed_fee_time_spent_bounds(self):
         test_values = {
             "Eligibility Code": u"V",
             "Matter Type 1": u"DMAP",
@@ -879,9 +879,12 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"DB",
             "Fixed Fee Amount": u"130",
             "Fixed Fee Code": u"HF",
-            "Time Spent": u"144",
         }
-        self._test_generated_contract_row_validates(override=test_values)
+        lower_bound = "133"
+        upper_bound = "899"
+        for time_spent in [lower_bound, upper_bound]:
+            test_values["Time Spent"] = time_spent
+            self._test_generated_contract_row_validates(override=test_values)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
     def test_validator_higher_fixed_fee_excess_time_spent(self):
@@ -894,8 +897,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"HF",
             "Time Spent": u"900",
         }
-        # TODO Clarify spec: are LF and HF both inclusive of 133?
-        expected_error = u"Row: 1 - Time spent must be >=133 and <900 minutes for HF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
@@ -909,7 +911,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"HF",
             "Time Spent": u"132",
         }
-        expected_error = u"Row: 1 - Time spent must be >=133 and <900 minutes for HF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -576,25 +576,23 @@ class ProviderCSVValidator(object):
             )
 
     def _validate_lower_fixed_fee_time_spent(self, cleaned_data):
-        MAX_TIME_ALLOWED = 133
+        MAX_TIME_ALLOWED = 132
         time_spent_in_minutes = cleaned_data.get("Time Spent", 0)
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
-        if fixed_fee_code == u"LF" and time_spent_in_minutes >= MAX_TIME_ALLOWED:
+        if fixed_fee_code == u"LF" and time_spent_in_minutes > MAX_TIME_ALLOWED:
             raise serializers.ValidationError(
-                "Time spent must be less than {} minutes for LF fixed fee code".format(MAX_TIME_ALLOWED)
+                "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
     def _validate_higher_fixed_fee_time_spent(self, cleaned_data):
         MIN_TIME_ALLOWED = 133
-        MAX_TIME_ALLOWED = 900
+        MAX_TIME_ALLOWED = 899
         time_spent_in_minutes = cleaned_data.get("Time Spent", 0)
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
-        time_spent_in_bounds = MIN_TIME_ALLOWED <= time_spent_in_minutes < MAX_TIME_ALLOWED
+        time_spent_in_bounds = MIN_TIME_ALLOWED <= time_spent_in_minutes <= MAX_TIME_ALLOWED
         if fixed_fee_code == u"HF" and not time_spent_in_bounds:
             raise serializers.ValidationError(
-                "Time spent must be >={} and <{} minutes for HF fixed fee code".format(
-                    MIN_TIME_ALLOWED, MAX_TIME_ALLOWED
-                )
+                "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
     @staticmethod


### PR DESCRIPTION
## What does this pull request do?

- Validates HF (higher fee) and LF (lower fee) fixed fee codes are used in conjunction with the correct amount of time spent
- Validation was introduced previously alongside the HF and LF codes in previous work. This branch updates validation messages, tweaks the time spent boundaries after clarification from the business, and adjusts tests

## Any other changes that would benefit highlighting?

Intentionally left blank.
