### PR TITLE
LGA-715 - CHS Complaints / EODs data split

### DIFF
--- a/cla_backend/apps/call_centre/permissions.py
+++ b/cla_backend/apps/call_centre/permissions.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.exceptions import MethodNotAllowed
 
 from core.permissions import ClientIDPermission
@@ -35,7 +35,8 @@ class OperatorOrganisationCasePermission(CallCentreClientIDPermission):
 
         case = self.get_case(request, view)
         if not case:
-            return False
+            # Allow list and dashboard views
+            return request.method in SAFE_METHODS
 
         try:
             has_permission = case_organisation_matches_user_organisation(case, request.user)

--- a/cla_backend/apps/call_centre/permissions.py
+++ b/cla_backend/apps/call_centre/permissions.py
@@ -1,5 +1,11 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
 from core.permissions import ClientIDPermission
-from rest_framework.permissions import BasePermission
+from legalaid.models import Case
+from .utils.organisation import case_organisation_matches_user_organisation
+from .utils.organisation.exceptions import OrganisationMatchException
 
 
 class CallCentreClientIDPermission(ClientIDPermission):
@@ -9,3 +15,21 @@ class CallCentreClientIDPermission(ClientIDPermission):
 class OperatorManagerPermission(BasePermission):
     def has_permission(self, request, view):
         return request.user.operator.is_manager
+
+
+class OperatorOrganisationPermission(CallCentreClientIDPermission):
+    def has_permission(self, request, view, *args, **kwargs):
+        has_permission = super(OperatorOrganisationPermission, self).has_permission(request, view)
+        if not has_permission:
+            return False
+
+        if request.method in SAFE_METHODS:
+            return True
+
+        case = get_object_or_404(Case, reference=view.kwargs.get("case_reference"))
+        try:
+            has_permission = case_organisation_matches_user_organisation(case, request.user)
+        except OrganisationMatchException:
+            return True
+
+        return has_permission

--- a/cla_backend/apps/call_centre/permissions.py
+++ b/cla_backend/apps/call_centre/permissions.py
@@ -7,12 +7,7 @@ from core.permissions import ClientIDPermission
 from legalaid.models import Case, EODDetails
 from complaints.models import Complaint
 from .utils.organisation import case_organisation_matches_user_organisation
-from .utils.organisation.exceptions import (
-    UserIsNotOperatorException,
-    OperatorDoesNotBelongToOrganisation,
-    CaseNotCreatedByOperatorException,
-    CaseCreatorDoesNotBelongToOrganisation,
-)
+from .utils.organisation.exceptions import OrganisationMismatchException
 
 
 class CallCentreClientIDPermission(ClientIDPermission):
@@ -40,13 +35,8 @@ class OperatorOrganisationCasePermission(CallCentreClientIDPermission):
 
         try:
             has_permission = case_organisation_matches_user_organisation(case, request.user)
-        except UserIsNotOperatorException:
-            return True
-        except OperatorDoesNotBelongToOrganisation:
-            return True
-        except CaseNotCreatedByOperatorException:
-            return True
-        except CaseCreatorDoesNotBelongToOrganisation:
+        except OrganisationMismatchException:
+            # Operator or case creator does not have an organisation
             return True
 
         return has_permission

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -24,6 +24,7 @@ from legalaid.serializers import (
     CaseNotesHistorySerializerBase,
     CSVUploadSerializerBase,
     EODDetailsSerializerBase,
+    EODDetailsCategorySerializerReadyOnly,
 )
 
 from .models import Operator
@@ -185,6 +186,13 @@ class AdaptationDetailsSerializer(AdaptationDetailsSerializerBase):
 class EODDetailsSerializer(EODDetailsSerializerBase):
     class Meta(EODDetailsSerializerBase.Meta):
         fields = ("categories", "notes", "reference")
+
+
+class EODDetailsSerializerReadyOnlySerializer(EODDetailsSerializerBase):
+    categories = EODDetailsCategorySerializerReadyOnly(many=True, allow_add_remove=False, required=False)
+
+    class Meta(EODDetailsSerializerBase.Meta):
+        fields = ("categories", "reference")
 
 
 class EligibilityCheckSerializer(EligibilityCheckSerializerBase):

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -234,6 +234,7 @@ class CaseSerializer(CaseSerializerFull):
     rejected = serializers.SerializerMethodField("is_rejected")
 
     complaint_count = serializers.IntegerField(source="complaint_count", read_only=True)
+    eod_details_count = serializers.IntegerField(source="eod_details_count", read_only=True)
 
     def is_rejected(self, case):
         try:
@@ -281,6 +282,7 @@ class CaseSerializer(CaseSerializerFull):
             "eod_details",
             "call_started",
             "complaint_count",
+            "eod_details_count",
         )
 
 

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -24,7 +24,6 @@ from legalaid.serializers import (
     CaseNotesHistorySerializerBase,
     CSVUploadSerializerBase,
     EODDetailsSerializerBase,
-    EODDetailsCategorySerializerReadyOnly,
 )
 
 from .models import Operator
@@ -188,13 +187,6 @@ class EODDetailsSerializer(EODDetailsSerializerBase):
         fields = ("categories", "notes", "reference")
 
 
-class EODDetailsSerializerReadyOnlySerializer(EODDetailsSerializerBase):
-    categories = EODDetailsCategorySerializerReadyOnly(many=True, allow_add_remove=False, required=False)
-
-    class Meta(EODDetailsSerializerBase.Meta):
-        fields = ("categories", "reference")
-
-
 class EligibilityCheckSerializer(EligibilityCheckSerializerBase):
     property_set = PropertySerializer(allow_add_remove=True, many=True, required=False)
     you = PersonSerializer(required=False)
@@ -322,7 +314,7 @@ class CreateCaseSerializer(CaseSerializer):
     personal_details = UUIDSerializer(slug_field="reference", required=False)
 
     class Meta(CaseSerializer.Meta):
-        fields = tuple(set(CaseSerializer.Meta.fields) - {"complaint_count"})
+        fields = tuple(set(CaseSerializer.Meta.fields) - {"complaint_count", "eod_details_count"})
 
 
 class ProviderSerializer(ProviderSerializerBase):

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -27,7 +27,7 @@ from legalaid.serializers import (
 )
 
 from .models import Operator
-from .utils.organisation.exceptions import OrganisationMatchException
+from .utils.organisation.exceptions import OrganisationMismatchException
 from .utils.organisation import case_organisation_matches_user_organisation
 
 
@@ -241,7 +241,7 @@ class CaseSerializer(CaseSerializerFull):
         user = self.context.get("request").user
         try:
             has_permission = case_organisation_matches_user_organisation(case, user)
-        except OrganisationMatchException:
+        except OrganisationMismatchException:
             has_permission = True
 
         return has_permission
@@ -250,7 +250,7 @@ class CaseSerializer(CaseSerializerFull):
         user = self.context.get("request").user
         try:
             has_permission = case_organisation_matches_user_organisation(case, user)
-        except OrganisationMatchException:
+        except OrganisationMismatchException:
             has_permission = True
 
         if has_permission:

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -246,7 +246,11 @@ class CreateCaseTestCase(BaseCaseTestCase):
 class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
     @property
     def response_keys(self):
-        return super(UpdateCaseTestCase, self).response_keys + ["complaint_count", "eod_details_count"]
+        return super(UpdateCaseTestCase, self).response_keys + [
+            "complaint_count",
+            "eod_details_count",
+            "eod_details_editable",
+        ]
 
     def test_patch_operator_notes_allowed(self):
         """

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -246,7 +246,7 @@ class CreateCaseTestCase(BaseCaseTestCase):
 class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
     @property
     def response_keys(self):
-        return super(UpdateCaseTestCase, self).response_keys + ["complaint_count"]
+        return super(UpdateCaseTestCase, self).response_keys + ["complaint_count", "eod_details_count"]
 
     def test_patch_operator_notes_allowed(self):
         """

--- a/cla_backend/apps/call_centre/tests/api/test_organisation_complaints.py
+++ b/cla_backend/apps/call_centre/tests/api/test_organisation_complaints.py
@@ -1,0 +1,123 @@
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+
+from legalaid.tests.views.mixins.case_api import FullCaseAPIMixin
+from core.tests.mommy_utils import make_recipe
+from .test_case_api import BaseCaseTestCase
+
+
+class OrganisationComplaintsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
+    def setUp(self):
+        super(OrganisationComplaintsTestCase, self).setUp()
+
+        self.foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
+        self.foo_org_operator = make_recipe(
+            "call_centre.operator", is_manager=False, is_cla_superuser=False, organisation=self.foo_org
+        )
+
+        self.bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
+        self.bar_org_operator = make_recipe(
+            "call_centre.operator", is_manager=False, is_cla_superuser=False, organisation=self.bar_org
+        )
+
+        self.no_org_operator = make_recipe("call_centre.operator", is_manager=False, is_cla_superuser=False)
+
+    """
+    When an a case is created by an operator that has a organisation then only operators of the same organisation
+    can register complaints against that case.
+    """
+
+    def test_operator_can_create_complaint_for_cases_created_by_operator_of_same_organisation(self):
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", case=case)
+
+        create_complaint_url = reverse(u"%s:complaints-list" % self.API_URL_NAMESPACE)
+
+        data = {"eod": str(eod.reference), "description": "This is a description"}
+        response = self.client.post(
+            create_complaint_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token
+        )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+    """
+    When an a case is created by an operator that has a organisation then only operators of the same organisation
+    can register complaints against that case.
+    """
+
+    def test_operator_cannot_create_complaint_for_cases_created_by_operator_of_another_organisation(self):
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.bar_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", case=case)
+
+        create_complaint_url = reverse(u"%s:complaints-list" % self.API_URL_NAMESPACE)
+
+        data = {"eod": str(eod.reference), "description": "This is a description"}
+        response = self.client.post(
+            create_complaint_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token
+        )
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    """
+    When a case is created by an user that does not have a organisation then any operator or
+    operator manager can register a complaint against that case.
+    """
+
+    def test_operator_can_create_complaint_for_cases_created_by_operator_with_no_organisation(self):
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.no_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", case=case)
+
+        create_complaint_url = reverse(u"%s:complaints-list" % self.API_URL_NAMESPACE)
+
+        data = {"eod": str(eod.reference), "description": "This is a description"}
+
+        response = self.client.post(
+            create_complaint_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token
+        )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+    """
+    All Operator Managers should be able to see that there is a complaint against
+    """
+
+    def test_operator_manager_case_creator_different_organisation_see_complaints_count(self):
+        self.operator_manager.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.bar_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", notes="hello", case=case)
+        complaints = make_recipe(
+            "complaints.complaint", eod=eod, description="This is a test", category=None, _quantity=3
+        )
+
+        url = reverse(u"%s:case-detail" % self.API_URL_NAMESPACE, args=(), kwargs={"reference": case.reference})
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.manager_token)
+        self.assertEqual(response.data.get("complaint_count"), len(complaints))
+        return response
+
+    """
+    All Operator Managers should be able to see that there is a complaint against
+    """
+
+    def test_operator_manager_case_creator_same_organisation_see_complaints_count(self):
+        self.operator_manager.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", notes="hello", case=case)
+        complaints = make_recipe(
+            "complaints.complaint", eod=eod, description="This is a test", category=None, _quantity=3
+        )
+
+        url = reverse(u"%s:case-detail" % self.API_URL_NAMESPACE, args=(), kwargs={"reference": case.reference})
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.manager_token)
+        self.assertEqual(response.data.get("complaint_count"), len(complaints))
+        return response

--- a/cla_backend/apps/call_centre/tests/api/test_organisation_complaints.py
+++ b/cla_backend/apps/call_centre/tests/api/test_organisation_complaints.py
@@ -137,19 +137,19 @@ class OrganisationComplaintsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
         # Case creator belongs to another organisation
         self.operator_manager.organisation = self.foo_org
         self.operator_manager.save()
-        self._assert_complaint_dashboard(complaints, complaint_editable=False)
+        self._assert_complaint_dashboard(complaints, is_editable=False)
 
         # Case creator doesn't have organisation
         self.operator_manager.organisation = None
         self.operator_manager.save()
-        self._assert_complaint_dashboard(complaints, complaint_editable=True)
+        self._assert_complaint_dashboard(complaints, is_editable=True)
 
         # Case creator belongs to same organisation
         self.operator_manager.organisation = self.bar_org
         self.operator_manager.save()
-        self._assert_complaint_dashboard(complaints, complaint_editable=True)
+        self._assert_complaint_dashboard(complaints, is_editable=True)
 
-    def _assert_complaint_dashboard(self, complaints, complaint_editable):
+    def _assert_complaint_dashboard(self, complaints, is_editable):
         complaint_ids = [complaint.id for complaint in complaints]
         url = reverse(u"%s:complaints-list" % self.API_URL_NAMESPACE)
         response = self.client.get(url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.manager_token)
@@ -157,4 +157,4 @@ class OrganisationComplaintsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
         results = response.data.get("results")
         for complaint in results:
             self.assertIn(complaint.get("id"), complaint_ids)
-            self.assertEqual(complaint.get("complaint_editable"), complaint_editable)
+            self.assertEqual(complaint.get("is_editable"), is_editable)

--- a/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
+++ b/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.urlresolvers import reverse
 
 from rest_framework import status
@@ -120,11 +118,8 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
     All Operator Managers should be able to see that there is a EOD against
     """
 
-    def test_operator_case_creator_different_organisation_eod_response(self):
-        # Check the returned response keys when current operator organisation
-        # does not match case creator organisation
-
-        self.operator.organisation = self.foo_org
+    def test_operator_manager_case_creator_different_organisation_see_eod_details_count(self):
+        self.operator_manager.organisation = self.foo_org
         self.operator.save()
 
         case = make_recipe("legalaid.case", created_by=self.bar_org_operator.user)
@@ -143,24 +138,16 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
             ),
         ]
 
-        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
-        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
-        response = self.client.get(create_eod_url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
-        expected_dict = {
-            "reference": str(eod.reference),
-            "categories": [{"id": category.id} for category in categories],
-        }
-        self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
+        url = reverse(u"%s:case-detail" % self.API_URL_NAMESPACE, args=(), kwargs={"reference": case.reference})
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.manager_token)
+        self.assertEqual(response.data.get("eod_details_count"), len(categories))
 
     """
     All Operator Managers should be able to see that there is a EOD against
     """
 
-    def test_operator_case_creator_same_organisation_eod_response(self):
-        # Check the returned response keys when current operator organisation
-        # does matches case creator organisation
-
-        self.operator.organisation = self.foo_org
+    def test_operator_manager_case_creator_same_organisation_see_complaints_count(self):
+        self.operator_manager.organisation = self.foo_org
         self.operator.save()
 
         case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
@@ -179,12 +166,6 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
             ),
         ]
 
-        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
-        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
-        response = self.client.get(create_eod_url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
-        expected_dict = {
-            "reference": str(eod.reference),
-            "notes": eod.notes,
-            "categories": [{"category": category.category, "is_major": category.is_major} for category in categories],
-        }
-        self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
+        url = reverse(u"%s:case-detail" % self.API_URL_NAMESPACE, args=(), kwargs={"reference": case.reference})
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.manager_token)
+        self.assertEqual(response.data.get("eod_details_count"), len(categories))

--- a/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
+++ b/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
@@ -1,0 +1,199 @@
+import json
+
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+
+from legalaid.models import EODDetails
+from legalaid.tests.views.mixins.case_api import FullCaseAPIMixin
+from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
+from core.tests.mommy_utils import make_recipe
+from .test_case_api import BaseCaseTestCase
+
+
+class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
+    def setUp(self):
+        super(OrganisationEODDetailsTestCase, self).setUp()
+
+        self.foo_org = make_recipe("call_centre.organisation", name="Organisation Foo")
+        self.foo_org_operator = make_recipe(
+            "call_centre.operator", is_manager=False, is_cla_superuser=False, organisation=self.foo_org
+        )
+
+        self.bar_org = make_recipe("call_centre.organisation", name="Organisation Bar")
+        self.bar_org_operator = make_recipe(
+            "call_centre.operator", is_manager=False, is_cla_superuser=False, organisation=self.bar_org
+        )
+
+        self.no_org_operator = make_recipe("call_centre.operator", is_manager=False, is_cla_superuser=False)
+
+    """
+    When an a case is created by an operator that has a organisation then only operators of the same organisation
+    can register complaints and EOD against that case.
+    """
+
+    def test_operator_can_create_eod_for_cases_created_by_operator_of_same_organisation(self):
+        from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
+
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
+
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+
+        data = {
+            "case_reference": case.reference,
+            "categories": [{"category": EXPRESSIONS_OF_DISSATISFACTION.INCORRECT, "is_major": False}],
+            "notes": "",
+        }
+        response = self.client.post(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+        return response
+
+    def test_operator_can_update_eod_for_cases_created_by_operator_of_same_organisation(self):
+        from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
+
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", notes="hello", case=case)
+        self.assertEqual(eod.categories.count(), 0)
+
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+
+        data = {
+            "reference": str(eod.reference),
+            "categories": [
+                {"category": EXPRESSIONS_OF_DISSATISFACTION.INCORRECT, "is_major": False},
+                {"category": EXPRESSIONS_OF_DISSATISFACTION.PASS_TO_PUBLIC, "is_major": False},
+            ],
+            "notes": "",
+        }
+        response = self.client.patch(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        eod_reloaded = EODDetails.objects.get(reference=eod.reference)
+        self.assertEqual(eod_reloaded.categories.count(), 2)
+        return response
+
+    """
+    When an a case is created by an operator that has a organisation then only operators of the same organisation
+    can register complaints and EOD against that case.
+    """
+
+    def test_operator_cannot_create_eod_for_cases_created_by_operator_of_another_organisation(self):
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.bar_org_operator.user)
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+        data = {
+            "case_reference": case.reference,
+            "categories": [{"category": EXPRESSIONS_OF_DISSATISFACTION.INCORRECT, "is_major": False}],
+            "notes": "",
+        }
+        response = self.client.post(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+        return response
+
+    """
+    When a case is created by an user that does not have a organisation then any operator or
+    operator managercan register a complaint and EOD against that case.
+    """
+
+    def test_operator_can_create_eod_for_cases_created_by_operator_with_no_organisation(self):
+        from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
+
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.no_org_operator.user)
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+        data = {
+            "case_reference": case.reference,
+            "categories": [{"category": EXPRESSIONS_OF_DISSATISFACTION.INCORRECT, "is_major": False}],
+            "notes": "",
+        }
+        response = self.client.post(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+        return response
+
+    """
+    All Operator Managers should be able to see that there is a complaint against
+    """
+
+    def test_operator_case_creator_different_organisation_eod_response(self):
+        # Check the returned response keys when current operator organisation
+        # does not match case creator organisation
+
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.bar_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", notes="hello", case=case)
+        categories = [
+            make_recipe(
+                "legalaid.eod_details_category", eod_details=eod, category=EXPRESSIONS_OF_DISSATISFACTION.INCORRECT
+            ),
+            make_recipe(
+                "legalaid.eod_details_category",
+                eod_details=eod,
+                category=EXPRESSIONS_OF_DISSATISFACTION.PASS_TO_PUBLIC,
+            ),
+            make_recipe(
+                "legalaid.eod_details_category", eod_details=eod, category=EXPRESSIONS_OF_DISSATISFACTION.SCOPE
+            ),
+        ]
+
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+        response = self.client.get(create_eod_url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        expected_dict = {
+            "reference": str(eod.reference),
+            "categories": [{"id": category.id} for category in categories],
+        }
+        self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
+        return response
+
+    """
+    All Operator Managers should be able to see that there is a complaint against
+    """
+
+    def test_operator_case_creator_same_organisation_eod_response(self):
+        # Check the returned response keys when current operator organisation
+        # does matches case creator organisation
+
+        self.operator.organisation = self.foo_org
+        self.operator.save()
+
+        case = make_recipe("legalaid.case", created_by=self.foo_org_operator.user)
+        eod = make_recipe("legalaid.eod_details", notes="hello", case=case)
+        categories = [
+            make_recipe(
+                "legalaid.eod_details_category", eod_details=eod, category=EXPRESSIONS_OF_DISSATISFACTION.INCORRECT
+            ),
+            make_recipe(
+                "legalaid.eod_details_category",
+                eod_details=eod,
+                category=EXPRESSIONS_OF_DISSATISFACTION.PASS_TO_PUBLIC,
+            ),
+            make_recipe(
+                "legalaid.eod_details_category", eod_details=eod, category=EXPRESSIONS_OF_DISSATISFACTION.SCOPE
+            ),
+        ]
+
+        path = u"%s:eoddetails-detail" % self.API_URL_NAMESPACE
+        create_eod_url = reverse(path, args=(), kwargs={"case_reference": case.reference})
+        response = self.client.get(create_eod_url, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        expected_dict = {
+            "reference": str(eod.reference),
+            "notes": eod.notes,
+            "categories": [{"category": category.category, "is_major": category.is_major} for category in categories],
+        }
+        self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
+        return response

--- a/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
+++ b/cla_backend/apps/call_centre/tests/api/test_organisation_eod_details.py
@@ -29,12 +29,10 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
 
     """
     When an a case is created by an operator that has a organisation then only operators of the same organisation
-    can register complaints and EOD against that case.
+    can register EOD against that case.
     """
 
     def test_operator_can_create_eod_for_cases_created_by_operator_of_same_organisation(self):
-        from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
-
         self.operator.organisation = self.foo_org
         self.operator.save()
 
@@ -77,11 +75,10 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         eod_reloaded = EODDetails.objects.get(reference=eod.reference)
         self.assertEqual(eod_reloaded.categories.count(), 2)
-        return response
 
     """
     When an a case is created by an operator that has a organisation then only operators of the same organisation
-    can register complaints and EOD against that case.
+    can register EOD against that case.
     """
 
     def test_operator_cannot_create_eod_for_cases_created_by_operator_of_another_organisation(self):
@@ -98,16 +95,13 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
         }
         response = self.client.post(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
-        return response
 
     """
     When a case is created by an user that does not have a organisation then any operator or
-    operator managercan register a complaint and EOD against that case.
+    operator manager can register a EOD against that case.
     """
 
     def test_operator_can_create_eod_for_cases_created_by_operator_with_no_organisation(self):
-        from cla_common.constants import EXPRESSIONS_OF_DISSATISFACTION
-
         self.operator.organisation = self.foo_org
         self.operator.save()
 
@@ -121,10 +115,9 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
         }
         response = self.client.post(create_eod_url, data, format="json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
-        return response
 
     """
-    All Operator Managers should be able to see that there is a complaint against
+    All Operator Managers should be able to see that there is a EOD against
     """
 
     def test_operator_case_creator_different_organisation_eod_response(self):
@@ -158,10 +151,9 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
             "categories": [{"id": category.id} for category in categories],
         }
         self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
-        return response
 
     """
-    All Operator Managers should be able to see that there is a complaint against
+    All Operator Managers should be able to see that there is a EOD against
     """
 
     def test_operator_case_creator_same_organisation_eod_response(self):
@@ -196,4 +188,3 @@ class OrganisationEODDetailsTestCase(BaseCaseTestCase, FullCaseAPIMixin):
             "categories": [{"category": category.category, "is_major": category.is_major} for category in categories],
         }
         self.assertDictEqual(expected_dict, json.loads(response.rendered_content))
-        return response

--- a/cla_backend/apps/call_centre/utils/organisation/__init__.py
+++ b/cla_backend/apps/call_centre/utils/organisation/__init__.py
@@ -1,29 +1,30 @@
 from call_centre.models import Operator
 
-from .exceptions import (
-    UserIsNotOperatorException,
-    OperatorDoesNotBelongToOrganisation,
-    CaseNotCreatedByOperatorException,
-    CaseCreatorDoesNotBelongToOrganisation,
-)
+from .exceptions import UserIsNotOperatorException
 
 
 def case_organisation_matches_user_organisation(case, user):
+    # Return True when:
+    # Current operator organisations matches case creator organisation
+    # Case creator does not have organisation
+
+    if not case.created_by:
+        return True
+
+    try:
+        case_creator_organisation = case.created_by.operator.organisation
+    except Operator.DoesNotExist:
+        return True
+
+    if case_creator_organisation is None:
+        return True
+
     try:
         current_operator_organisation = user.operator.organisation
     except Operator.DoesNotExist:
-        raise UserIsNotOperatorException("Current user is not an operator")
+        raise UserIsNotOperatorException("Case creator has organisation but current user is not an operator")
 
     if current_operator_organisation is None:
-        raise OperatorDoesNotBelongToOrganisation("Operator does not have an organisation")
-
-    try:
-        # Case creator is not an operator
-        case_creator_organisation = case.created_by.operator.organisation
-    except Operator.DoesNotExist:
-        raise CaseNotCreatedByOperatorException("Case created by someone not an operator")
-
-    if case_creator_organisation is None:
-        raise CaseCreatorDoesNotBelongToOrganisation("Case created by an operator that does not have an organisation")
+        return False
 
     return case_creator_organisation == current_operator_organisation

--- a/cla_backend/apps/call_centre/utils/organisation/__init__.py
+++ b/cla_backend/apps/call_centre/utils/organisation/__init__.py
@@ -1,4 +1,5 @@
-from django.core.exceptions import ObjectDoesNotExist
+from call_centre.models import Operator
+
 from .exceptions import (
     UserIsNotOperatorException,
     OperatorDoesNotBelongToOrganisation,
@@ -10,15 +11,18 @@ from .exceptions import (
 def case_organisation_matches_user_organisation(case, user):
     try:
         current_operator_organisation = user.operator.organisation
-    except ObjectDoesNotExist:
-        raise UserIsNotOperatorException("Current user is not an operator or")
+    except Operator.DoesNotExist:
+        raise UserIsNotOperatorException("Current user is not an operator")
+
     if current_operator_organisation is None:
         raise OperatorDoesNotBelongToOrganisation("Operator does not have an organisation")
 
     try:
+        # Case creator is not an operator
         case_creator_organisation = case.created_by.operator.organisation
-    except ObjectDoesNotExist:
+    except Operator.DoesNotExist:
         raise CaseNotCreatedByOperatorException("Case created by someone not an operator")
+
     if case_creator_organisation is None:
         raise CaseCreatorDoesNotBelongToOrganisation("Case created by an operator that does not have an organisation")
 

--- a/cla_backend/apps/call_centre/utils/organisation/__init__.py
+++ b/cla_backend/apps/call_centre/utils/organisation/__init__.py
@@ -1,0 +1,25 @@
+from django.core.exceptions import ObjectDoesNotExist
+from .exceptions import (
+    UserIsNotOperatorException,
+    OperatorDoesNotBelongToOrganisation,
+    CaseNotCreatedByOperatorException,
+    CaseCreatorDoesNotBelongToOrganisation,
+)
+
+
+def case_organisation_matches_user_organisation(case, user):
+    try:
+        current_operator_organisation = user.operator.organisation
+    except ObjectDoesNotExist:
+        raise UserIsNotOperatorException("Current user is not an operator or")
+    if current_operator_organisation is None:
+        raise OperatorDoesNotBelongToOrganisation("Operator does not have an organisation")
+
+    try:
+        case_creator_organisation = case.created_by.operator.organisation
+    except ObjectDoesNotExist:
+        raise CaseNotCreatedByOperatorException("Case created by someone not an operator")
+    if case_creator_organisation is None:
+        raise CaseCreatorDoesNotBelongToOrganisation("Case created by an operator that does not have an organisation")
+
+    return case_creator_organisation == current_operator_organisation

--- a/cla_backend/apps/call_centre/utils/organisation/__init__.py
+++ b/cla_backend/apps/call_centre/utils/organisation/__init__.py
@@ -25,7 +25,7 @@ def case_organisation_matches_user_organisation(case, user):
         raise UserIsNotOperatorException("Case creator has organisation but current user is not an operator")
 
     if current_operator_organisation is None:
-        return False
+        return user.operator.is_cla_superuser
 
     return case_creator_organisation == current_operator_organisation
 

--- a/cla_backend/apps/call_centre/utils/organisation/__init__.py
+++ b/cla_backend/apps/call_centre/utils/organisation/__init__.py
@@ -1,33 +1,27 @@
 from call_centre.models import Operator
 
-from .exceptions import UserIsNotOperatorException
-
 
 def case_organisation_matches_user_organisation(case, user):
     # Return True when:
-    # Current operator organisations matches case creator organisation
-    # Case creator does not have organisation
+    # Current operator organisations matches case organisation
+    # Case does not have organisation
+    # Current user is cla_superuser
+    # Current user is not operator
 
-    if not case.created_by:
+    if not case.organisation:
+        # Case has no organisation anyone can edit
         return True
 
     try:
-        case_creator_organisation = case.created_by.operator.organisation
+        operator_organisation = user.operator.organisation
     except Operator.DoesNotExist:
+        # user is not operator. Organisation access control only applies to operators
         return True
 
-    if case_creator_organisation is None:
-        return True
-
-    try:
-        current_operator_organisation = user.operator.organisation
-    except Operator.DoesNotExist:
-        raise UserIsNotOperatorException("Case creator has organisation but current user is not an operator")
-
-    if current_operator_organisation is None:
+    if operator_organisation is None:
         return user.operator.is_cla_superuser
 
-    return case_creator_organisation == current_operator_organisation
+    return case.organisation == operator_organisation
 
 
 class NoOrganisationCaseAssignCurrentOrganisationMixin(object):

--- a/cla_backend/apps/call_centre/utils/organisation/exceptions.py
+++ b/cla_backend/apps/call_centre/utils/organisation/exceptions.py
@@ -4,15 +4,3 @@ class OrganisationMismatchException(Exception):
 
 class UserIsNotOperatorException(OrganisationMismatchException):
     pass
-
-
-class OperatorDoesNotBelongToOrganisation(OrganisationMismatchException):
-    pass
-
-
-class CaseNotCreatedByOperatorException(OrganisationMismatchException):
-    pass
-
-
-class CaseCreatorDoesNotBelongToOrganisation(OrganisationMismatchException):
-    pass

--- a/cla_backend/apps/call_centre/utils/organisation/exceptions.py
+++ b/cla_backend/apps/call_centre/utils/organisation/exceptions.py
@@ -1,0 +1,18 @@
+class OrganisationMatchException(Exception):
+    pass
+
+
+class UserIsNotOperatorException(OrganisationMatchException):
+    pass
+
+
+class OperatorDoesNotBelongToOrganisation(OrganisationMatchException):
+    pass
+
+
+class CaseNotCreatedByOperatorException(OrganisationMatchException):
+    pass
+
+
+class CaseCreatorDoesNotBelongToOrganisation(OrganisationMatchException):
+    pass

--- a/cla_backend/apps/call_centre/utils/organisation/exceptions.py
+++ b/cla_backend/apps/call_centre/utils/organisation/exceptions.py
@@ -1,18 +1,18 @@
-class OrganisationMatchException(Exception):
+class OrganisationMismatchException(Exception):
     pass
 
 
-class UserIsNotOperatorException(OrganisationMatchException):
+class UserIsNotOperatorException(OrganisationMismatchException):
     pass
 
 
-class OperatorDoesNotBelongToOrganisation(OrganisationMatchException):
+class OperatorDoesNotBelongToOrganisation(OrganisationMismatchException):
     pass
 
 
-class CaseNotCreatedByOperatorException(OrganisationMatchException):
+class CaseNotCreatedByOperatorException(OrganisationMismatchException):
     pass
 
 
-class CaseCreatorDoesNotBelongToOrganisation(OrganisationMatchException):
+class CaseCreatorDoesNotBelongToOrganisation(OrganisationMismatchException):
     pass

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -230,6 +230,17 @@ class CaseViewSet(CallCentrePermissionsViewSetMixin, mixins.CreateModelMixin, Ba
         else:
             qs = qs.extra(select={"complaint_count": "SELECT NULL"})
 
+        qs = qs.extra(
+            select={
+                "eod_details_count": """
+                SELECT COUNT(legalaid_eoddetailscategory.id)
+                FROM legalaid_eoddetails
+                JOIN legalaid_eoddetailscategory ON legalaid_eoddetails.id = legalaid_eoddetailscategory.eod_details_id
+                WHERE legalaid_case.id = legalaid_eoddetails.case_id
+            """
+            }
+        )
+
         return qs
 
     def get_serializer_class(self):

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -101,6 +101,7 @@ from .forms import (
 )
 
 from .models import Operator
+from .utils.organisation import NoOrganisationCaseReassignmentMixin
 
 
 class CallCentrePermissionsViewSetMixin(object):
@@ -547,7 +548,7 @@ class AdaptationDetailsMetadataViewSet(CallCentrePermissionsViewSetMixin, BaseAd
     serializer_class = AdaptationDetailsSerializer
 
 
-class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, BaseEODDetailsViewSet):
+class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, NoOrganisationCaseReassignmentMixin, BaseEODDetailsViewSet):
 
     serializer_class = EODDetailsSerializer
 
@@ -555,6 +556,9 @@ class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, BaseEODDetailsViewSet
         permissions = super(EODDetailsViewSet, self).get_permissions()
         permissions.append(OperatorOrganisationCasePermission())
         return permissions
+
+    def get_case(self):
+        return self.object.case
 
 
 class EventViewSet(CallCentrePermissionsViewSetMixin, BaseEventViewSet):
@@ -664,7 +668,7 @@ class NotificationViewSet(CallCentrePermissionsViewSetMixin, BaseNotificationVie
     pass
 
 
-class ComplaintViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintViewSet):
+class ComplaintViewSet(CallCentrePermissionsViewSetMixin, NoOrganisationCaseReassignmentMixin, BaseComplaintViewSet):
     filter_backends = (DjangoFilterBackend, OrderingFilter, SearchFilter)
     filter_fields = ("justified", "level", "category", "owner", "created_by")
 
@@ -703,6 +707,9 @@ class ComplaintViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintViewSet):
         permissions = super(ComplaintViewSet, self).get_permissions()
         permissions.append(OperatorOrganisationComplaintPermission())
         return permissions
+
+    def get_case(self):
+        return self.object.eod.case
 
 
 class ComplaintCategoryViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintCategoryViewSet):

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -237,6 +237,8 @@ class CaseViewSet(CallCentrePermissionsViewSetMixin, mixins.CreateModelMixin, Ba
             }
         )
 
+        qs = qs.extra(select={"eod_details_editable": "SELECT NULL"})
+
         return qs
 
     def get_serializer_class(self):

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -62,7 +62,12 @@ from knowledgebase.views import BaseArticleViewSet, BaseArticleCategoryViewSet
 from diagnosis.views import BaseDiagnosisViewSet
 from guidance.views import BaseGuidanceNoteViewSet
 
-from .permissions import CallCentreClientIDPermission, OperatorManagerPermission, OperatorOrganisationPermission
+from .permissions import (
+    CallCentreClientIDPermission,
+    OperatorManagerPermission,
+    OperatorOrganisationCasePermission,
+    OperatorOrganisationComplaintPermission,
+)
 from .serializers import (
     EligibilityCheckSerializer,
     CaseSerializer,
@@ -551,7 +556,7 @@ class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, BaseEODDetailsViewSet
 
     def get_permissions(self):
         permissions = super(EODDetailsViewSet, self).get_permissions()
-        permissions.append(OperatorOrganisationPermission())
+        permissions.append(OperatorOrganisationCasePermission())
         return permissions
 
 
@@ -696,6 +701,11 @@ class ComplaintViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintViewSet):
         dashboard = self.request.QUERY_PARAMS.get("dashboard") == "True"
         show_closed = self.request.QUERY_PARAMS.get("show_closed") == "True"
         return super(ComplaintViewSet, self).get_queryset(dashboard=dashboard, show_closed=show_closed)
+
+    def get_permissions(self):
+        permissions = super(ComplaintViewSet, self).get_permissions()
+        permissions.append(OperatorOrganisationComplaintPermission())
+        return permissions
 
 
 class ComplaintCategoryViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintCategoryViewSet):

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -559,8 +559,11 @@ class EODDetailsViewSet(
         permissions.append(OperatorOrganisationCasePermission())
         return permissions
 
-    def get_case(self):
-        return self.object.case
+    def get_case(self, obj):
+        try:
+            return obj.case
+        except Case.DoesNotExist:
+            return None
 
 
 class EventViewSet(CallCentrePermissionsViewSetMixin, BaseEventViewSet):
@@ -730,8 +733,8 @@ class ComplaintViewSet(
         permissions.append(OperatorOrganisationComplaintPermission())
         return permissions
 
-    def get_case(self):
-        return self.object.eod.case
+    def get_case(self, obj):
+        return obj.eod.case
 
 
 class ComplaintCategoryViewSet(CallCentrePermissionsViewSetMixin, BaseComplaintCategoryViewSet):

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -87,7 +87,6 @@ from .serializers import (
     CSVUploadSerializer,
     CSVUploadDetailSerializer,
     EODDetailsSerializer,
-    EODDetailsSerializerReadyOnlySerializer,
 )
 
 from .forms import (
@@ -102,9 +101,6 @@ from .forms import (
 )
 
 from .models import Operator
-
-from .utils.organisation import case_organisation_matches_user_organisation
-from .utils.organisation.exceptions import OrganisationMatchException
 
 
 class CallCentrePermissionsViewSetMixin(object):
@@ -552,18 +548,6 @@ class AdaptationDetailsMetadataViewSet(CallCentrePermissionsViewSetMixin, BaseAd
 class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, BaseEODDetailsViewSet):
 
     serializer_class = EODDetailsSerializer
-    serializer_class_readonly = EODDetailsSerializerReadyOnlySerializer
-
-    def get_serializer_class(self):
-        serializer_class = super(EODDetailsViewSet, self).get_serializer_class()
-        case = get_object_or_404(Case, reference=self.kwargs.get("case_reference"))
-        try:
-            if not case_organisation_matches_user_organisation(case, self.request.user):
-                serializer_class = self.serializer_class_readonly
-        except OrganisationMatchException:
-            pass
-
-        return serializer_class
 
     def get_permissions(self):
         permissions = super(EODDetailsViewSet, self).get_permissions()

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -101,7 +101,7 @@ from .forms import (
 )
 
 from .models import Operator
-from .utils.organisation import NoOrganisationCaseReassignmentMixin
+from .utils.organisation import NoOrganisationCaseAssignCurrentOrganisationMixin
 
 
 class CallCentrePermissionsViewSetMixin(object):
@@ -548,7 +548,9 @@ class AdaptationDetailsMetadataViewSet(CallCentrePermissionsViewSetMixin, BaseAd
     serializer_class = AdaptationDetailsSerializer
 
 
-class EODDetailsViewSet(CallCentrePermissionsViewSetMixin, NoOrganisationCaseReassignmentMixin, BaseEODDetailsViewSet):
+class EODDetailsViewSet(
+    CallCentrePermissionsViewSetMixin, NoOrganisationCaseAssignCurrentOrganisationMixin, BaseEODDetailsViewSet
+):
 
     serializer_class = EODDetailsSerializer
 
@@ -686,7 +688,9 @@ class NotificationViewSet(CallCentrePermissionsViewSetMixin, BaseNotificationVie
     pass
 
 
-class ComplaintViewSet(CallCentrePermissionsViewSetMixin, NoOrganisationCaseReassignmentMixin, BaseComplaintViewSet):
+class ComplaintViewSet(
+    CallCentrePermissionsViewSetMixin, NoOrganisationCaseAssignCurrentOrganisationMixin, BaseComplaintViewSet
+):
     filter_backends = (DjangoFilterBackend, OrderingFilter, SearchFilter)
     filter_fields = ("justified", "level", "category", "owner", "created_by")
 

--- a/cla_backend/apps/complaints/serializers.py
+++ b/cla_backend/apps/complaints/serializers.py
@@ -6,7 +6,7 @@ from cla_eventlog.serializers import LogSerializerBase
 from core.fields import NullBooleanField
 from core.serializers import UUIDSerializer
 from .models import Category, Complaint
-from call_centre.utils.organisation.exceptions import OrganisationMatchException
+from call_centre.utils.organisation.exceptions import OrganisationMismatchException
 from call_centre.utils.organisation import case_organisation_matches_user_organisation
 
 
@@ -48,7 +48,7 @@ class ComplaintSerializerBase(serializers.ModelSerializer):
         user = self.context.get("request").user
         try:
             has_permission = case_organisation_matches_user_organisation(complaint.eod.case, user)
-        except OrganisationMatchException:
+        except OrganisationMismatchException:
             has_permission = True
 
         return has_permission

--- a/cla_backend/apps/complaints/serializers.py
+++ b/cla_backend/apps/complaints/serializers.py
@@ -37,14 +37,14 @@ class ComplaintSerializerBase(serializers.ModelSerializer):
     full_letter = serializers.DateTimeField(source="full_letter", read_only=True)
     out_of_sla = NullBooleanField(source="out_of_sla", read_only=True)
     holding_letter_out_of_sla = NullBooleanField(source="holding_letter_out_of_sla", read_only=True)
-    complaint_editable = serializers.BooleanField(source="complaint_editable", read_only=True)
+
+    is_editable = serializers.SerializerMethodField("is_complaint_editable")
 
     # # virtual fields on model
     status_label = serializers.CharField(source="status_label", read_only=True)
     requires_action_at = serializers.DateTimeField(source="requires_action_at", read_only=True)
 
-    # Make complaint_editable virtual field field reflect whether user can edit complaint
-    def transform_complaint_editable(self, complaint, value):
+    def is_complaint_editable(self, complaint):
         user = self.context.get("request").user
         try:
             has_permission = case_organisation_matches_user_organisation(complaint.eod.case, user)

--- a/cla_backend/apps/complaints/tests/test_complaints_api.py
+++ b/cla_backend/apps/complaints/tests/test_complaints_api.py
@@ -57,6 +57,7 @@ class ComplaintTestCase(ComplaintTestMixin, CLAOperatorAuthBaseApiTestMixin, Sim
             "out_of_sla",
             "holding_letter_out_of_sla",
             "requires_action_at",
+            "is_editable",
         ]
 
     def test_methods_not_allowed(self):

--- a/cla_backend/apps/complaints/views.py
+++ b/cla_backend/apps/complaints/views.py
@@ -108,6 +108,9 @@ class BaseComplaintViewSet(
                     )
                 ]
             )
+
+        # Make complaint_editable accessible in serializer
+        qs = qs.extra(select={"complaint_editable": "SELECT NULL"})
         return qs
 
     def pre_save(self, obj, *args, **kwargs):

--- a/cla_backend/apps/complaints/views.py
+++ b/cla_backend/apps/complaints/views.py
@@ -109,8 +109,6 @@ class BaseComplaintViewSet(
                 ]
             )
 
-        # Make complaint_editable accessible in serializer
-        qs = qs.extra(select={"complaint_editable": "SELECT NULL"})
         return qs
 
     def pre_save(self, obj, *args, **kwargs):

--- a/cla_backend/apps/legalaid/events.py
+++ b/cla_backend/apps/legalaid/events.py
@@ -66,6 +66,13 @@ class CaseEvent(BaseEvent):
             "description": "Case viewed",
             "stops_timer": False,
         },
+        "CASE_CREATED_BY_CHANGED": {
+            "type": LOG_TYPES.SYSTEM,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [],
+            "description": "Case creator changed",
+            "stops_timer": False,
+        },
         "COMPLAINT_FLAG_TOGGLED": {
             "type": LOG_TYPES.SYSTEM,
             "level": LOG_LEVELS.MINOR,

--- a/cla_backend/apps/legalaid/events.py
+++ b/cla_backend/apps/legalaid/events.py
@@ -66,11 +66,11 @@ class CaseEvent(BaseEvent):
             "description": "Case viewed",
             "stops_timer": False,
         },
-        "CASE_CREATED_BY_CHANGED": {
+        "CASE_ORGANISATION_SET": {
             "type": LOG_TYPES.SYSTEM,
             "level": LOG_LEVELS.HIGH,
             "selectable_by": [],
-            "description": "Case creator changed",
+            "description": "Case organisation set",
             "stops_timer": False,
         },
         "COMPLAINT_FLAG_TOGGLED": {

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -227,6 +227,12 @@ class EODDetailsCategorySerializerBase(serializers.ModelSerializer):
         fields = ("category", "is_major")
 
 
+class EODDetailsCategorySerializerReadyOnly(serializers.ModelSerializer):
+    class Meta(object):
+        model = EODDetailsCategory
+        fields = ("id",)
+
+
 class EODDetailsSerializerBase(serializers.ModelSerializer):
     notes = serializers.CharField(max_length=5000, required=False)
     categories = EODDetailsCategorySerializerBase(many=True, allow_add_remove=True, required=False)

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -227,12 +227,6 @@ class EODDetailsCategorySerializerBase(serializers.ModelSerializer):
         fields = ("category", "is_major")
 
 
-class EODDetailsCategorySerializerReadyOnly(serializers.ModelSerializer):
-    class Meta(object):
-        model = EODDetailsCategory
-        fields = ("id",)
-
-
 class EODDetailsSerializerBase(serializers.ModelSerializer):
     notes = serializers.CharField(max_length=5000, required=False)
     categories = EODDetailsCategorySerializerBase(many=True, allow_add_remove=True, required=False)

--- a/cla_backend/apps/legalaid/tests/views/mixins/case_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/case_api.py
@@ -65,6 +65,7 @@ class BaseFullCaseAPIMixin(SimpleResourceAPIMixin):
             "exempt_user_reason",
             "ecf_statement",
             "complaint_flag",
+            "eod_details_count",
         ]
 
     def assertPersonalDetailsEqual(self, data, obj):


### PR DESCRIPTION
## What does this pull request do?
Restrict adding, editing and viewing case Complaint/EOD to operators that are of the same organisation as the case creator

Allow operators of all organisation to see whether there are Complaint/EOD against a case

## Any other changes that would benefit highlighting?

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
