### PR TITLE
LGA-716 - Associate operators with an organisation

### DIFF
--- a/cla_backend/apps/call_centre/admin/__init__.py
+++ b/cla_backend/apps/call_centre/admin/__init__.py
@@ -10,6 +10,10 @@ class OperatorAdmin(OneToOneUserAdmin):
     actions = None
     simple_op_form = OperatorAdminForm
     full_op_form = FullOperatorAdminForm
+
+    def operator_organisation(obj):
+        return obj.organisation if obj.organisation else ""
+
     list_display = (
         "username_display",
         "email_display",
@@ -18,8 +22,10 @@ class OperatorAdmin(OneToOneUserAdmin):
         "is_active_display",
         "is_manager",
         "is_cla_superuser",
+        operator_organisation,
     )
     search_fields = ["user__username", "user__first_name", "user__last_name", "user__email"]
+    list_filter = ["organisation__name"]
 
     def _is_loggedin_superuser(self, request):
         user = request.user

--- a/cla_backend/apps/call_centre/admin/__init__.py
+++ b/cla_backend/apps/call_centre/admin/__init__.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from core.admin.modeladmin import OneToOneUserAdmin
 from .forms import OperatorAdminForm, FullOperatorAdminForm, CaseworkerAdminForm
-from ..models import Operator, Caseworker
+from ..models import Operator, Caseworker, Organisation
 
 
 class OperatorAdmin(OneToOneUserAdmin):
@@ -120,3 +120,4 @@ class CaseworkerAdmin(OneToOneUserAdmin):
 
 admin.site.register(Operator, OperatorAdmin)
 admin.site.register(Caseworker, CaseworkerAdmin)
+admin.site.register(Organisation)

--- a/cla_backend/apps/call_centre/admin/__init__.py
+++ b/cla_backend/apps/call_centre/admin/__init__.py
@@ -13,7 +13,7 @@ class OperatorAdmin(OneToOneUserAdmin):
     full_op_form = FullOperatorAdminForm
 
     def operator_organisation(obj):
-        return obj.organisation if obj.organisation else ""
+        return obj.organisation or ""
 
     list_display = (
         "username_display",

--- a/cla_backend/apps/call_centre/admin/forms.py
+++ b/cla_backend/apps/call_centre/admin/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+
 from core.admin.forms import OneToOneUserAdminForm
 from ..models import Operator, Caseworker
 

--- a/cla_backend/apps/call_centre/admin/forms.py
+++ b/cla_backend/apps/call_centre/admin/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-
 from core.admin.forms import OneToOneUserAdminForm
 from ..models import Operator, Caseworker
 
@@ -7,7 +6,17 @@ from ..models import Operator, Caseworker
 class OperatorAdminForm(OneToOneUserAdminForm):
     class Meta(object):
         model = Operator
-        fields = ["username", "password", "password2", "first_name", "last_name", "email", "is_active", "is_manager"]
+        fields = [
+            "username",
+            "password",
+            "password2",
+            "first_name",
+            "last_name",
+            "email",
+            "is_active",
+            "is_manager",
+            "organisation",
+        ]
 
 
 class CaseworkerAdminForm(OneToOneUserAdminForm):

--- a/cla_backend/apps/call_centre/admin/forms.py
+++ b/cla_backend/apps/call_centre/admin/forms.py
@@ -40,4 +40,5 @@ class FullOperatorAdminForm(OneToOneUserAdminForm):
             "is_active",
             "is_manager",
             "is_cla_superuser",
+            "organisation",
         ]

--- a/cla_backend/apps/call_centre/management/commands/cla_superuser_organisation_perms.py
+++ b/cla_backend/apps/call_centre/management/commands/cla_superuser_organisation_perms.py
@@ -6,14 +6,8 @@ class Command(BaseCommand):
     help = "Assign CLA Superusers 'Can add organisation' and 'Can change organisation' permissions"
 
     def handle(self, *args, **options):
-        group = Group.objects.get(name="CLA Superusers")
-        if not group:
+        groups = Group.objects.filter(name="CLA Superusers")
+        if not groups.exists():
             return
-
-        can_add_organisation_perm = Permission.objects.get(name="Can add organisation")
-        if can_add_organisation_perm:
-            group.permissions.add(can_add_organisation_perm)
-
-        can_change_organisation_perm = Permission.objects.get(name="Can change organisation")
-        if can_change_organisation_perm:
-            group.permissions.add(can_change_organisation_perm)
+        permissions = Permission.objects.filter(name__in=["Can add organisation", "Can change organisation"])
+        groups.first().permissions.add(*permissions)

--- a/cla_backend/apps/call_centre/management/commands/cla_superuser_organisation_perms.py
+++ b/cla_backend/apps/call_centre/management/commands/cla_superuser_organisation_perms.py
@@ -1,0 +1,19 @@
+from django.core.management import BaseCommand
+from django.contrib.auth.models import Group, Permission
+
+
+class Command(BaseCommand):
+    help = "Assign CLA Superusers 'Can add organisation' and 'Can change organisation' permissions"
+
+    def handle(self, *args, **options):
+        group = Group.objects.get(name="CLA Superusers")
+        if not group:
+            return
+
+        can_add_organisation_perm = Permission.objects.get(name="Can add organisation")
+        if can_add_organisation_perm:
+            group.permissions.add(can_add_organisation_perm)
+
+        can_change_organisation_perm = Permission.objects.get(name="Can change organisation")
+        if can_change_organisation_perm:
+            group.permissions.add(can_change_organisation_perm)

--- a/cla_backend/apps/call_centre/management/commands/create_and_assign_agilisys_organisation.py
+++ b/cla_backend/apps/call_centre/management/commands/create_and_assign_agilisys_organisation.py
@@ -1,0 +1,16 @@
+from django.core.management import BaseCommand
+from call_centre.models import Organisation, Operator
+
+
+class Command(BaseCommand):
+    help = "Create Agilisys organisation and assign current agilisys operators to that organisation"
+
+    def handle(self, *args, **options):
+        (organisation, created) = Organisation.objects.get_or_create(name="Agilisys")
+        operators = Operator.objects.filter(organisation__isnull=True, user__email__endswith="@agilisys.co.uk")
+        if not operators.count():
+            self.stdout.write("Could not find Agilisys operators to update")
+        else:
+            self.stdout.write("Updating {count} Agilisys operators...".format(count=operators.count()), ending="")
+            operators.update(organisation=organisation)
+            self.stdout.write("done")

--- a/cla_backend/apps/call_centre/management/commands/create_and_assign_agilisys_organisation.py
+++ b/cla_backend/apps/call_centre/management/commands/create_and_assign_agilisys_organisation.py
@@ -6,11 +6,11 @@ class Command(BaseCommand):
     help = "Create Agilisys organisation and assign current agilisys operators to that organisation"
 
     def handle(self, *args, **options):
-        (organisation, created) = Organisation.objects.get_or_create(name="Agilisys")
+        organisation, created = Organisation.objects.get_or_create(name="Agilisys")
         operators = Operator.objects.filter(organisation__isnull=True, user__email__endswith="@agilisys.co.uk")
-        if not operators.count():
-            self.stdout.write("Could not find Agilisys operators to update")
-        else:
+        if operators.exists():
             self.stdout.write("Updating {count} Agilisys operators...".format(count=operators.count()), ending="")
             operators.update(organisation=organisation)
             self.stdout.write("done")
+        else:
+            self.stdout.write("Could not find Agilisys operators to update")

--- a/cla_backend/apps/call_centre/migrations/0003_auto_20190726_1200.py
+++ b/cla_backend/apps/call_centre/migrations/0003_auto_20190726_1200.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+import model_utils.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("call_centre", "0002_caseworker")]
+
+    operations = [
+        migrations.CreateModel(
+            name="Organisation",
+            fields=[
+                ("id", models.AutoField(verbose_name="ID", serialize=False, auto_created=True, primary_key=True)),
+                (
+                    "created",
+                    model_utils.fields.AutoCreatedField(
+                        default=django.utils.timezone.now, verbose_name="created", editable=False
+                    ),
+                ),
+                (
+                    "modified",
+                    model_utils.fields.AutoLastModifiedField(
+                        default=django.utils.timezone.now, verbose_name="modified", editable=False
+                    ),
+                ),
+                ("name", models.CharField(max_length=255, unique=True, null=True)),
+            ],
+            options={"abstract": False},
+            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name="operator",
+            name="organisation",
+            field=models.ForeignKey(to="call_centre.Organisation", null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/cla_backend/apps/call_centre/migrations/0003_auto_20190729_1416.py
+++ b/cla_backend/apps/call_centre/migrations/0003_auto_20190729_1416.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                         default=django.utils.timezone.now, verbose_name="modified", editable=False
                     ),
                 ),
-                ("name", models.CharField(max_length=255, unique=True, null=True)),
+                ("name", models.CharField(unique=True, max_length=255)),
             ],
             options={"abstract": False},
             bases=(models.Model,),
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="operator",
             name="organisation",
-            field=models.ForeignKey(to="call_centre.Organisation", null=True),
+            field=models.ForeignKey(blank=True, to="call_centre.Organisation", null=True),
             preserve_default=True,
         ),
     ]

--- a/cla_backend/apps/call_centre/models.py
+++ b/cla_backend/apps/call_centre/models.py
@@ -26,7 +26,7 @@ class Caseworker(TimeStampedModel):
 
 
 class Organisation(TimeStampedModel):
-    name = models.CharField(max_length=255, blank=False, null=False, unique=True)
+    name = models.CharField(max_length=255, unique=True)
 
     def __unicode__(self):
         return self.name

--- a/cla_backend/apps/call_centre/models.py
+++ b/cla_backend/apps/call_centre/models.py
@@ -25,8 +25,16 @@ class Caseworker(TimeStampedModel):
         return obj
 
 
+class Organisation(TimeStampedModel):
+    name = models.CharField(max_length=255, blank=False, null=False, unique=True)
+
+    def __unicode__(self):
+        return self.name
+
+
 class Operator(TimeStampedModel):
     user = models.OneToOneField("auth.User")
+    organisation = models.ForeignKey(Organisation, null=True)
     is_manager = models.BooleanField(default=False)
     is_cla_superuser = models.BooleanField(default=False)
 

--- a/cla_backend/apps/call_centre/models.py
+++ b/cla_backend/apps/call_centre/models.py
@@ -34,7 +34,7 @@ class Organisation(TimeStampedModel):
 
 class Operator(TimeStampedModel):
     user = models.OneToOneField("auth.User")
-    organisation = models.ForeignKey(Organisation, null=True)
+    organisation = models.ForeignKey(Organisation, null=True, blank=True)
     is_manager = models.BooleanField(default=False)
     is_cla_superuser = models.BooleanField(default=False)
 

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -342,6 +342,7 @@ class OperatorSerializer(ExtendedUserSerializerBase):
             "created",
             "last_login",
             "is_cla_superuser",
+            "organisation",
         )
 
 

--- a/cla_backend/apps/call_centre/tests/admin/test_views.py
+++ b/cla_backend/apps/call_centre/tests/admin/test_views.py
@@ -411,7 +411,7 @@ class OperatorAdminViewTestCase(TestCase):
         loggedin_op = self.operators["foo_org_manager"]
         changing_op = self.operators["foo_org_op"]
 
-        # go to cla op manager2 change form
+        # go to cla op foo_org_op change form
         # change changing_op.first_name to something random and save
         # check everything is OK
         post_data = self._get_operator_post_data()
@@ -420,6 +420,39 @@ class OperatorAdminViewTestCase(TestCase):
         post_data["organisation"] = changing_op.organisation.id
 
         self._test_change_form(loggedin_op.user, changing_op, should_see_is_cla_superuser=False, post_data=post_data)
+
+    def test_operator_manager_cannot_change_operator_organisation_to_another_organisation(self):
+        loggedin_op = self.operators["foo_org_manager"]
+        changing_op = self.operators["foo_org_op"]
+
+        # go to cla op foo_org_op change form
+        # change changing_op.first_name to something random
+        # change changing_op.organisation to another organisation and save
+        # AssertionError should be raise by self._test_change_form
+        post_data = self._get_operator_post_data()
+        post_data["username"] = changing_op.user.username
+        post_data["first_name"] = get_random_string()
+        post_data["organisation"] = self.bar_organisation.id
+
+        with self.assertRaises(AssertionError):
+            self._test_change_form(
+                loggedin_op.user, changing_op, should_see_is_cla_superuser=False, post_data=post_data
+            )
+
+    def test_cla_superadmin_can_change_operator_organisation(self):
+        loggedin_op = self.operators["op_superuser1"]
+        changing_op = self.operators["foo_org_op"]
+
+        # go to cla op foo_org_op change form
+        # change changing_op.first_name to something random
+        # change changing_op.organisation to another organisation and save
+        # check everything is OK
+        post_data = self._get_operator_post_data()
+        post_data["username"] = changing_op.user.username
+        post_data["first_name"] = get_random_string()
+        post_data["organisation"] = self.bar_organisation.id
+
+        self._test_change_form(loggedin_op.user, changing_op, should_see_is_cla_superuser=True, post_data=post_data)
 
 
 class CaseworkerAdminViewTestCase(TestCase):

--- a/cla_backend/apps/call_centre/tests/api/test_user_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_user_api.py
@@ -55,7 +55,47 @@ class UserTestCase(CLAOperatorAuthBaseApiTestMixin, UserAPIMixin, APITestCase):
 
         return operators
 
-    def test_operator_manager_with_organisation_create_operator(self):
+    def test_operator_manager_can_get_operator_without_organisation_details(self):
+        foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
+        self.manager_token.user.operator.organisation = foo_org
+        self.manager_token.user.operator.save()
+
+        operator = make_recipe("call_centre.operator")
+        response = self.client.get(
+            self.get_user_detail_url(operator.user.username),
+            HTTP_AUTHORIZATION=self.get_http_authorization(token=self.manager_token),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response
+
+    def test_operator_manager_can_get_operator_of_same_organisation_details(self):
+        foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
+        self.manager_token.user.operator.organisation = foo_org
+        self.manager_token.user.operator.save()
+
+        operator = make_recipe("call_centre.operator", organisation=foo_org)
+        response = self.client.get(
+            self.get_user_detail_url(operator.user.username),
+            HTTP_AUTHORIZATION=self.get_http_authorization(token=self.manager_token),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response
+
+    def test_operator_manager_cannot_get_operator_of_different_organisation_details(self):
+        foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
+        bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
+        self.manager_token.user.operator.organisation = foo_org
+        self.manager_token.user.operator.save()
+
+        operator = make_recipe("call_centre.operator", organisation=bar_org)
+        response = self.client.get(
+            self.get_user_detail_url(operator.user.username),
+            HTTP_AUTHORIZATION=self.get_http_authorization(token=self.manager_token),
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        return response
+
+    def test_operator_manager_can_create_operator_of_same_organisation(self):
         foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
 
         self.manager_token.user.operator.organisation = foo_org

--- a/cla_backend/apps/call_centre/tests/api/test_user_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_user_api.py
@@ -50,16 +50,13 @@ class UserTestCase(CLAOperatorAuthBaseApiTestMixin, UserAPIMixin, APITestCase):
 
         no_org_operators = make_recipe("call_centre.operator", _quantity=3)
         for operator in no_org_operators:
-            operator.save()
             operators["no_org"].append(operator.user.username)
 
         return operators
 
     def test_operator_listing(self):
         foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
-        foo_org.save()
         bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
-        bar_org.save()
         operators = self._assign_operators_to_organisation(foo_org, bar_org)
 
         self.operator_manager.organisation = bar_org
@@ -79,9 +76,7 @@ class UserTestCase(CLAOperatorAuthBaseApiTestMixin, UserAPIMixin, APITestCase):
 
     def test_cla_superuser_operator_listing(self):
         foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
-        foo_org.save()
         bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
-        bar_org.save()
         operators = self._assign_operators_to_organisation(foo_org, bar_org)
         # flatten dict of lists
         expected_usernames = list({x for v in operators.itervalues() for x in v})
@@ -99,9 +94,7 @@ class UserTestCase(CLAOperatorAuthBaseApiTestMixin, UserAPIMixin, APITestCase):
 
     def test_cannot_reset_operator_password_of_another_organisation(self):
         foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
-        foo_org.save()
         bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
-        bar_org.save()
 
         self.manager_token.user.operator.organisation = foo_org
         self.manager_token.user.operator.save()

--- a/cla_backend/apps/call_centre/tests/api/test_user_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_user_api.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
+from django.core.urlresolvers import reverse
 
 from core.tests.mommy_utils import make_recipe
 from legalaid.tests.views.test_base import CLAOperatorAuthBaseApiTestMixin
@@ -34,3 +35,41 @@ class UserTestCase(CLAOperatorAuthBaseApiTestMixin, UserAPIMixin, APITestCase):
             HTTP_AUTHORIZATION=self.get_http_authorization(token=self.manager_token),
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_operator_listing(self):
+        organisation_foo = make_recipe("call_centre.organisation", name="Organisation Foo")
+        organisation_foo.save()
+        organisation_bar = make_recipe("call_centre.organisation", name="Organisation Bar")
+        organisation_bar.save()
+
+        foo_operators = []
+        bar_operators = []
+        for index, operator in enumerate(self.other_users):
+            if index % 2 == 0:
+                operator.organisation = organisation_foo
+                foo_operators.append(operator.user.username)
+            else:
+                operator.organisation = organisation_bar
+                bar_operators.append(operator.user.username)
+            operator.save()
+
+        self.operator_manager.organisation = organisation_bar
+        self.operator_manager.save()
+        bar_operators.append(self.operator_manager.user.username)
+
+        self.operator.organisation = organisation_bar
+        self.operator.save()
+        bar_operators.append(self.operator.user.username)
+
+        operators = make_recipe("call_centre.operator", _quantity=3)
+        operators_without_organisation = []
+        for operator in operators:
+            operator.save()
+            operators_without_organisation.append(operator.user.username)
+
+        url = reverse("%s:user-list" % self.API_URL_NAMESPACE)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.get_http_authorization(token=self.manager_token))
+
+        for operator in response.data:
+            self.assertNotIn(operator["username"], foo_operators)
+            self.assertIn(operator["username"], bar_operators + operators_without_organisation)

--- a/cla_backend/apps/call_centre/tests/mommy_recipes.py
+++ b/cla_backend/apps/call_centre/tests/mommy_recipes.py
@@ -1,7 +1,7 @@
 from model_mommy.recipe import Recipe
 
-from ..models import Operator, Caseworker
+from ..models import Operator, Caseworker, Organisation
 
-
+organisation = Recipe(Organisation)
 operator = Recipe(Operator)
 caseworker = Recipe(Caseworker)

--- a/cla_backend/apps/call_centre/tests/test_commands.py
+++ b/cla_backend/apps/call_centre/tests/test_commands.py
@@ -7,24 +7,21 @@ from core.tests.mommy_utils import make_recipe, make_user
 class OrganisationOperatorCommandTest(TestCase):
     def test_create_and_assign_agilisys_organisation(self):
         organisation = make_recipe("call_centre.organisation", name="Agilisys")
-        organisation.save()
 
-        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk")).save()
-        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk")).save()
-        make_recipe(
-            "call_centre.operator", user=make_user(email="user3@agilisys.co.uk"), organisation=organisation
-        ).save()
-        make_recipe("call_centre.operator", user=make_user(email="user1@hgs.co.uk")).save()
-        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk")).save()
-        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk"))
+        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk"))
+        make_recipe("call_centre.operator", user=make_user(email="user3@agilisys.co.uk"), organisation=organisation)
+        make_recipe("call_centre.operator", user=make_user(email="user1@hgs.co.uk"))
+        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk"))
+        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk"))
 
         out = StringIO()
         call_command("create_and_assign_agilisys_organisation", stdout=out)
         self.assertIn("Updating 2 Agilisys operators...done", out.getvalue())
 
     def test_create_and_assign_agilisys_organisation_idempotent(self):
-        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk")).save()
-        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk"))
+        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk"))
         out = StringIO()
         call_command("create_and_assign_agilisys_organisation", stdout=out)
         call_command("create_and_assign_agilisys_organisation", stdout=out)

--- a/cla_backend/apps/call_centre/tests/test_commands.py
+++ b/cla_backend/apps/call_centre/tests/test_commands.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.core.management import call_command
+from django.utils.six import StringIO
+from core.tests.mommy_utils import make_recipe, make_user
+
+
+class OrganisationOperatorCommandTest(TestCase):
+    def test_create_and_assign_agilisys_organisation(self):
+        organisation = make_recipe("call_centre.organisation", name="Agilisys")
+        organisation.save()
+
+        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk")).save()
+        make_recipe(
+            "call_centre.operator", user=make_user(email="user3@agilisys.co.uk"), organisation=organisation
+        ).save()
+        make_recipe("call_centre.operator", user=make_user(email="user1@hgs.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user1@yahoo.co.uk")).save()
+
+        out = StringIO()
+        call_command("create_and_assign_agilisys_organisation", stdout=out)
+        self.assertIn("Updating 2 Agilisys operators...done", out.getvalue())
+
+    def test_create_and_assign_agilisys_organisation_idempotent(self):
+        make_recipe("call_centre.operator", user=make_user(email="user1@agilisys.co.uk")).save()
+        make_recipe("call_centre.operator", user=make_user(email="user2@agilisys.co.uk")).save()
+        out = StringIO()
+        call_command("create_and_assign_agilisys_organisation", stdout=out)
+        call_command("create_and_assign_agilisys_organisation", stdout=out)
+        self.assertIn("Could not find Agilisys operators to update", out.getvalue())

--- a/cla_backend/apps/call_centre/tests/test_models.py
+++ b/cla_backend/apps/call_centre/tests/test_models.py
@@ -120,11 +120,9 @@ class OperatorTestCase(TestCase):
 
     def test_operator_with_organisation(self):
         organisation = make_recipe("call_centre.organisation", name="Test organisation")
-        organisation.save()
         operator = make_recipe(
             "call_centre.operator", is_cla_superuser=False, is_manager=False, organisation=organisation
         )
-        operator.save()
 
         self.assertEqual(operator.organisation.name, "Test organisation")
         self.assertEqual(operator.organisation.id, organisation.id)

--- a/cla_backend/apps/call_centre/tests/test_models.py
+++ b/cla_backend/apps/call_centre/tests/test_models.py
@@ -117,3 +117,14 @@ class OperatorTestCase(TestCase):
         operator.is_cla_superuser = False
         operator.save()
         self.assertEqual(operator.user.groups.count(), 0)
+
+    def test_operator_with_organisation(self):
+        organisation = make_recipe("call_centre.organisation", name="Test organisation")
+        organisation.save()
+        operator = make_recipe(
+            "call_centre.operator", is_cla_superuser=False, is_manager=False, organisation=organisation
+        )
+        operator.save()
+
+        self.assertEqual(operator.organisation.name, "Test organisation")
+        self.assertEqual(operator.organisation.id, organisation.id)

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -488,10 +488,11 @@ class UserViewSet(CallCentrePermissionsViewSetMixin, BaseUserViewSet):
     def get_queryset(self):
         qs = super(BaseUserViewSet, self).get_queryset()
         operator = self.get_logged_in_user_model()
-        query = Q(organisation__isnull=True)
         if operator.organisation:
+            query = Q(organisation__isnull=True)
             query.add(Q(organisation=operator.organisation.id), Q.OR)
-        return qs.filter(query)
+            qs = qs.filter(query)
+        return qs
 
     def get_logged_in_user_model(self):
         return self.request.user.operator

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Q
+from django.db import transaction
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
 
@@ -484,8 +485,23 @@ class UserViewSet(CallCentrePermissionsViewSetMixin, BaseUserViewSet):
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ("is_manager",)
 
+    def get_queryset(self):
+        qs = super(BaseUserViewSet, self).get_queryset()
+        operator = self.get_logged_in_user_model()
+        query = Q(organisation__isnull=True)
+        if operator.organisation:
+            query.add(Q(organisation=operator.organisation.id), Q.OR)
+        return qs.filter(query)
+
     def get_logged_in_user_model(self):
         return self.request.user.operator
+
+    @transaction.atomic
+    def create(self, request, *args, **kwargs):
+        operator = self.get_logged_in_user_model()
+        if operator.organisation:
+            request.DATA["organisation"] = operator.organisation.id
+        return super(UserViewSet, self).create(request, *args, **kwargs)
 
 
 class PersonalDetailsViewSet(CallCentrePermissionsViewSetMixin, FormActionMixin, FullPersonalDetailsViewSet):


### PR DESCRIPTION
## What does this pull request do?

Creates new Organisation model

- Added organisation foreign key to Operator model
- Added django command to auto create Agilisys organisation and assign existing operators to organisation
- Restricted organisation operator managers to only seeing operators in their organisation
- Automatically add newly created operator to the same organisation as the operator manager that is creating them
- Added command to assign CLA Superusers 'Can add organisation' and 'Can change organisation' permissions

## Any other changes that would benefit highlighting?

Associate operators with an organisation so that content can be restricted to a specific organisation

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
