### PR TITLE
Increment migration number to avoid conflict of migration files numbering

### DIFF
--- a/cla_backend/apps/legalaid/migrations/0027_update_education_matter_type1_descriptions.py
+++ b/cla_backend/apps/legalaid/migrations/0027_update_education_matter_type1_descriptions.py
@@ -22,6 +22,6 @@ def noop(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    dependencies = [("legalaid", "0025_case_audit_log")]
+    dependencies = [("legalaid", "0026_safe_to_contact_remove_no_message")]
 
     operations = [migrations.RunPython(matter_type1_updates, noop)]


### PR DESCRIPTION
## What does this pull request do?

Increment migration number to avoid conflict of migration files numbering.

The two files were developed in two branches and both started with 0026

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
