### PR TITLE
LGA-438 Add pip check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,11 @@ jobs:
           command: |
             source env/bin/activate
             pip install --requirement requirements.txt --requirement requirements/testing.txt
+      - run:
+          name: Check dependencies compatibility
+          command: |
+            source env/bin/activate
+            pip check
       - save_cache:
           key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,6 @@ jobs:
           command: |
             source env/bin/activate
             pip install --requirement requirements.txt --requirement requirements/testing.txt
-      - run:
-          name: Check dependencies compatibility
-          command: |
-            source env/bin/activate
             pip check
       - save_cache:
           key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}


### PR DESCRIPTION
## What does this pull request do?

Add `pip check` to CI test job to verify dependency compatibility.

## Any other changes that would benefit highlighting?

This will remain un-mergeable until Django 1.8 upgrade resolves django-moj-irat 0.3 incompatibility.

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
