### PR TITLE
LGA-264, LGA-267, LGA-269 HF, HR, HM fixed fee validation

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -994,8 +994,39 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         for eligibility_code in lf_eligibility_codes:
             test_values["Eligibility Code"] = eligibility_code
             expected_error = (
-                u"Row: 1 - The eligibility code {} you have entered is not valid with the Fixed Fee HF, "
-                u"please review the eligibility code.".format(eligibility_code)
+                u"Row: 1 - The Fixed Fee code you have entered is not valid with the Eligibility Code entered"
+            )
+            self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_eligibility_codes_with_hf_fixed_fee(self):
+        hf_eligibility_codes = {u"T", u"V"}
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Code": u"HF",
+            "Time Spent": u"133",
+        }
+        for eligibility_code in hf_eligibility_codes:
+            test_values["Eligibility Code"] = eligibility_code
+            self._test_generated_contract_row_validates(override=test_values)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_eligibility_codes_missing_hf_fixed_fee(self):
+        lf_eligibility_codes = {u"S", u"W", u"X", u"Z"}
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Amount": u"65",
+            "Fixed Fee Code": u"HF",
+            "Time Spent": u"133",
+        }
+        for eligibility_code in lf_eligibility_codes:
+            test_values["Eligibility Code"] = eligibility_code
+            expected_error = (
+                u"Row: 1 - The Fixed Fee code you have entered is not valid with the Eligibility Code entered"
             )
             self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 

--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -968,6 +968,20 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         self._test_generated_contract_row_validates(override=test_values)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_hwfm_rate_fixed_fee_mt1_incorrect(self):
+        test_values = {
+            "Eligibility Code": u"V",
+            "Matter Type 1": u"FAMZ",
+            "Matter Type 2": u"FMEC",
+            "Fixed Fee Amount": u"119.6",
+            "Fixed Fee Code": u"HM",
+        }
+        expected_error = (
+            u"Row: 1 - The Fixed Fee code you have entered is not valid with the Matter Type 1 Code entered"
+        )
+        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
     def test_validator_mt1_fixed_fee_code_mismatch(self):
         test_values = {
             "Matter Type 1": u"FAMY",

--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -853,7 +853,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"DB",
             "Fixed Fee Amount": u"65",
             "Fixed Fee Code": u"LF",
-            "Time Spent": u"66",
+            "Time Spent": u"132",
         }
         self._test_generated_contract_row_validates(override=test_values)
 
@@ -867,11 +867,11 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"LF",
             "Time Spent": u"133",
         }
-        expected_error = u"Row: 1 - Time spent must be less than 133 minutes for LF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
-    def test_validator_higher_fixed_fee_time_spent(self):
+    def test_validator_higher_fixed_fee_time_spent_bounds(self):
         test_values = {
             "Eligibility Code": u"V",
             "Matter Type 1": u"DMAP",
@@ -879,9 +879,12 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"DB",
             "Fixed Fee Amount": u"130",
             "Fixed Fee Code": u"HF",
-            "Time Spent": u"144",
         }
-        self._test_generated_contract_row_validates(override=test_values)
+        lower_bound = "133"
+        upper_bound = "899"
+        for time_spent in [lower_bound, upper_bound]:
+            test_values["Time Spent"] = time_spent
+            self._test_generated_contract_row_validates(override=test_values)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
     def test_validator_higher_fixed_fee_excess_time_spent(self):
@@ -894,8 +897,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"HF",
             "Time Spent": u"900",
         }
-        # TODO Clarify spec: are LF and HF both inclusive of 133?
-        expected_error = u"Row: 1 - Time spent must be >=133 and <900 minutes for HF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
@@ -909,7 +911,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"HF",
             "Time Spent": u"132",
         }
-        expected_error = u"Row: 1 - Time spent must be >=133 and <900 minutes for HF fixed fee code"
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)

--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -915,6 +915,29 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_hourly_rate_fixed_fee_time_spent(self):
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Code": u"HR",
+            "Time Spent": u"900",
+        }
+        self._test_generated_contract_row_validates(override=test_values)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_hourly_rate_fixed_fee_insufficient_time_spent(self):
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Code": u"HR",
+            "Time Spent": u"899",
+        }
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid with time spent on the case"
+        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
     def test_fixed_fee_code_df_is_valid(self):
         test_values = {
             "Eligibility Code": u"V",
@@ -964,6 +987,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Stage Reached": u"DB",
             "Fixed Fee Amount": u"119.6",
             "Fixed Fee Code": u"HR",
+            "Time Spent": u"900",
         }
         self._test_generated_contract_row_validates(override=test_values)
 

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -595,6 +595,15 @@ class ProviderCSVValidator(object):
                 "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
+    def _validate_hourly_rate_fixed_fee_time_spent(self, cleaned_data):
+        MIN_TIME_ALLOWED = 900
+        time_spent_in_minutes = cleaned_data.get("Time Spent", 0)
+        fixed_fee_code = cleaned_data.get("Fixed Fee Code")
+        if fixed_fee_code == u"HR" and time_spent_in_minutes < MIN_TIME_ALLOWED:
+            raise serializers.ValidationError(
+                "The Fixed Fee code you have entered is not valid with time spent on the case"
+            )
+
     @staticmethod
     def _validate_mt1_fee_codes(cleaned_data):
         mt1_fee_code_mapping = {u"MSCB": u"MR", u"FAMY": u"HM"}
@@ -652,6 +661,7 @@ class ProviderCSVValidator(object):
                     self._validate_fixed_fee_amount_present,
                     self._validate_lower_fixed_fee_time_spent,
                     self._validate_higher_fixed_fee_time_spent,
+                    self._validate_hourly_rate_fixed_fee_time_spent,
                     self._validate_mt1_fee_codes,
                     self._validate_fee_code_is_not_na,
                     self._validate_eligibility_code_2018,

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -612,11 +612,13 @@ class ProviderCSVValidator(object):
         code = cleaned_data.get("Eligibility Code")
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
         validate_present(code, message="Eligibility Code field is required because no determination was specified")
-        if code in {u"S", u"W", u"X", u"Z"} and fixed_fee_code != u"LF":
+        if fixed_fee_code == u"LF" and code not in {u"S", u"W", u"X", u"Z"}:
             raise serializers.ValidationError(
-                u"The eligibility code {} you have entered is not valid with "
-                u"the Fixed Fee {}, please review the "
-                u"eligibility code.".format(code, fixed_fee_code)
+                u"The Fixed Fee code you have entered is not valid with the Eligibility Code entered"
+            )
+        if fixed_fee_code == u"HF" and code not in {u"T", u"V"}:
+            raise serializers.ValidationError(
+                u"The Fixed Fee code you have entered is not valid with the Eligibility Code entered"
             )
 
     @staticmethod

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -576,25 +576,23 @@ class ProviderCSVValidator(object):
             )
 
     def _validate_lower_fixed_fee_time_spent(self, cleaned_data):
-        MAX_TIME_ALLOWED = 133
+        MAX_TIME_ALLOWED = 132
         time_spent_in_minutes = cleaned_data.get("Time Spent", 0)
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
-        if fixed_fee_code == u"LF" and time_spent_in_minutes >= MAX_TIME_ALLOWED:
+        if fixed_fee_code == u"LF" and time_spent_in_minutes > MAX_TIME_ALLOWED:
             raise serializers.ValidationError(
-                "Time spent must be less than {} minutes for LF fixed fee code".format(MAX_TIME_ALLOWED)
+                "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
     def _validate_higher_fixed_fee_time_spent(self, cleaned_data):
         MIN_TIME_ALLOWED = 133
-        MAX_TIME_ALLOWED = 900
+        MAX_TIME_ALLOWED = 899
         time_spent_in_minutes = cleaned_data.get("Time Spent", 0)
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
-        time_spent_in_bounds = MIN_TIME_ALLOWED <= time_spent_in_minutes < MAX_TIME_ALLOWED
+        time_spent_in_bounds = MIN_TIME_ALLOWED <= time_spent_in_minutes <= MAX_TIME_ALLOWED
         if fixed_fee_code == u"HF" and not time_spent_in_bounds:
             raise serializers.ValidationError(
-                "Time spent must be >={} and <{} minutes for HF fixed fee code".format(
-                    MIN_TIME_ALLOWED, MAX_TIME_ALLOWED
-                )
+                "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
     @staticmethod

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -604,6 +604,14 @@ class ProviderCSVValidator(object):
                 "The Fixed Fee code you have entered is not valid with time spent on the case"
             )
 
+    def _validate_hwfm_fixed_fee_mt1_code(self, cleaned_data):
+        fixed_fee_code_is_hm = cleaned_data.get("Fixed Fee Code") == u"HM"
+        mt1_is_famy = cleaned_data.get("Matter Type 1") == u"FAMY"
+        if fixed_fee_code_is_hm and not mt1_is_famy:
+            raise serializers.ValidationError(
+                "The Fixed Fee code you have entered is not valid with the Matter Type 1 Code entered"
+            )
+
     @staticmethod
     def _validate_mt1_fee_codes(cleaned_data):
         mt1_fee_code_mapping = {u"MSCB": u"MR", u"FAMY": u"HM"}
@@ -662,6 +670,7 @@ class ProviderCSVValidator(object):
                     self._validate_lower_fixed_fee_time_spent,
                     self._validate_higher_fixed_fee_time_spent,
                     self._validate_hourly_rate_fixed_fee_time_spent,
+                    self._validate_hwfm_fixed_fee_mt1_code,
                     self._validate_mt1_fee_codes,
                     self._validate_fee_code_is_not_na,
                     self._validate_eligibility_code_2018,


### PR DESCRIPTION
## What does this pull request do?

Adds further validation for `HF`, `HR`, and `HM` fixed fee codes:
- That the correct eligibility codes are use with `HF`
- That time spent is >= 900 for `HR`
- That Matter Type 1 is `FAMY` for `HM`

## Any other changes that would benefit highlighting?

Intentionally left blank.