### PR TITLE
LGA-386 Improve outcome code validation message

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -823,6 +823,17 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         self._test_generated_contract_row_validates(override=test_values)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_invalid_outcome_code(self):
+        test_values = {
+            "Matter Type 1": u"EPRO",
+            "Matter Type 2": u"ESOS",
+            "Stage Reached": u"EA",
+            "Outcome Code": u"INVALID",
+        }
+        expected_error = u"Row: 1 - You have not selected a valid Outcome Code."
+        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
     def test_validator_fixed_fee_amount_present(self):
         test_values = {
             "Matter Type 1": u"DMAP",

--- a/cla_backend/apps/legalaid/utils/csvupload/contracts.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/contracts.py
@@ -259,10 +259,9 @@ contract_2013_category_spec = {
     u"welfare": deepcopy(welfare_category_spec),
 }
 
-# TODO Implement contract 2018 changes here
 discrimination_category_spec["OUTCOME_CODES"].update({u"QAA"})
 family_category_spec["OUTCOME_CODES"].update({u"FAA", u"FAB", u"FAC"})
-housing_category_spec["OUTCOME_CODES"].update({u"HAA", u"HAC", u"HAB"})
+housing_category_spec["OUTCOME_CODES"].update({u"HAA", u"HAB", u"HAC"})
 debt_category_spec["OUTCOME_CODES"].update({u"DAA"})
 education_category_spec["OUTCOME_CODES"].update({u"EAA"})
 

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -324,7 +324,7 @@ validators.update(
         "Matter Type 1": [validate_present, validate_in(get_valid_matter_type1(CONTRACT_EIGHTEEN))],
         "Matter Type 2": [validate_present, validate_in(get_valid_matter_type2(CONTRACT_EIGHTEEN))],
         "Stage Reached": [validate_in(get_valid_stage_reached(CONTRACT_EIGHTEEN))],
-        "Outcome Code": [validate_in(get_valid_outcomes(CONTRACT_EIGHTEEN))],
+        "Outcome Code": [],
         "Determination": [validate_in(get_determination_codes(CONTRACT_EIGHTEEN))],
         "Fixed Fee Amount": [],
         "Fixed Fee Code": [validate_in(contract_2018_fixed_fee_codes)],
@@ -465,6 +465,12 @@ class ProviderCSVValidator(object):
                 u"the time spent (%s) on this case, please review the "
                 u"eligibility code." % (code, time_spent)
             )
+
+    @staticmethod
+    def _validate_outcome_code(cleaned_data):
+        outcome_code = cleaned_data.get("Outcome Code")
+        if outcome_code and outcome_code not in get_valid_outcomes(CONTRACT_EIGHTEEN):
+            raise serializers.ValidationError("You have not selected a valid Outcome Code.")
 
     @staticmethod
     def _validate_category_consistency(cleaned_data):
@@ -666,6 +672,7 @@ class ProviderCSVValidator(object):
         if settings.CONTRACT_2018_ENABLED:
             if applicable_contract == CONTRACT_EIGHTEEN:
                 return [
+                    self._validate_outcome_code,
                     self._validate_fixed_fee_amount_present,
                     self._validate_lower_fixed_fee_time_spent,
                     self._validate_higher_fixed_fee_time_spent,


### PR DESCRIPTION
## What does this pull request do?

Improve message for invalid outcome codes

## Any other changes that would benefit highlighting?

Validation was already in place but returned unreadable error message, so has been replaced with this new method.
