### PR TITLE
LGA-731: Callback window changes

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -226,6 +226,8 @@ class CaseSerializer(CaseSerializerFull):
     organisation_name = serializers.RelatedField(source="organisation", read_only=True)
     billable_time = serializers.IntegerField(read_only=True)
     rejected = serializers.SerializerMethodField("is_rejected")
+    callback_time_string = serializers.Field(source="callback_time_string")
+    callback_time_string_short = serializers.Field(source="callback_time_string_short")
 
     complaint_count = serializers.IntegerField(source="complaint_count", read_only=True)
 
@@ -275,6 +277,7 @@ class CaseSerializer(CaseSerializerFull):
             "ecf_statement",
             "case_count",
             "requires_action_at",
+            "callback_time_string",
             "callback_attempt",
             "source",
             "complaint_flag",
@@ -306,6 +309,7 @@ class CaseListSerializer(CaseSerializer):
             "case_count",
             "source",
             "requires_action_at",
+            "callback_time_string",
             "flagged_with_eod",
             "is_urgent",
             "organisation_name",

--- a/cla_backend/apps/call_centre/templates/call_centre/email/case_cb1_created.txt
+++ b/cla_backend/apps/call_centre/templates/call_centre/email/case_cb1_created.txt
@@ -9,6 +9,6 @@ Tel: {{ case.personal_details.mobile_phone }}
 {% endif %}
 Reference: {{ case.reference }}
 
-Time slot: {{ case.requires_action_at|date:"c" }}
+Time slot: {{ case.callback_time_string }}
 {% endfilter %}
 URL: {{ case_url }}

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -66,6 +66,7 @@ class BaseCaseTestCase(CLAOperatorAuthBaseApiTestMixin, BaseFullCaseAPIMixin, AP
             "outcome_code",
             "outcome_description",
             "requires_action_at",
+            "callback_time_string",
             "callback_attempt",
             "source",
             "complaint_flag",
@@ -857,8 +858,9 @@ class CallMeBackTestCase(ImplicitEventCodeViewTestCaseMixin, BaseCaseTestCase):
         return self._default_local_dt + datetime.timedelta(minutes=480)
 
     def get_expected_notes(self, data):
-        return "Callback scheduled for %s. %s" % (
+        return "Callback scheduled for %s - %s. %s" % (
             timezone.localtime(self._default_dt).strftime("%d/%m/%Y %H:%M"),
+            (timezone.localtime(self._default_dt) + datetime.timedelta(minutes=30)).strftime("%H:%M"),
             data["notes"],
         )
 

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -386,7 +386,12 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
         self.assertEqual(log.code, expected_outcome)
 
         self.assertEqual(
-            log.notes, "Callback scheduled for %s. lorem ipsum" % timezone.localtime(dt).strftime("%d/%m/%Y %H:%M")
+            log.notes,
+            "Callback scheduled for %s - %s. lorem ipsum"
+            % (
+                timezone.localtime(dt).strftime("%d/%m/%Y %H:%M"),
+                (timezone.localtime(dt) + datetime.timedelta(minutes=30)).strftime("%H:%M"),
+            ),
         )
         self.assertEqual(log.created_by, self.user)
         self.assertEqual(log.case, case)

--- a/cla_backend/apps/checker/serializers.py
+++ b/cla_backend/apps/checker/serializers.py
@@ -165,7 +165,7 @@ class CaseSerializer(CaseSerializerBase):
     personal_details = PersonalDetailsSerializer()
     thirdparty_details = ThirdPartyDetailsSerializer(required=False)
     requires_action_at = serializers.DateTimeField(required=False)
-    callback_window_type = serializers.ChoiceField(choices=CALLBACK_WINDOW_TYPES)
+    callback_window_type = serializers.ChoiceField(choices=CALLBACK_WINDOW_TYPES, required=False)
 
     class Meta(CaseSerializerBase.Meta):
         fields = (

--- a/cla_backend/apps/checker/serializers.py
+++ b/cla_backend/apps/checker/serializers.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from rest_framework import serializers
 
+from cla_common.constants import CALLBACK_WINDOW_TYPES
 from diagnosis.graph import get_graph
 from diagnosis.serializers import DiagnosisSerializer
 
@@ -164,6 +165,7 @@ class CaseSerializer(CaseSerializerBase):
     personal_details = PersonalDetailsSerializer()
     thirdparty_details = ThirdPartyDetailsSerializer(required=False)
     requires_action_at = serializers.DateTimeField(required=False)
+    callback_window_type = serializers.ChoiceField(choices=CALLBACK_WINDOW_TYPES)
 
     class Meta(CaseSerializerBase.Meta):
         fields = (
@@ -171,6 +173,7 @@ class CaseSerializer(CaseSerializerBase):
             "personal_details",
             "reference",
             "requires_action_at",
+            "callback_window_type",
             "adaptation_details",
             "thirdparty_details",
         )

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -31,6 +31,7 @@ class BaseCaseTestCase(CLACheckerAuthBaseApiTestMixin, SimpleResourceAPIMixin, A
                 "personal_details",
                 "reference",
                 "requires_action_at",
+                "callback_window_type",
                 "adaptation_details",
                 "thirdparty_details",
             ],

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -224,7 +224,11 @@ class CallMeBackCaseTestCase(BaseCaseTestCase):
 
         self.assertEqual(
             log.notes,
-            "Callback scheduled for %s. " % (timezone.localtime(self._default_dt).strftime("%d/%m/%Y %H:%M")),
+            "Callback scheduled for %s - %s. "
+            % (
+                timezone.localtime(self._default_dt).strftime("%d/%m/%Y %H:%M"),
+                (timezone.localtime(self._default_dt) + datetime.timedelta(minutes=30)).strftime("%H:%M"),
+            ),
         )
         _dt = timezone.localtime(self._default_dt)
         self.assertDictEqual(

--- a/cla_backend/apps/legalaid/admin.py
+++ b/cla_backend/apps/legalaid/admin.py
@@ -39,6 +39,20 @@ class CaseAdmin(admin.ModelAdmin):
         "adaptation_details",
         "from_case",
     )
+    readonly_fields = ("callback_window_type",)
+
+    def get_fields(self, request, obj=None, **kwargs):
+        fields = super(CaseAdmin, self).get_fields(request, obj, **kwargs)
+        fields = self.move_field_after("callback_window_type", "requires_action_at", fields)
+        return fields
+
+    @staticmethod
+    def move_field_after(field_to_move, target_field, fields):
+        if field_to_move in fields and target_field in fields:
+            field_to_move_index = fields.index(field_to_move)
+            target_field_index = fields.index(target_field)
+            fields.insert(target_field_index + 1, fields.pop(field_to_move_index))
+        return fields
 
 
 admin.site.register(Category, CategoryModelAdmin)

--- a/cla_backend/apps/legalaid/forms.py
+++ b/cla_backend/apps/legalaid/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.utils import timezone
 
 from cla_eventlog.forms import BaseCaseLogForm
@@ -24,8 +26,9 @@ class BaseCallMeBackForm(BaseCaseLogForm):
 
     def get_notes(self):
         dt = timezone.localtime(self.get_requires_action_at())
-        return u"Callback scheduled for {dt}. {notes}".format(
-            dt=dt.strftime("%d/%m/%Y %H:%M"), notes=self.cleaned_data["notes"] or ""
+        end = dt + datetime.timedelta(minutes=30)
+        return u"Callback scheduled for {start} - {end}. {notes}".format(
+            start=dt.strftime("%d/%m/%Y %H:%M"), end=end.strftime("%H:%M"), notes=self.cleaned_data["notes"] or ""
         )
 
     def save(self, user):

--- a/cla_backend/apps/legalaid/migrations/0022_case_callback_window_type.py
+++ b/cla_backend/apps/legalaid/migrations/0022_case_callback_window_type.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("legalaid", "0021_auto_20190515_1042")]
+
+    operations = [
+        migrations.AddField(
+            model_name="case",
+            name="callback_window_type",
+            field=models.CharField(
+                default=b"HALF_HOUR_EITHER_SIDE",
+                max_length=50,
+                editable=False,
+                choices=[
+                    (b"HALF_HOUR_EITHER_SIDE", b"Single time, with phone call up to 30 minutes before or after"),
+                    (b"HALF_HOUR_WINDOW", b"Half hour time slot"),
+                ],
+            ),
+            preserve_default=True,
+        )
+    ]

--- a/cla_backend/apps/legalaid/migrations/0023_case_callback_window_type.py
+++ b/cla_backend/apps/legalaid/migrations/0023_case_callback_window_type.py
@@ -6,7 +6,7 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [("legalaid", "0021_auto_20190515_1042")]
+    dependencies = [("legalaid", "0022_case_organisation")]
 
     operations = [
         migrations.AddField(

--- a/cla_backend/apps/legalaid/migrations/0024_default_to_half_hour_window.py
+++ b/cla_backend/apps/legalaid/migrations/0024_default_to_half_hour_window.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("legalaid", "0023_case_callback_window_type")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="case",
+            name="callback_window_type",
+            field=models.CharField(
+                default=b"HALF_HOUR_WINDOW",
+                max_length=50,
+                editable=False,
+                choices=[
+                    (b"HALF_HOUR_EITHER_SIDE", b"Single time, with phone call up to 30 minutes before or after"),
+                    (b"HALF_HOUR_WINDOW", b"Half hour time slot"),
+                ],
+            ),
+            preserve_default=True,
+        )
+    ]

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -654,7 +654,7 @@ class Case(TimeStampedModel, ModelDiffMixin):
     callback_window_type = models.CharField(
         max_length=50,
         choices=CALLBACK_WINDOW_TYPES.CHOICES,
-        default=CALLBACK_WINDOW_TYPES.HALF_HOUR_EITHER_SIDE,
+        default=CALLBACK_WINDOW_TYPES.HALF_HOUR_WINDOW,
         editable=False,
     )
     callback_attempt = models.PositiveSmallIntegerField(default=0)

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -41,6 +41,7 @@ from cla_common.constants import (
     ELIGIBILITY_REASONS,
     EXPRESSIONS_OF_DISSATISFACTION,
     RESEARCH_CONTACT_VIA,
+    CALLBACK_WINDOW_TYPES,
 )
 
 from legalaid.fields import MoneyField
@@ -649,6 +650,12 @@ class Case(TimeStampedModel, ModelDiffMixin):
     )
 
     requires_action_at = models.DateTimeField(auto_now=False, blank=True, null=True)
+    callback_window_type = models.CharField(
+        max_length=50,
+        choices=CALLBACK_WINDOW_TYPES.CHOICES,
+        default=CALLBACK_WINDOW_TYPES.HALF_HOUR_EITHER_SIDE,
+        editable=False,
+    )
     callback_attempt = models.PositiveSmallIntegerField(default=0)
 
     locked_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name="case_locked")

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -926,14 +926,16 @@ class Case(TimeStampedModel, ModelDiffMixin):
 
     def set_requires_action_at(self, requires_action_at):
         self.requires_action_at = requires_action_at
+        self.callback_window_type = self._meta.get_field("callback_window_type").default
         self.callback_attempt += 1
-        self.save(update_fields=["requires_action_at", "callback_attempt", "modified"])
+        self.save(update_fields=["requires_action_at", "callback_window_type", "callback_attempt", "modified"])
 
     def reset_requires_action_at(self):
         if self.requires_action_at is not None or self.callback_attempt != 0:
             self.requires_action_at = None
+            self.callback_window_type = self._meta.get_field("callback_window_type").default
             self.callback_attempt = 0
-            self.save(update_fields=["requires_action_at", "callback_attempt", "modified"])
+            self.save(update_fields=["requires_action_at", "callback_window_type", "callback_attempt", "modified"])
 
     @property
     def doesnt_requires_action(self):
@@ -950,7 +952,7 @@ class Case(TimeStampedModel, ModelDiffMixin):
     @property
     def callback_time_string(self):
         if not self.requires_action_at:
-            return ""
+            return None
         end_time = self.requires_action_at + datetime.timedelta(minutes=30)
         if self.callback_window_type == CALLBACK_WINDOW_TYPES.HALF_HOUR_WINDOW:
             return u"{start} - {end}".format(

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -1,6 +1,7 @@
 import logging
 import datetime
 import re
+from django.template.defaultfilters import date as date_filter
 from django.utils import timezone
 
 from jsonfield import JSONField
@@ -948,12 +949,15 @@ class Case(TimeStampedModel, ModelDiffMixin):
 
     @property
     def callback_time_string(self):
+        if not self.requires_action_at:
+            return ""
+        end_time = self.requires_action_at + datetime.timedelta(minutes=30)
         if self.callback_window_type == CALLBACK_WINDOW_TYPES.HALF_HOUR_WINDOW:
-            return u"{start:%a %b %d %Y %X} - {end:%X}".format(
-                start=self.requires_action_at, end=self.requires_action_at + datetime.timedelta(minutes=30)
+            return u"{start} - {end}".format(
+                start=date_filter(self.requires_action_at, "g:iA"), end=date_filter(end_time, "g:iA")
             )
         else:
-            return self.requires_action_at.strftime("%c")
+            return date_filter(self.requires_action_at, "g:iA")
 
 
 class CaseNotesHistory(TimeStampedModel):

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -946,6 +946,15 @@ class Case(TimeStampedModel, ModelDiffMixin):
     def requires_action_by_operator_manager(self):
         return self.requires_action_by == REQUIRES_ACTION_BY.OPERATOR_MANAGER
 
+    @property
+    def callback_time_string(self):
+        if self.callback_window_type == CALLBACK_WINDOW_TYPES.HALF_HOUR_WINDOW:
+            return u"{start:%a %b %d %Y %X} - {end:%X}".format(
+                start=self.requires_action_at, end=self.requires_action_at + datetime.timedelta(minutes=30)
+            )
+        else:
+            return self.requires_action_at.strftime("%c")
+
 
 class CaseNotesHistory(TimeStampedModel):
     case = models.ForeignKey(Case, db_index=True)

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.validators import MaxValueValidator
 from django.db import models
 from django.db.models import SET_NULL
-from django.utils.timezone import utc
+from django.utils.timezone import localtime, utc
 from django.core.exceptions import ObjectDoesNotExist
 
 from model_utils.models import TimeStampedModel
@@ -956,10 +956,11 @@ class Case(TimeStampedModel, ModelDiffMixin):
         end_time = self.requires_action_at + datetime.timedelta(minutes=30)
         if self.callback_window_type == CALLBACK_WINDOW_TYPES.HALF_HOUR_WINDOW:
             return u"{start} - {end}".format(
-                start=date_filter(self.requires_action_at, "g:iA"), end=date_filter(end_time, "g:iA")
+                start=date_filter(localtime(self.requires_action_at), "g:iA"),
+                end=date_filter(localtime(end_time), "g:iA"),
             )
         else:
-            return date_filter(self.requires_action_at, "g:iA")
+            return date_filter(localtime(self.requires_action_at), "g:iA")
 
 
 class CaseNotesHistory(TimeStampedModel):

--- a/cla_backend/apps/legalaid/tests/test_models.py
+++ b/cla_backend/apps/legalaid/tests/test_models.py
@@ -1370,6 +1370,7 @@ class SplitCaseTestCase(CloneModelsTestCaseMixin, TestCase):
             "source",
             "complaint_flag",
             "organisation",
+            "callback_window_type",
         ]
 
         if internal:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.3.0#egg=cla_common==0.3.0
+git+https://github.com/ministryofjustice/cla_common.git@0.3.1#egg=cla_common==0.3.1
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?
Allows storing of callback times with the meaning of either a single time with an implicit window around it, or an explicit half hour window. Then provides this in serializers and in a property that calculates the correct representation of the time for the callback.

## Any other changes that would benefit highlighting?
Accompanies changes to cla_backend and cla_public
Should be reviewed but not merged until we're ready to go live with the change

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
