### PR TITLE
LGA-691 - Make circleci build job dependant on test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,4 +148,7 @@ workflows:
     jobs:
       - lint
       - test
-      - build
+      - build:
+          requires:
+            - lint
+            - test


### PR DESCRIPTION
## What does this pull request do?

Make circleci build job dependant on test job

## Any other changes that would benefit highlighting?
Currently circleci continues with the build job even when the test job fails, this could lead a accidentally deploying a release with failing tests. This PR ensures tests pass before the build of release image is started.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
