### PR TITLE
LGA-705 - Push images to ECR repository on Live-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     environment:
       DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
       DSD_DOCKER_IMAGE: "cla_backend"
+      ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
+      ECR_DOCKER_IMAGE: "laa-get-access/laa-cla-backend"
     steps:
       - checkout
       - setup_remote_docker:
@@ -19,6 +21,13 @@ jobs:
               --password $DOCKER_PASSWORD \
               --email "${DOCKER_USERNAME}@digital.justice.gov.uk" \
               $DSD_DOCKER_REGISTRY
+      - run:
+          name: Login to the ECR Docker registry
+          command: |
+            apk add --no-cache --no-progress py2-pip
+            pip install awscli
+            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ${ecr_login}
       - run:
           name: Build Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
     environment:
       DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
       DSD_DOCKER_IMAGE: "cla_backend"
-      ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
-      ECR_DOCKER_IMAGE: "laa-get-access/laa-cla-backend"
     steps:
       - checkout
       - setup_remote_docker:
@@ -26,7 +24,7 @@ jobs:
           command: |
             apk add --no-cache --no-progress py2-pip
             pip install awscli
-            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ecr_login="$(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
             ${ecr_login}
       - run:
           name: Build Docker image

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,3 +1,5 @@
 #!/bin/sh -e
 safe_git_branch=${CIRCLE_BRANCH//\//-}
 short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -14,7 +14,10 @@ function tag_and_push() {
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
+  tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
 fi
+tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
+tag_and_push "$ECR_DEPLOY_IMAGE"
 tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"


### PR DESCRIPTION
## What does this pull request do?

Reverts ministryofjustice/cla_backend#606
Update to push images to Live-1 ECR repo instead of Live-0
Removed hard coded values for ECR_DOCKER_REGISTRY, ECR_DOCKER_IMAGE and AWS_DEFAULT_REGION and moved values into environment variables

## Any other changes that would benefit highlighting?
https://github.com/ministryofjustice/cloud-platform-environments/pull/1937 (merged)

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"

