### PR TITLE
Shrink Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ docker-compose.yml
 cla_backend/settings/local.py
 static/
 venv/
+*.pyc
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
       py2-pip \
       supervisor \
       tzdata \
-      uwsgi
+      uwsgi-python
 
 # To install pip dependencies
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN mkdir -p /var/log/nginx/cla_backend /var/log/wsgi /var/run/celery /var/log/c
     touch /var/log/wsgi/app.log /var/log/wsgi/debug.log && \
     chmod -R g+s /var/log/wsgi
 
+RUN adduser -D www-data -G www-data && \
+    chown -R www-data:www-data /var/log/uwsgi /var/log/nginx/cla_backend && \
+    chmod -R g+s /var/log/wsgi
+
 WORKDIR /home/app/django
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,111 +1,47 @@
-#
-# CLA_BACKEND Dockerfile all environments
-#
-# Pull base image.
-FROM phusion/baseimage:0.9.22
+FROM alpine:3.9
 
-# Set correct environment variables.
-ENV HOME /root
+RUN apk add --no-cache \
+      bash \
+      gettext \
+      nginx \
+      py2-pip \
+      supervisor \
+      tzdata \
+      uwsgi
 
-# Use baseimage-docker's init process.
-CMD ["/sbin/my_init"]
+# To install pip dependencies
+RUN apk add --no-cache \
+      build-base \
+      git \
+      libxml2-dev \
+      libxslt-dev \
+      postgresql-dev \
+      python2-dev
 
-# Set timezone
-RUN echo $TZ > /etc/timezone && \
-    apt-get update && apt-get install -y tzdata && \
-    rm /etc/localtime && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata && \
-    apt-get clean
-
-# Remove SSHD
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-
-# Dependencies
-RUN DEBIAN_FRONTEND='noninteractive' \
-  apt-get update && apt-get install -y \
-    apt-utils \
-    bash \
-    build-essential \
-    g++ \
-    git \
-    libpcre3 \
-    libpcre3-dev \
-    libpq-dev \
-    libxslt-dev \
-    libxml2-dev \
-    make \
-    python-dev \
-    python-pip \
-    python-software-properties \
-    software-properties-common && \
-  apt-get -y build-dep \
-    python-psycopg2 && \
-  rm -rf /var/lib/apt/lists/*
-
-# Install Nginx.
-RUN DEBIAN_FRONTEND='noninteractive' add-apt-repository ppa:nginx/stable && apt-get update
-RUN DEBIAN_FRONTEND='noninteractive' apt-get -y install nginx-full && \
-  chown -R www-data:www-data /var/lib/nginx
-
-ADD ./docker/nginx.conf /etc/nginx/nginx.conf
-ADD ./docker/htpassword /etc/nginx/conf.d/htpassword
-RUN rm -f /etc/nginx/sites-enabled/default && \
-    chown www-data:www-data /etc/nginx/conf.d/htpassword
-
-# Pip install Python packages
+RUN cp /usr/share/zoneinfo/Europe/London /etc/localtime
 RUN pip install -U setuptools pip==18.1 wheel
-RUN pip install GitPython uwsgi requests
 
-RUN mkdir -p /var/log/wsgi && \
+ENV APP_HOME /home/app/django
+COPY ./requirements /tmp/requirements
+RUN cd /tmp/requirements && pip install -r production.txt
+
+COPY ./docker/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker/htpassword /etc/nginx/conf.d/htpassword
+COPY ./docker/supervisord-services.ini /etc/supervisor.d/
+
+RUN mkdir -p /var/log/nginx/cla_backend /var/log/wsgi /var/run/celery /var/log/celery && \
     touch /var/log/wsgi/app.log /var/log/wsgi/debug.log && \
-    chown -R www-data:www-data /var/log/wsgi && \
     chmod -R g+s /var/log/wsgi
 
-RUN  mkdir -p /var/log/nginx/cla_backend
-ADD ./docker/cla_backend.ini /etc/wsgi/conf.d/cla_backend.ini
+WORKDIR /home/app/django
+COPY . .
 
-# Define mountable directories.
-VOLUME ["/data", "/var/log/nginx", "/var/log/wsgi"]
-
-# APP_HOME
-ENV APP_HOME /home/app/django
-
-# Add requirements to docker
-ADD ./requirements /tmp/requirements
-
-# PIP INSTALL APPLICATION
-RUN cd /tmp/requirements && pip install -r production.txt && find . -name '*.pyc' -delete
-
-# Add project directory to docker
-ADD . /home/app/django
-
-RUN cd /home/app/django && cat docker/version >> /etc/profile
-
-# PYCLEAN
-RUN cd /home/app/django && find . -name '*.pyc' -delete
-
-# install startup files for runit
-ADD ./docker/migrations.startup /etc/my_init.d/migrations.startup
-
-# install service files for runit
-ADD ./docker/nginx.service /etc/service/nginx/run
-
-# install service files for runit
-ADD ./docker/uwsgi.service /etc/service/uwsgi/run
-
-# install service files for runit
-ADD ./docker/celery.service /etc/service/celery/run
-
-#sym-link to local.py, which overrides all common settings.
 RUN ln -s /home/app/django/cla_backend/settings/docker.py /home/app/django/cla_backend/settings/local.py
 
-# Collect static
-RUN cd /home/app/django && python manage.py collectstatic --noinput
+RUN python manage.py collectstatic --noinput && \
+    python manage.py compilemessages
 
-# Compile messages
-RUN cd /home/app/django && python manage.py compilemessages
-
-# Expose ports.
 EXPOSE 80
 
+ENTRYPOINT ["docker/entrypoint.sh"]
+CMD ["supervisord", "--nodaemon"]

--- a/docker/celery.service
+++ b/docker/celery.service
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-mkdir -p /var/run/celery/
-mkdir -p /var/log/celery/
-
-cd /home/app/django
-export DJANGO_SETTINGS_MODULE=cla_backend.settings
-exec celery -A cla_backend worker -l info -c 1 --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -5,6 +5,7 @@ uid = www-data
 gid = www-data
 chmod-socket = 666
 chown-socket = www-data
+plugins = python
 master = true
 enable-threads = true
 processes = 2

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -1,6 +1,10 @@
 [uwsgi]
 vhost = true
 socket = /tmp/backend.sock
+uid = www-data
+gid = www-data
+chmod-socket = 666
+chown-socket = www-data
 master = true
 enable-threads = true
 processes = 2

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -1,10 +1,6 @@
 [uwsgi]
 vhost = true
 socket = /tmp/backend.sock
-uid = www-data
-gid = www-data
-chmod-socket = 666
-chown-socket = www-data
 master = true
 enable-threads = true
 processes = 2
@@ -13,8 +9,9 @@ env = DJANGO_SETTINGS_MODULE=cla_backend.settings
 module = cla_backend.wsgi:application
 post-buffering = 1
 harakiri = 20
-buffer-size=32768
-post-buffering-bufsize=32768
+buffer-size = 32768
+post-buffering-bufsize = 32768
+
 # Cronjobs moved here inside container for logging compatibility
 # https://github.com/ministryofjustice/cla_backend-deploy/commit/5f81cde78924bbf2dc554b23240c619dcfebd8f2
 cron2=minute=0,hour=5,unique=1 python /home/app/django/manage.py housekeeping

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -42,3 +42,5 @@ sentry_config
 migrations
 admin_password
 load_test_data
+
+exec "$@"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,4 @@
+user www-data;
 worker_processes 4;
 pid /run/nginx.pid;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,4 +1,3 @@
-user www-data;
 worker_processes 4;
 pid /run/nginx.pid;
 
@@ -22,7 +21,6 @@ http {
         client_max_body_size 5M;
 
         server_names_hash_bucket_size 512;
-        # server_name_in_redirect off;
 
         ssl_prefer_server_ciphers on;
         ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
@@ -68,34 +66,6 @@ http {
         gzip on;
         gzip_disable "msie6";
 
-        # gzip_vary on;
-        # gzip_proxied any;
-        # gzip_comp_level 6;
-        # gzip_buffers 16 8k;
-        # gzip_http_version 1.1;
-        # gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
-        ##
-        # nginx-naxsi config
-        ##
-        # Uncomment it if you installed nginx-naxsi
-        ##
-
-        #include /etc/nginx/naxsi_core.rules;
-
-        ##
-        # nginx-passenger config
-        ##
-        # Uncomment it if you installed nginx-passenger
-        ##
-
-        #passenger_root /usr;
-        #passenger_ruby /usr/bin/ruby;
-
-        ##
-        # Virtual Host Configs
-        ##
-
         include /etc/nginx/conf.d/*.conf;
         include /etc/nginx/sites-enabled/*;
 
@@ -104,16 +74,13 @@ server {
     listen 80;
 
     server_name  ~^(.+)$;
-#
+
     gzip                on;
     gzip_proxied        any;
     gzip_types          text/html text/plain text/xml application/xml application/xml+rss application/json application/javascript text/javascript text/css application/font-woff font/otf application/font-otf application/font application/otf application/octet-stream application/x-font-otf;
 
    access_log      /var/log/nginx/cla_backend/access.log logstash_json;
    error_log       /var/log/nginx/cla_backend/error.log error;
-
-#   auth_basic            "private";
-#   auth_basic_user_file  conf.d/htpassword;
 
     location / {
         uwsgi_param   Host                 $host;
@@ -127,25 +94,6 @@ server {
         alias /home/app/django/cla_backend/static/;
     }
 }
-#mail {
-#       # See sample authentication script at:
-#       # http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
-#
-#       # auth_http localhost/auth.php;
-#       # pop3_capabilities "TOP" "USER";
-#       # imap_capabilities "IMAP4rev1" "UIDPLUS";
-#
-#       server {
-#               listen     localhost:110;
-#               protocol   pop3;
-#               proxy      on;
-#       }
-#
-#       server {
-#               listen     localhost:143;
-#               protocol   imap;
-#               proxy      on;
-#       }
-#}
+
 }
 daemon off;

--- a/docker/nginx.service
+++ b/docker/nginx.service
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec /usr/sbin/nginx -c /etc/nginx/nginx.conf

--- a/docker/supervisord-services.ini
+++ b/docker/supervisord-services.ini
@@ -1,10 +1,16 @@
 [program:nginx]
 command=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stderr_logfile=/dev/stderr
 
 [program:uwsgi]
-command=/usr/sbin/uwsgi --ini /home/app/django/docker/cla_backend.ini --die-on-term
+command=/usr/sbin/uwsgi --ini /home/app/django/docker/cla_backend.ini --die-on-term --log-master
+stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stderr_logfile=/dev/stderr
 
 [program:celery]
 command=celery -A cla_backend worker -l info -c 1 --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid
 directory=/home/app/django
 environment=DJANGO_SETTINGS_MODULE="cla_backend.settings"
+stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stderr_logfile=/dev/stderr

--- a/docker/supervisord-services.ini
+++ b/docker/supervisord-services.ini
@@ -1,0 +1,10 @@
+[program:nginx]
+command=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+
+[program:uwsgi]
+command=/usr/sbin/uwsgi --ini /home/app/django/docker/cla_backend.ini --die-on-term
+
+[program:celery]
+command=celery -A cla_backend worker -l info -c 1 --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid
+directory=/home/app/django
+environment=DJANGO_SETTINGS_MODULE="cla_backend.settings"

--- a/docker/uwsgi.service
+++ b/docker/uwsgi.service
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-chown -R www-data:www-data /var/log/wsgi
-exec /usr/local/bin/uwsgi --ini /etc/wsgi/conf.d/cla_backend.ini


### PR DESCRIPTION
## What does this pull request do?

Switches the Docker image to use Alpine Linux and pre-installed nginx and uwsgi, effectively reducing the image size by ~60%.

```
.../laa-get-access/laa-cla-backend    shrink-image.b65eee4           470MB
.../laa-get-access/laa-cla-backend    master                        1.27GB
```

## Todo

- [x] `connect() to unix:////tmp/backend.sock failed (13: Permission denied) while connecting to upstream` from Nginx -- most likely a side-effect of removing the `www-data` user (fixed in c98650bbc71dc53c0d84b1e222beaee89f9409c5)
- [x] can the integration between nginx-uwsgi-celery be tested in this repository, for example by probing ping/healthcheck? (I have a prototype for this but will open a separate pull request for it.)

## Why do these changes?

The current image is 1.27GB in size. This new version that is based on the official Alpine Linux/Python 2.7 image is around ~480MB big.

The reduced image size will

* speed up builds for this repository (5-6 minutes vs the previous 9-10 minutes).
* speed up running the [end-to-end tests](https://github.com/ministryofjustice/laa-cla-e2e-tests)

## Any other changes that would benefit highlighting?

* Since the image replaced the `/sbin/my_init` supervision process, `supervisord` was introduced as a replacement. Consequently, the `*.service` files were replaced with a single `supervisord-services.ini`.
* The migration is now run as part of the entrypoint process, every time the container boots up.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title" **Not applicable.**
