### PR TITLE
LGA-651: Allow users to upload and download files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN mkdir -p /var/log/nginx/cla_backend /var/log/wsgi /var/run/celery /var/log/c
     chmod -R g+s /var/log/wsgi
 
 RUN adduser -D www-data -G www-data && \
-    chown -R www-data:www-data /var/log/uwsgi /var/log/nginx/cla_backend && \
-    chmod -R g+s /var/log/wsgi
+    chown -R www-data:www-data /var/log/uwsgi && chmod -R g+s /var/log/wsgi && \
+    chown -R www-data:www-data /var/tmp/nginx /var/log/nginx /etc/nginx/conf.d/htpassword
 
 WORKDIR /home/app/django
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
       py2-pip \
       supervisor \
       tzdata \
-      uwsgi-python
+      uwsgi-python && \
+    rm /etc/nginx/conf.d/default.conf
 
 # To install pip dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
## What does this pull request do?

Attempts to fix the issue preventing users from uploading and downloading large files.

## Any other changes that would benefit highlighting?

**Explicitly allow www-data access to /var/tmp/nginx**
In Alpine Linux, the default directory by used by nginx is `/var/tmp/nginx`, compared to Ubuntu's `/var/lib/nginx`.

Currently, users cannot upload and download files due to permission issues which are most likely caused by `/var/tmp/nginx` not having correct permissions.

This change was not picked up when I migrated the image from Ubuntu to Alpine and needs amending.

Alternatively, we could run the nginx process as the `nginx` user, but that would need more changes which I would like to defer now.

**Remove default nginx configuration**
There is a default configuration in Alpine which we do not need and can be removed.

**Collapse layers changing permissions for aufs**
Please see details in 15a59a9.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
