### PR TITLE
LGA-850 - Make date range check work when clocks go back

### DIFF
--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -55,7 +55,7 @@ class DateRangeReportForm(ReportForm):
         if self.max_date_range and "date_from" in self.cleaned_data and "date_to" in self.cleaned_data:
             from_, to = self.date_range
             delta = to - from_
-            if delta > timedelta(days=self.max_date_range):
+            if delta > timedelta(days=self.max_date_range, hours=12):
                 raise forms.ValidationError(
                     "The date range (%s) should span "
                     "no more than %s working days" % (delta, str(self.max_date_range))

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -107,32 +107,36 @@ class ReportsDateRangeValidationWorks(TestCase):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 3, 29, 12)
-        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=4)})
+        start = datetime.datetime(2019, 3, 29, 12)  # GMT
+        end = datetime.datetime(2019, 4, 2, 12)  # BST
+        i = T(data={"date_from": start, "date_to": end})
         self.assertTrue(i.is_valid())
 
     def test_valid_date_range_clocks_going_back(self):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 10, 25, 12)
-        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=4)})
+        start = datetime.datetime(2019, 10, 25, 12)  # BST
+        end = datetime.datetime(2019, 10, 29, 12)  # GMT
+        i = T(data={"date_from": start, "date_to": end})
         self.assertTrue(i.is_valid())
 
     def test_invalid_date_range_clocks_going_forward(self):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 3, 29, 12)
-        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=5)})
+        start = datetime.datetime(2019, 3, 29, 12)  # GMT
+        end = datetime.datetime(2019, 4, 3, 12)  # BST
+        i = T(data={"date_from": start, "date_to": end})
         self.assertFalse(i.is_valid())
 
     def test_invalid_date_range_clocks_going_back(self):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 10, 25, 12)
-        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=5)})
+        start = datetime.datetime(2019, 10, 25, 12)  # BST
+        end = datetime.datetime(2019, 10, 30, 12)  # GMT
+        i = T(data={"date_from": start, "date_to": end})
         self.assertFalse(i.is_valid())
 
 

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -76,18 +76,64 @@ class ReportOrganisationColumnTestCase(TestCase):
 
 
 class ReportsDateRangeValidationWorks(TestCase):
-    def test_range_validation_works(self):
+    def test_valid_date_range(self):
+        class T(reports.forms.DateRangeReportForm):
+            max_date_range = 5
+
+        now = datetime.datetime.now()
+        i = T(data={"date_from": now - datetime.timedelta(days=4), "date_to": now})
+        self.assertTrue(i.is_valid())
+        self.assertEqual(i.errors.keys(), [])
+
+    def test_invalid_date_range(self):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
         now = datetime.datetime.now()
         i = T(data={"date_from": now - datetime.timedelta(days=5), "date_to": now})
         self.assertFalse(i.is_valid())
-        self.assertEqual(
-            i.errors, {u"__all__": [u"The date range (6 days, 0:00:00) should span no more than 5 working days"]}
+        self.assertEqual(i.errors.keys(), ["__all__"])
+        self.assertEqual(len(i.errors["__all__"]), 1)
+        self.assertIn(
+            i.errors[u"__all__"][0],
+            [
+                u"The date range (6 days, 0:00:00) should span no more than 5 working days",
+                u"The date range (6 days, 1:00:00) should span no more than 5 working days",
+                u"The date range (5 days, 23:00:00) should span no more than 5 working days",
+            ],
         )
-        i2 = T(data={"date_from": now - datetime.timedelta(days=1), "date_to": now})
-        self.assertTrue(i2.is_valid())
+
+    def test_valid_date_range_clocks_going_forward(self):
+        class T(reports.forms.DateRangeReportForm):
+            max_date_range = 5
+
+        start = datetime.datetime(2019, 3, 29, 12)
+        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=4)})
+        self.assertTrue(i.is_valid())
+
+    def test_valid_date_range_clocks_going_back(self):
+        class T(reports.forms.DateRangeReportForm):
+            max_date_range = 5
+
+        start = datetime.datetime(2019, 10, 25, 12)
+        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=4)})
+        self.assertTrue(i.is_valid())
+
+    def test_invalid_date_range_clocks_going_forward(self):
+        class T(reports.forms.DateRangeReportForm):
+            max_date_range = 5
+
+        start = datetime.datetime(2019, 3, 29, 12)
+        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=5)})
+        self.assertFalse(i.is_valid())
+
+    def test_invalid_date_range_clocks_going_back(self):
+        class T(reports.forms.DateRangeReportForm):
+            max_date_range = 5
+
+        start = datetime.datetime(2019, 10, 25, 12)
+        i = T(data={"date_from": start, "date_to": start + datetime.timedelta(days=5)})
+        self.assertFalse(i.is_valid())
 
 
 class MIDuplicateCasesTestCase(TestCase):

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -107,8 +107,8 @@ class ReportsDateRangeValidationWorks(TestCase):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 3, 29, 12)  # GMT
-        end = datetime.datetime(2019, 4, 2, 12)  # BST
+        start = datetime.datetime(2019, 3, 29)  # GMT
+        end = datetime.datetime(2019, 4, 2)  # BST
         i = T(data={"date_from": start, "date_to": end})
         self.assertTrue(i.is_valid())
 
@@ -116,8 +116,8 @@ class ReportsDateRangeValidationWorks(TestCase):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 10, 25, 12)  # BST
-        end = datetime.datetime(2019, 10, 29, 12)  # GMT
+        start = datetime.datetime(2019, 10, 25)  # BST
+        end = datetime.datetime(2019, 10, 29)  # GMT
         i = T(data={"date_from": start, "date_to": end})
         self.assertTrue(i.is_valid())
 
@@ -125,8 +125,8 @@ class ReportsDateRangeValidationWorks(TestCase):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 3, 29, 12)  # GMT
-        end = datetime.datetime(2019, 4, 3, 12)  # BST
+        start = datetime.datetime(2019, 3, 29)  # GMT
+        end = datetime.datetime(2019, 4, 3)  # BST
         i = T(data={"date_from": start, "date_to": end})
         self.assertFalse(i.is_valid())
 
@@ -134,8 +134,8 @@ class ReportsDateRangeValidationWorks(TestCase):
         class T(reports.forms.DateRangeReportForm):
             max_date_range = 5
 
-        start = datetime.datetime(2019, 10, 25, 12)  # BST
-        end = datetime.datetime(2019, 10, 30, 12)  # GMT
+        start = datetime.datetime(2019, 10, 25)  # BST
+        end = datetime.datetime(2019, 10, 30)  # GMT
         i = T(data={"date_from": start, "date_to": end})
         self.assertFalse(i.is_valid())
 


### PR DESCRIPTION
# What does this pull request do?
Fixes the date range check on the reports generation form when the date range crosses a date on which the clocks go back.
Adds some solid tests which always test the cases when the clocks go back or forward, rather than only testing the current dates, and which actually test the edges of the allowed date ranges.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
