### PR TITLE
LGA-625 - The eligibility code must be one of the valid codes - S, T, V, W, X, Z

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_csvupload_api.py
@@ -1086,7 +1086,7 @@ class ProviderCSVValidatorTestCase(unittest.TestCase):
 
     @override_settings(CONTRACT_2018_ENABLED=True)
     def test_eligibility_codes_with_lf_fixed_fee(self):
-        lf_eligibility_codes = {u"S", u"W", u"X", u"Z"}
+        lf_eligibility_codes = {u"S", u"T", u"V", u"W", u"X", u"Z"}
         test_values = {
             "Matter Type 1": u"DTOT",
             "Matter Type 2": u"DOTH",

--- a/cla_backend/apps/legalaid/utils/csvupload/validators.py
+++ b/cla_backend/apps/legalaid/utils/csvupload/validators.py
@@ -654,7 +654,7 @@ class ProviderCSVValidator(object):
         code = cleaned_data.get("Eligibility Code")
         fixed_fee_code = cleaned_data.get("Fixed Fee Code")
         validate_present(code, message="Eligibility Code field is required because no determination was specified")
-        if fixed_fee_code == u"LF" and code not in {u"S", u"W", u"X", u"Z"}:
+        if fixed_fee_code == u"LF" and code not in {u"S", u"T", u"V", u"W", u"X", u"Z"}:
             raise serializers.ValidationError(
                 u"The Fixed Fee code you have entered is not valid with the Eligibility Code entered"
             )


### PR DESCRIPTION
## What does this pull request do?

Add T and V Eligibility codes to Low Fee Fixed Fee Code validation
## Any other changes that would benefit highlighting?


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
