### PR TITLE
LGA-876 - Remove NO_MESSAGE choice from safe_to_contact field choices

### DIFF
--- a/cla_backend/apps/legalaid/migrations/0026_safe_to_contact_remove_no_message.py
+++ b/cla_backend/apps/legalaid/migrations/0026_safe_to_contact_remove_no_message.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from cla_common.constants import CONTACT_SAFETY
+
+
+def migrate_no_message_to_safe_to_contact(apps, schema_editor):
+    PersonalDetails = apps.get_model("legalaid", "PersonalDetails")
+    PersonalDetails.objects.filter(safe_to_contact="NO_MESSAGE").update(safe_to_contact=CONTACT_SAFETY.SAFE)
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("legalaid", "0025_case_audit_log")]
+
+    operations = [
+        migrations.RunPython(migrate_no_message_to_safe_to_contact, noop),
+        migrations.AlterField(
+            model_name="personaldetails",
+            name="safe_to_contact",
+            field=models.CharField(
+                default=b"SAFE",
+                max_length=30,
+                null=True,
+                blank=True,
+                choices=[(b"SAFE", b"Safe to contact"), (b"DONT_CALL", b"Not safe to call")],
+            ),
+            preserve_default=True,
+        ),
+    ]

--- a/cla_backend/apps/legalaid/tests/test_migrations.py
+++ b/cla_backend/apps/legalaid/tests/test_migrations.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+import mock
+
+from cla_common.constants import CONTACT_SAFETY
+from core.tests.mommy_utils import make_recipe
+from legalaid.models import PersonalDetails
+import legalaid.migrations
+
+
+class NoMessageSafeToContactMigrationSetTestCase(TestCase):
+    def test_migrate_no_message_to_safe_to_contact(self):
+        personal_details_safe = make_recipe(
+            "legalaid.personal_details", safe_to_contact=CONTACT_SAFETY.SAFE, _quantity=2
+        )
+        personal_details_no_call = make_recipe(
+            "legalaid.personal_details", safe_to_contact=CONTACT_SAFETY.DONT_CALL, _quantity=2
+        )
+        personal_details_no_message = make_recipe(
+            "legalaid.personal_details", safe_to_contact="NO_MESSAGE", _quantity=3
+        )
+
+        __import__("legalaid.migrations.0026_safe_to_contact_remove_no_message")
+        migration = getattr(legalaid.migrations, "0026_safe_to_contact_remove_no_message")
+        apps_mock = mock.Mock()
+        apps_mock.get_model = mock.MagicMock(return_value=PersonalDetails)
+        migration.migrate_no_message_to_safe_to_contact(apps_mock, None)
+
+        personal_details = personal_details_safe + personal_details_no_message
+        for personal_detail in personal_details:
+            personal_detail = PersonalDetails.objects.get(pk=personal_detail.pk)
+            self.assertEqual(personal_detail.safe_to_contact, CONTACT_SAFETY.SAFE)
+
+        for personal_detail in personal_details_no_call:
+            personal_detail = PersonalDetails.objects.get(pk=personal_detail.pk)
+            self.assertEqual(personal_detail.safe_to_contact, CONTACT_SAFETY.DONT_CALL)
+
+        self.assertEqual(PersonalDetails.objects.filter(safe_to_contact="NO_MESSAGE").count(), 0)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.3.6#egg=cla_common==0.3.6
+git+https://github.com/ministryofjustice/cla_common.git@b7b64cc132a602796e71b8b0cebbe8d4137d4795#egg=cla_common==b7b64cc132a602796e71b8b0cebbe8d4137d4795
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

Remove NO_MESSAGE choice from safe_to_contact field choices
Migrate existing records with NO_MESSAGE to SAFE because CHS operators do not leave a message

### ONCE MIGRATION HAS HAPPENED IT IS NOT REVERSIBLE
## Requires updating cla_common to remove option from `CONTACT_SAFETY` constant
 
Requires https://github.com/ministryofjustice/cla_frontend/pull/669

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
