### PR TITLE
LGA-492 Fixed fee amount validation rule zero amount allowed

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -971,7 +971,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Code": u"DF",
             "Determination": u"FINI",
         }
-        valid_amounts = [0.50, 10, 20.50, 40]
+        valid_amounts = [0, 0.50, 10, 20.50, 40]
         for amount in valid_amounts:
             test_values["Fixed Fee Amount"] = u"{}".format(amount)
             self._test_generated_contract_row_validates(override=test_values)
@@ -991,20 +991,6 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             test_values["Fixed Fee Amount"] = u"{}".format(amount)
             expected_error = u"Row: 1 - The value you have entered exceeds the Fixed Fee"
             self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
-
-    @override_settings(CONTRACT_2018_ENABLED=True)
-    def test_df_fixed_fee_zero_amount_as_missing(self):
-        test_values = {
-            "Eligibility Code": u"V",
-            "Matter Type 1": u"HRNT",
-            "Matter Type 2": u"HPRI",
-            "Stage Reached": u"HA",
-            "Fixed Fee Code": u"DF",
-            "Fixed Fee Amount": u"0",
-            "Determination": u"FINI",
-        }
-        expected_error = u"Row: 1 - Fixed Fee Amount must be entered for Fixed Fee Code (DF)"
-        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
     def test_df_fixed_fee_negative_amount_fails(self):

--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -647,7 +647,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         gte_0 = v.validate_gte(0)
 
         self.assertEqual(1, gte_0(1))
-        with self.assertRaisesRegexp(serializers.ValidationError, ".*must be > 0"):
+        with self.assertRaisesRegexp(serializers.ValidationError, ".*must be >= 0"):
             gte_0(-1)
 
     def test_validate_not_current_month(self):
@@ -1003,7 +1003,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Fixed Fee Amount": u"-1",
             "Determination": u"FINI",
         }
-        expected_error = u"Row: 1 Field (20 / T): Fixed Fee Amount - Field must be > 0"
+        expected_error = u"Row: 1 Field (20 / T): Fixed Fee Amount - Field must be >= 0"
         self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     # TODO enable when Matter Type 1 MSCB added

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -576,7 +576,9 @@ class ProviderCSVValidator(object):
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
         fixed_fee_codes = contract_2018_fixed_fee_codes.copy()
         fixed_fee_codes.remove("NA")
-        if fixed_fee_code in fixed_fee_codes and not cleaned_data.get("Fixed Fee Amount"):
+        fixed_fee_amount = cleaned_data.get("Fixed Fee Amount")
+        fixed_fee_amount_present_or_zero = fixed_fee_amount or fixed_fee_amount == 0
+        if fixed_fee_code in fixed_fee_codes and not fixed_fee_amount_present_or_zero:
             raise serializers.ValidationError(
                 "Fixed Fee Amount must be entered for Fixed Fee Code ({})".format(fixed_fee_code)
             )

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -65,7 +65,7 @@ def validate_gte(minimum):
 
     def _validate_gte(val):
         if val and (val < minimum):
-            raise serializers.ValidationError("Field must be > %s" % minimum)
+            raise serializers.ValidationError("Field must be >= %s" % minimum)
         return val
 
     return _validate_gte


### PR DESCRIPTION
## What does this pull request do?

Amend PR #556 to allow `0` as a valid Fixed Fee Amount.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [X] Provided JIRA ticket number in the title