### PR TITLE
LGA-973 - Use Django cache to cache bank holidays lookups

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -4,6 +4,7 @@ import os
 
 from cla_common.call_centre_availability import OpeningHours
 from cla_common.constants import OPERATOR_HOURS
+from cla_common.services import CacheAdapter
 
 # PATH vars
 
@@ -351,6 +352,15 @@ CELERY_IMPORTS = ["reports.tasks", "notifications.tasks"]
 
 CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "True") == "True"
 PING_JSON_KEYS["CONTRACT_2018_ENABLED_key"] = "CONTRACT_2018_ENABLED"
+
+
+def bank_holidays_cache_adapter_factory():
+    from django.core.cache import cache
+
+    return cache
+
+
+CacheAdapter.set_adapter_factory(bank_holidays_cache_adapter_factory)
 
 # .local.py overrides all the common settings.
 try:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,8 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@b7b64cc132a602796e71b8b0cebbe8d4137d4795#egg=cla_common==b7b64cc132a602796e71b8b0cebbe8d4137d4795
+git+https://github.com/ministryofjustice/cla_common.git@a9af895a91aaa71b1b4df41e1761cd95baaadffe#egg=cla_common==0.3.6
+speaklater==1.3 # Required by cla_common
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

Use Django cache to cache bank holidays lookups
Requires https://github.com/ministryofjustice/cla_common/pull/91

## Any other changes that would benefit highlighting?

The dependency on django cache for caching bank holidays has been removed cla_common.call_centre_availability. Now the dependency must be satisfied through the CacheAdapter class

## Requires

https://github.com/ministryofjustice/cla_common/pull/91

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
