### PR TITLE
Add --noinput flag to migrations so that it doesn't hang during deployment

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,7 @@ migrations() {
     if [ "$BACKEND_ENABLED" == "True" ]; then
 
         python manage.py install_postgres_extensions
-        python manage.py migrate
+        python manage.py migrate --noinput
 
         python manage.py loaddata initial_groups.json
         python manage.py loaddata initial_category.json


### PR DESCRIPTION
## What does this pull request do?

Add --noinput flag to migrations so that it doesn't hang during deployment

## Any other changes that would benefit highlighting?

Migrations are run as part of the container entrpoint commans. Without the --noinput flag the migrate command will hang waiting for input, this will cause the deployment to fail as the container does not come up successfully.

## Checklist

- [] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
