### PR TITLE
LGA-568 Allow same day consecutive outcome codes with differing notes

### DIFF
--- a/cla_backend/apps/cla_eventlog/models.py
+++ b/cla_backend/apps/cla_eventlog/models.py
@@ -56,7 +56,9 @@ class Log(TimeStampedModel):
         except Log.DoesNotExist:
             logger.debug("LGA-125 No outcome codes exist for case today")
         else:
-            return latest_outcome_code_today.code == self.code
+            codes_match = latest_outcome_code_today.code == self.code
+            notes_match = latest_outcome_code_today.notes == self.notes
+            return codes_match and notes_match
         return False
 
     def save(self, *args, **kwargs):

--- a/cla_backend/apps/cla_eventlog/tests/test_events.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_events.py
@@ -1,20 +1,17 @@
-from django.test import TestCase
-
-from core.tests.mommy_utils import make_recipe, make_user
-
-from timer.models import Timer
 from datetime import timedelta
 
-from legalaid.models import Case
 from cla_common.constants import REQUIRES_ACTION_BY
+from django.test import TestCase
 from django.utils.timezone import now
 
 from cla_eventlog import event_registry
 from cla_eventlog.constants import LOG_TYPES, LOG_ROLES, LOG_LEVELS
-from cla_eventlog.models import Log
 from cla_eventlog.events import BaseEvent
-
+from cla_eventlog.models import Log
 from cla_eventlog.tests.base import EventTestCaseMixin
+from core.tests.mommy_utils import make_recipe, make_user
+from legalaid.models import Case
+from timer.models import Timer
 
 
 class TestEvent(BaseEvent):

--- a/cla_backend/apps/cla_eventlog/tests/test_events.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_events.py
@@ -3,9 +3,11 @@ from django.test import TestCase
 from core.tests.mommy_utils import make_recipe, make_user
 
 from timer.models import Timer
+from datetime import timedelta
 
 from legalaid.models import Case
 from cla_common.constants import REQUIRES_ACTION_BY
+from django.utils.timezone import now
 
 from cla_eventlog import event_registry
 from cla_eventlog.constants import LOG_TYPES, LOG_ROLES, LOG_LEVELS
@@ -223,6 +225,42 @@ class BaseEventTestCase(TestCase):
         case = Case.objects.get(pk=self.dummy_case.pk)
 
         self.assertEqual(case.requires_action_by, None)
+
+
+class ConsecutiveOutcomeCodesTestCase(TestCase):
+    def setUp(self):
+        super(ConsecutiveOutcomeCodesTestCase, self).setUp()
+        self.dummy_case = make_recipe("legalaid.case")
+        self.dummy_user = make_user()
+        self.log_attributes = dict(
+            case=self.dummy_case, code="FOO", type=LOG_TYPES.OUTCOME, level=LOG_LEVELS.HIGH, created_by=self.dummy_user
+        )
+
+    def test_same_day_consecutive_outcome_code_not_allowed(self):
+        l1 = Log(**self.log_attributes)
+        l1.save()
+        self.assertIsNotNone(l1.pk)
+        l2 = Log(**self.log_attributes)
+        l2.save()
+        self.assertIsNone(l2.pk)
+
+    def test_next_day_consecutive_outcome_code_allowed(self):
+        yesterday = now() - timedelta(days=1)
+        l1 = Log(**self.log_attributes)
+        l1.save()
+        self.assertIsNotNone(l1.pk)
+        Log.objects.filter(pk=l1.pk).update(created=yesterday)
+        l2 = Log(**self.log_attributes)
+        l2.save()
+        self.assertIsNotNone(l2.pk)
+
+    def test_same_day_consecutive_outcome_code_allowed_with_notes(self):
+        l1 = Log(**self.log_attributes)
+        l1.save()
+        self.assertIsNotNone(l1.pk)
+        l2 = Log(notes="foo", **self.log_attributes)
+        l2.save()
+        self.assertIsNotNone(l2.pk)
 
 
 class SelectableEventsTestCase(EventTestCaseMixin, TestCase):

--- a/cla_backend/apps/cla_eventlog/tests/test_events.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_events.py
@@ -267,6 +267,13 @@ class ConsecutiveOutcomeCodesTestCase(TestCase):
         l2.save()
         self.assertIsNotNone(l2.pk)
 
+    def test_same_day_non_consecutive_outcome_codes_allowed(self):
+        for code in ["FOO", "BAR", "FOO"]:
+            self.log_attributes["code"] = code
+            log = Log(**self.log_attributes)
+            log.save()
+            self.assertIsNotNone(log.pk)
+
 
 class SelectableEventsTestCase(EventTestCaseMixin, TestCase):
     def test_select_selectable_code(self):

--- a/cla_backend/apps/cla_eventlog/tests/test_events.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_events.py
@@ -241,6 +241,14 @@ class ConsecutiveOutcomeCodesTestCase(TestCase):
         l2.save()
         self.assertIsNone(l2.pk)
 
+    def test_same_day_consecutive_outcome_code_with_matching_notes_not_allowed(self):
+        l1 = Log(notes="foo", **self.log_attributes)
+        l1.save()
+        self.assertIsNotNone(l1.pk)
+        l2 = Log(notes="foo", **self.log_attributes)
+        l2.save()
+        self.assertIsNone(l2.pk)
+
     def test_next_day_consecutive_outcome_code_allowed(self):
         yesterday = now() - timedelta(days=1)
         l1 = Log(**self.log_attributes)


### PR DESCRIPTION
## What does this pull request do?

- Allow same day consecutive outcome codes if notes field differs
- Add ConsecutiveOutcomeCodesTestCase

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [X] Provided JIRA ticket number in the title