### PR TITLE
LGA-693 - Code coverage on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,10 @@ jobs:
       - store_artifacts:
           path: htmlcov
           destination: coverage
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
             coverage html
       - store_artifacts:
           path: htmlcov
+          destination: coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
             coverage run --source cla_backend manage.py test --verbosity=2
             coverage report -m
             coverage html
+            coveralls
       - store_artifacts:
           path: htmlcov
           destination: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,14 @@ jobs:
           paths:
             - "~/.cache/pip"
       - run:
-          name: Run unit tests
+          name: Run tests with coverage
           command: |
             source env/bin/activate
-            python manage.py test --verbosity=2
+            coverage run --source cla_backend manage.py test --verbosity=2
+            coverage report -m
+            coverage html
+      - store_artifacts:
+          path: htmlcov
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/cla_backend/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cla_backend/tree/master)
+
+[![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/cla_backend/badge.svg?branch=master)](https://coveralls.io/github/ministryofjustice/cla_backend?branch=master)
     
 Backend API for the Civil Legal Aid Tool.
 

--- a/cla_backend/apps/core/testing.py
+++ b/cla_backend/apps/core/testing.py
@@ -2,11 +2,11 @@ from django.core.management import call_command
 from django.test.utils import get_runner
 from django.conf import settings
 
-# use jenkins runner if present otherwise the default django one
+# use jenkins runner if present otherwise the django one from unittest-xml-reporting
 if "django_jenkins" in settings.INSTALLED_APPS:
     base_runner = "django_jenkins.runner.CITestSuiteRunner"
 else:
-    base_runner = "django.test.runner.DiscoverRunner"
+    base_runner = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
 
 
 class CLADiscoverRunner(get_runner(settings, base_runner)):

--- a/cla_backend/settings/circle.py
+++ b/cla_backend/settings/circle.py
@@ -15,3 +15,5 @@ DATABASES = {
         "PORT": os.environ.get("DB_PORT", ""),
     }
 }
+
+TEST_OUTPUT_DIR = "test-reports"

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+coverage==4.5.4
 mock==1.0.1
 model-mommy==1.2.3
 git+https://github.com/HassenPy/django-pdb.git@0.3.2#egg=django-pdb==0.3.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,4 +4,5 @@ coverage==4.5.4
 coveralls==1.8.2
 mock==1.0.1
 model-mommy==1.2.3
+unittest-xml-reporting==2.5.1
 git+https://github.com/HassenPy/django-pdb.git@0.3.2#egg=django-pdb==0.3.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,7 @@
 -r base.txt
 
 coverage==4.5.4
+coveralls==1.8.2
 mock==1.0.1
 model-mommy==1.2.3
 git+https://github.com/HassenPy/django-pdb.git@0.3.2#egg=django-pdb==0.3.2


### PR DESCRIPTION
## What does this pull request do?

Wraps test running in `coverage`
Stores the output on circleci as artifacts
Sends coverage results to coveralls.io
Adds a coveralls badge to the readme
Generates and stores test metadata in xml format for CircleCI to monitor

## Any other changes that would benefit highlighting?

No

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
