### PR TITLE
LGA-777 - Adding category of law filter to future callbacks view

### DIFF
--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -261,11 +261,15 @@ class CaseViewSet(CallCentrePermissionsViewSetMixin, mixins.CreateModelMixin, Ba
         """
         now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         in_7_days = now + datetime.timedelta(days=7)
+        category = request.QUERY_PARAMS.get("category")
         qs = (
             self.get_queryset()
             .filter(requires_action_at__gte=now, requires_action_at__lt=in_7_days)
             .order_by("requires_action_at")
         )
+        if category:
+            qs = qs.filter(diagnosis__category__code=category)
+
         self.object_list = self.filter_queryset(qs)
 
         serializer = self.get_serializer(self.object_list, many=True)


### PR DESCRIPTION
## What does this pull request do?

Adds category of law filter to future callbacks view

## Any other changes that would benefit highlighting?

As part of the dual run period operators need to be able to see callbacks for a specific category of law

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
