### PR TITLE
LGA-717 - Skip installation of pgrypto extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,13 +110,10 @@ jobs:
           POSTGRES_DB: circle_test
     steps:
       - checkout
-      - run: sudo apt-get install postgresql-client-9.6
       - run:
           name: Setup Postgres
           command: |
             dockerize -wait tcp://localhost:5432 -timeout 1m
-            psql -d postgresql://$DB_USER@localhost/$DB_NAME -c "create extension pgcrypto;"
-            psql -d postgresql://$DB_USER@localhost/template1 -c 'create extension pgcrypto;'
       - run:
           name: Setup Python environment
           command: |


### PR DESCRIPTION
## What does this pull request do?

Skipping this step means we don't have to install postgres on the first container (the
python one), which was causing the following error during build

```#!/bin/bash -eo pipefail
sudo apt-get install postgresql-client-9.6
Reading package lists... Done


Building dependency tree       


Reading state information... Done

E: Unable to locate package postgresql-client-9.6
E: Couldn't find any package by glob 'postgresql-client-9.6'
E: Couldn't find any package by regex 'postgresql-client-9.6'
Exited with code 100
```

Running the Circle job with two docker images isn't doing what we probably think it is, specifically in that all `steps` are run on the primary container (the first one listed). This is why we were needing to install postgres as a step, when we already had a postgres sidecar container: the commands were being run on the container based on the python-2.7 image.

I don't think the extensions we were installing were actually going on the postgres instance used in the tests (which is presumably the sidecar) but I could be wrong about that.

The tests run now, so either the behaviour is the same as before (no extensions on the postgres instance actually in use) or the tests don't actually require the extensions to be present.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
