### PR TITLE
LGA-618 - Fix 2018 Discrimination Contracts not applying

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -11,6 +11,11 @@ from rest_framework import serializers
 from rest_framework.test import APITestCase
 
 import legalaid.utils.csvupload.validators as v
+from legalaid.utils.csvupload.contracts import (
+    CONTRACT_EIGHTEEN_DISCRIMINATION,
+    contract_2018_category_spec,
+    get_applicable_contract,
+)
 from cla_provider.models import Staff
 from core.tests.mommy_utils import make_recipe
 from core.tests.test_base import SimpleResourceAPIMixin
@@ -389,6 +394,12 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
         validator = self.get_provider_csv_validator()
         self.assertEqual(len(validator.validate()), 2)
 
+    @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_validator_is_2018_discrimination(self):
+        for matter_type in contract_2018_category_spec["discrimination"]["MATTER_TYPE1"]:
+            if get_applicable_contract(datetime.datetime(2019, 9, 1), matter_type) != CONTRACT_EIGHTEEN_DISCRIMINATION:
+                self.fail("Applicable contract is not 2018 discrimination contract")
+
     def test_invalid_field_count(self):
         validator = self.get_provider_csv_validator([[], []])
         with self.assertRaisesRegexp(serializers.ValidationError, r"Row: 1 - Incorrect number of columns"):
@@ -759,6 +770,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             "Matter Type 2": u"QAGE",
             "Stage Reached": u"QA",
             "Outcome Code": u"QAA",
+            "Fixed Fee Code": u"NA",
         }
         self._test_generated_contract_row_validates(override=test_values)
 

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -365,11 +365,19 @@ class ProviderCSVValidator(object):
         )
         return field_order.index("Date Opened")
 
+    @staticmethod
+    def get_matter_type1_index():
+        field_order = (
+            new_field_order_when_contract_2018_enabled if settings.CONTRACT_2018_ENABLED else original_field_order
+        )
+        return field_order.index("Matter Type 1")
+
     def _get_applicable_contract_for_row(self, row):
         try:
             case_date_opened_string = row[self.get_date_opened_index()]
             case_date_opened = validate_date(case_date_opened_string)
-            return get_applicable_contract(case_date_opened=case_date_opened)  # TODO pass Matter Type 1
+            matter_type1 = row[self.get_matter_type1_index()]
+            return get_applicable_contract(case_date_opened=case_date_opened, case_matter_type_1=matter_type1)
         except IndexError:
             logger.warning("Could not get applicable contract for row, defaulting to 2013. \nRow: {}".format(row))
             return CONTRACT_THIRTEEN
@@ -380,7 +388,7 @@ class ProviderCSVValidator(object):
             if settings.CONTRACT_2018_ENABLED:
                 return contract_2013_validators_for_new_field_order
             return contract_2013_validators_for_original_field_order
-        elif applicable_contract == CONTRACT_EIGHTEEN:
+        elif applicable_contract in [CONTRACT_EIGHTEEN, CONTRACT_EIGHTEEN_DISCRIMINATION]:
             return contract_2018_validators_for_new_field_order
 
     def _validate_fields(self):


### PR DESCRIPTION
## What does this pull request do?

Fixes the issue with 2018 Discrimination Contracts not validating due to the matter_type1 field not being provided.

## Any other changes that would benefit highlighting?

2018 Discrimination rows can have NA as the value for the fixed fee code. These were being incorrectly reported as invalid on UAT

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
