### PR TITLE
Remove pushing images to Cloud Platforms ECR repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
     environment:
       DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
       DSD_DOCKER_IMAGE: "cla_backend"
-      ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
-      ECR_DOCKER_IMAGE: "laa-get-access/laa-cla-backend"
     steps:
       - checkout
       - setup_remote_docker:
@@ -21,13 +19,6 @@ jobs:
               --password $DOCKER_PASSWORD \
               --email "${DOCKER_USERNAME}@digital.justice.gov.uk" \
               $DSD_DOCKER_REGISTRY
-      - run:
-          name: Login to the ECR Docker registry
-          command: |
-            apk add --no-cache --no-progress py2-pip
-            pip install awscli
-            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
-            ${ecr_login}
       - run:
           name: Build Docker image
           command: |

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,5 +1,3 @@
 #!/bin/sh -e
 safe_git_branch=${CIRCLE_BRANCH//\//-}
 short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -14,10 +14,7 @@ function tag_and_push() {
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
-  tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
 fi
-tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
-tag_and_push "$ECR_DEPLOY_IMAGE"
 tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"


### PR DESCRIPTION
## What does this pull request do?

* Remove pushing images to Live-0 Cloud Platforms ECR repository

This project was pushing to old live-0 Cloud Platforms ECR repository which is no longer in use. Cloud platforms have removed all non-production namespaces on live-0 https://github.com/ministryofjustice/cloud-platform-environments/pull/1770

It seems the push to the ECR repository was added in anticipation of moving to kubernetes at the time. However the Cloud platforms environments have changed since the original work.

When this project does move to cloud platforms managed environment, the relevant repository can be added.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
- [x] Tested on staging
