### PR TITLE
LGA-586 - Turn on 2018 contract changes by default

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -354,7 +354,7 @@ CELERY_TIMEZONE = "UTC"
 # apps with celery tasks
 CELERY_IMPORTS = ["reports.tasks", "notifications.tasks"]
 
-CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "False") == "True"
+CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "True") == "True"
 PING_JSON_KEYS["CONTRACT_2018_ENABLED_key"] = "CONTRACT_2018_ENABLED"
 
 # .local.py overrides all the common settings.


### PR DESCRIPTION
## What does this pull request do?
Turn on 2018 contract changes by default flag to on.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
