### PR TITLE
LGA-609 - Add test for error message for NA fix fee code

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -1148,6 +1148,18 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
             self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
 
     @override_settings(CONTRACT_2018_ENABLED=True)
+    def test_fixed_fee_invalid_error_message(self):
+        test_values = {
+            "Matter Type 1": u"DTOT",
+            "Matter Type 2": u"DOTH",
+            "Stage Reached": u"DB",
+            "Fixed Fee Code": u"NA",
+            "Time Spent": u"133",
+        }
+        expected_error = u"Row: 1 - The Fixed Fee code you have entered is not valid for this case"
+        self._test_generated_2018_contract_row_validate_fails(override=test_values, expected_error=expected_error)
+
+    @override_settings(CONTRACT_2018_ENABLED=True)
     def test_discrimination_fixed_fee_invalid_error_message(self):
         test_values = {
             "Matter Type 1": u"HHOM",


### PR DESCRIPTION
## What does this pull request do?

Added test for error message when NA fix fee code is provided for 2018 cases that are not Discrimination or Education

## Any other changes that would benefit highlighting?

The logic to generate the error message under right conditions already existed but was just missing tests

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
