### PR TITLE
Re-enable missing logs

### DIFF
--- a/docker/supervisord-services.ini
+++ b/docker/supervisord-services.ini
@@ -1,16 +1,22 @@
 [program:nginx]
 command=/usr/sbin/nginx -c /etc/nginx/nginx.conf
-stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 
 [program:uwsgi]
 command=/usr/sbin/uwsgi --ini /home/app/django/docker/cla_backend.ini --die-on-term --log-master
-stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 
 [program:celery]
 command=celery -A cla_backend worker -l info -c 1 --logfile=/dev/stdout --pidfile=/var/run/celery/celery.pid
 directory=/home/app/django
 environment=DJANGO_SETTINGS_MODULE="cla_backend.settings"
-stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout
+stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0

--- a/docker/supervisord-services.ini
+++ b/docker/supervisord-services.ini
@@ -9,7 +9,7 @@ stdout_logfile=/dev/stdout # will only be effective if the program is also loggi
 stderr_logfile=/dev/stderr
 
 [program:celery]
-command=celery -A cla_backend worker -l info -c 1 --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid
+command=celery -A cla_backend worker -l info -c 1 --logfile=/dev/stdout --pidfile=/var/run/celery/celery.pid
 directory=/home/app/django
 environment=DJANGO_SETTINGS_MODULE="cla_backend.settings"
 stdout_logfile=/dev/stdout # will only be effective if the program is also logging to stdout

--- a/docker/supervisord-services.ini
+++ b/docker/supervisord-services.ini
@@ -1,22 +1,19 @@
 [program:nginx]
 command=/usr/sbin/nginx -c /etc/nginx/nginx.conf
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
-stderr_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:uwsgi]
 command=/usr/sbin/uwsgi --ini /home/app/django/docker/cla_backend.ini --die-on-term --log-master
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
-stderr_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:celery]
 command=celery -A cla_backend worker -l info -c 1 --logfile=/dev/stdout --pidfile=/var/run/celery/celery.pid
 directory=/home/app/django
 environment=DJANGO_SETTINGS_MODULE="cla_backend.settings"
 stdout_logfile=/dev/stdout
-stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
-stderr_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
## What does this pull request do?

Re-enables the (mistakenly) disabled logs of subprocesses started by the supervisor process control system.

Please review commit-by-commit for details.

## Context

Our `uwsgi-cron` logs have disappeared since 9 July:

![image](https://user-images.githubusercontent.com/1526295/65056992-cae04680-d969-11e9-8d08-25237f612404.png)

As it turns out, it was the first time #573 was deployed again to production (it was rolled back for some time). Unfortunately, the logs of our services were **disabled** with similar messages:

```
2019-09-13 07:33:35,150 CRIT uncaptured python exception, closing channel <POutputDispatcher at 140244011103440 for <Subprocess at 140244011290568 with name uwsgi in state STARTING> (stderr)> (<type 'exceptions.IOError'>:[Errno 29] Invalid seek [/usr/lib/python2.7/site-packages/supervisor/supervisord.py|runforever|221] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|handle_read_event|232] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|record_output|166] [/usr/lib/python2.7/site-packages/supervisor/dispatchers.py|_log|142] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|info|275] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|log|293] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|emit|186] [/usr/lib/python2.7/site-packages/supervisor/loggers.py|doRollover|211])
```

Meaningful bits:

```
uncaptured python exception, closing channel <...> name uwsgi <...> \
  exceptions.IOError'>:[Errno 29] Invalid seek
```

The logs are re-enabled by disabling log rotation to disable seeking in stdout.

## Any other changes that would benefit highlighting?

The Celery component will now also log to stdout :tada: 

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title" **Not applicable.**
