### PR TITLE
Update bank holiday days to be closer to todays date

### DIFF
--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -58,7 +58,9 @@ class ProviderAllocationFormTestCase(TestCase):
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
     def test_save_out_office_hours_bank_holiday(self, timezone_mock, models_timezone_mock):
-        _mock_datetime_now_with(datetime.datetime(2014, 1, 1, 9, 1, 0), timezone_mock, models_timezone_mock)
+        _mock_datetime_now_with(
+            datetime.datetime(datetime.date.today().year, 1, 1, 9, 1, 0), timezone_mock, models_timezone_mock
+        )
 
         case = make_recipe("legalaid.case")
         category = case.eligibility_check.category
@@ -183,7 +185,9 @@ class ProviderAllocationFormTestCase(TestCase):
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
     def test_save_out_office_hours_no_valid_provider(self, timezone_mock, models_timezone_mock):
-        _mock_datetime_now_with(datetime.datetime(2014, 1, 1, 8, 59, 0), timezone_mock, models_timezone_mock)
+        _mock_datetime_now_with(
+            datetime.datetime(datetime.date.today().year, 1, 1, 8, 59, 0), timezone_mock, models_timezone_mock
+        )
 
         case = make_recipe("legalaid.case")
         category = case.eligibility_check.category


### PR DESCRIPTION
## What does this pull request do?

Update bank holiday to be closer to todays date

## Any other changes that would benefit highlighting?

2014 Bank holidays were removed from the bank holidays API https://github.com/alphagov/calendars/commit/c28e7b570c39a10f60d2ed13b85d477b9a60159e#diff-1569053def8d48383b565a3d2d505529

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
