### PR TITLE
LGA-892- 2019 Christmas Eve / New Years Eve Reduced Operating Hours

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 source = cla_backend
-omit = *migrations*'
+omit =
+        *migrations*
+        settings/*

--- a/cla_backend/apps/call_centre/forms.py
+++ b/cla_backend/apps/call_centre/forms.py
@@ -1,14 +1,13 @@
 import datetime
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.forms.util import ErrorList
 from django.utils import timezone
 
 from cla_common.call_centre_availability import OpeningHours
-from cla_common.constants import GENDERS, ETHNICITIES, RELIGIONS, SEXUAL_ORIENTATIONS, DISABILITIES
+from cla_common.constants import GENDERS, ETHNICITIES, RELIGIONS, SEXUAL_ORIENTATIONS, DISABILITIES, OPERATOR_HOURS
 
 from knowledgebase.models import Article
 
@@ -22,7 +21,7 @@ from cla_provider.models import Provider
 from cla_provider.helpers import notify_case_RDSPed
 
 
-OPERATOR_HOURS = OpeningHours(**settings.OPERATOR_HOURS)
+operator_hours = OpeningHours(**OPERATOR_HOURS)
 
 
 class ProviderAllocationForm(BaseCaseLogForm):
@@ -209,7 +208,7 @@ class CallMeBackForm(BaseCallMeBackForm):
         if timezone.is_naive(_dt):
             _dt = timezone.make_aware(_dt, timezone.utc)
         _dt = timezone.localtime(_dt)
-        return _dt not in OPERATOR_HOURS
+        return _dt not in operator_hours
 
     def get_kwargs(self):
         kwargs = super(CallMeBackForm, self).get_kwargs()

--- a/cla_backend/apps/legalaid/tests/test_utils.py
+++ b/cla_backend/apps/legalaid/tests/test_utils.py
@@ -1,25 +1,27 @@
 from datetime import date, datetime, time
+import mock
 
 from django.test import TestCase
 from legalaid.utils.sla import is_in_business_hours, operator_hours
 
 
 class SlaCustomBusinessHoursTestCase(TestCase):
-    next_year = date.today().year + 1
+    year = 2019
 
-    xmas_eve = date(year=next_year, month=12, day=24)
+    xmas_eve = date(year=year, month=12, day=24)
     xmas_eve_before_hours = datetime.combine(xmas_eve, time(hour=8, minute=59))
     xmas_eve_noon = datetime.combine(xmas_eve, time(hour=12))
     xmas_eve_last_minute = datetime.combine(xmas_eve, time(hour=17, minute=29))
     xmas_eve_after_hours = datetime.combine(xmas_eve, time(hour=18))
 
-    new_years_eve = date(year=next_year, month=12, day=31)
+    new_years_eve = date(year=year, month=12, day=31)
     new_years_eve_before_hours = datetime.combine(new_years_eve, time(hour=8, minute=59))
     new_years_eve_noon = datetime.combine(new_years_eve, time(hour=12))
     new_years_eve_last_minute = datetime.combine(new_years_eve, time(hour=17, minute=29))
     new_years_eve_after_hours = datetime.combine(new_years_eve, time(hour=18))
 
-    def test_custom_business_hours(self):
+    @mock.patch("cla_common.call_centre_availability.current_datetime", return_value=datetime(year, 12, 24))
+    def test_custom_business_hours(self, current_datetime_mock):
         self.assertFalse(is_in_business_hours(self.xmas_eve_before_hours))
         self.assertTrue(is_in_business_hours(self.xmas_eve_noon))
         self.assertTrue(is_in_business_hours(self.xmas_eve_last_minute))
@@ -30,11 +32,12 @@ class SlaCustomBusinessHoursTestCase(TestCase):
         self.assertTrue(is_in_business_hours(self.new_years_eve_last_minute))
         self.assertFalse(is_in_business_hours(self.new_years_eve_after_hours))
 
-    def test_custom_day_timeslots(self):
+    @mock.patch("cla_common.call_centre_availability.current_datetime", return_value=datetime(year, 12, 24))
+    def test_custom_day_timeslots(self, current_datetime_mock):
         slots = operator_hours.time_slots(self.xmas_eve)
-        self.assertEquals(min(slots), datetime(self.next_year, 12, 24, 9, 0))
-        self.assertEquals(max(slots), datetime(self.next_year, 12, 24, 17, 0))
+        self.assertEquals(min(slots), datetime(self.year, 12, 24, 9, 0))
+        self.assertEquals(max(slots), datetime(self.year, 12, 24, 17, 30))
 
         slots = operator_hours.time_slots(self.new_years_eve)
-        self.assertEquals(min(slots), datetime(self.next_year, 12, 31, 9, 0))
-        self.assertEquals(max(slots), datetime(self.next_year, 12, 31, 17, 0))
+        self.assertEquals(min(slots), datetime(self.year, 12, 31, 9, 0))
+        self.assertEquals(max(slots), datetime(self.year, 12, 31, 17, 30))

--- a/cla_backend/apps/legalaid/utils/sla.py
+++ b/cla_backend/apps/legalaid/utils/sla.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from datetime import timedelta
 from django.utils import timezone
-from django.conf import settings
 
 from cla_common.call_centre_availability import (
     SLOT_INTERVAL_MINS,
@@ -10,9 +9,10 @@ from cla_common.call_centre_availability import (
     on_sunday,
     on_bank_holiday,
 )
+from cla_common.constants import OPERATOR_HOURS
 
 
-operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
+operator_hours = OpeningHours(**OPERATOR_HOURS)
 
 
 def is_in_business_hours(dt):

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -308,6 +308,8 @@ OPERATOR_HOURS = {
     "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
     "2018-12-24": (datetime.time(9, 0), datetime.time(17, 30)),
     "2018-12-31": (datetime.time(9, 0), datetime.time(17, 30)),
+    "2019-12-24": (datetime.time(9, 0), datetime.time(18, 00)),
+    "2019-12-31": (datetime.time(9, 0), datetime.time(18, 00)),
 }
 
 OBIEE_IP_PERMISSIONS = ("*",)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -3,6 +3,7 @@ import sys
 import os
 
 from cla_common.call_centre_availability import OpeningHours
+from cla_common.constants import OPERATOR_HOURS
 
 # PATH vars
 
@@ -302,15 +303,6 @@ CALL_CENTRE_NOTIFY_EMAIL_ADDRESS = os.environ.get("CALL_CENTRE_NOTIFY_EMAIL_ADDR
 NON_ROTA_HOURS = {"weekday": (datetime.time(8, 0), datetime.time(17, 0))}
 
 NON_ROTA_OPENING_HOURS = OpeningHours(**NON_ROTA_HOURS)
-
-OPERATOR_HOURS = {
-    "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
-    "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
-    "2018-12-24": (datetime.time(9, 0), datetime.time(17, 30)),
-    "2018-12-31": (datetime.time(9, 0), datetime.time(17, 30)),
-    "2019-12-24": (datetime.time(9, 0), datetime.time(18, 00)),
-    "2019-12-31": (datetime.time(9, 0), datetime.time(18, 00)),
-}
 
 OBIEE_IP_PERMISSIONS = ("*",)
 

--- a/cla_backend/settings/testing.py
+++ b/cla_backend/settings/testing.py
@@ -19,15 +19,6 @@ DATABASES["default"]["ENGINE"] = "cla_backend.apps.reports.db.backend"
 
 ALLOWED_HOSTS = ["*"]
 
-next_year = date.today().year + 1
-
-OPERATOR_HOURS = {
-    "weekday": (time(9, 0), time(20, 0)),
-    "saturday": (time(9, 0), time(12, 30)),
-    "{}-12-24".format(next_year): (time(9, 0), time(17, 30)),
-    "{}-12-31".format(next_year): (time(9, 0), time(17, 30)),
-}
-
 
 class DisableMigrations(object):
     def __contains__(self, item):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.3.1#egg=cla_common==0.3.1
+git+https://github.com/ministryofjustice/cla_common.git@befbfb34926c550c814382e14797581df016f962#egg=cla_common==0.3.5
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@befbfb34926c550c814382e14797581df016f962#egg=cla_common==0.3.5
+git+https://github.com/ministryofjustice/cla_common.git@0.3.6#egg=cla_common==0.3.6
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

Reduce callbacks to be booked between the hours of 9am-6pm on Christmas Eve New Years Eve 2019

Mock cla_common.call_centre_availability.current_datetime when running custom sla hours test during Christmas and New Years Eve

## Any other changes that would benefit highlighting?

Previously the legalaid.tests.test_utils.SlaCustomBusinessHoursTestCase tests were set to use dates in the future as the operating hours could not be in the past as of https://github.com/ministryofjustice/cla_backend/pull/494 (also https://github.com/ministryofjustice/cla_backend/pull/493#issuecomment-451196319)

The problem with having those dates in the future is you cannot test this year Christmas / New years eve opening hours.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
