### PR TITLE
LGA-1046 - Reset the task last message at the start of task.run

### DIFF
--- a/cla_backend/apps/reports/tasks.py
+++ b/cla_backend/apps/reports/tasks.py
@@ -110,6 +110,9 @@ class OBIEEExportTask(ExportTaskBase):
         self.user = User.objects.get(pk=user_id)
         self._create_export()
         self._set_up_form(form_class_name, post_data)
+        # A task is not instantiated for every request. So unless we reset this message it will contain incorrect value
+        # https://docs.celeryproject.org/en/3.0/userguide/tasks.html#instantiation
+        self.message = ""
 
         diversity_keyphrase = self.form.cleaned_data["passphrase"]
         start = self.form.month

--- a/cla_backend/apps/reports/tests/test_tasks.py
+++ b/cla_backend/apps/reports/tests/test_tasks.py
@@ -1,0 +1,42 @@
+import mock
+import datetime
+import json
+from psycopg2 import InternalError
+from django.test import TestCase
+from reports.tasks import OBIEEExportTask
+from core.tests.mommy_utils import make_user, make_recipe
+from legalaid.utils.diversity import save_diversity_data
+
+
+class OBIEEExportTaskTestCase(TestCase):
+    def setUp(self):
+        self.personal_details = make_recipe("legalaid.personal_details")
+        save_diversity_data(self.personal_details.pk, {"test": "test"})
+
+        self.task = OBIEEExportTask()
+        self.task._create_export = mock.MagicMock()
+        self.task.send_to_s3 = mock.MagicMock()
+        self.user = make_user()
+
+    def run_task(self, passphrase):
+        today = datetime.datetime.today()
+        filename = "cla.database.zip"
+        post_data = {"action": "Export", "date_month": today.month, "date_year": today.year, "passphrase": passphrase}
+        post_data = json.dumps(post_data)
+        form_class_name = "MIOBIEEExportExtract"
+        self.task.run(user_id=self.user.id, form_class_name=form_class_name, post_data=post_data, filename=filename)
+
+    def test_bad_passphrase_message(self):
+        with self.assertRaisesMessage(InternalError, "Wrong key or corrupt data"):
+            self.run_task("badpass")
+        self.assertEqual("Check passphrase and try again", self.task.message)
+
+    def test_message_reset_per_run(self):
+        # Run task with an invalid passphrase
+        with self.assertRaisesMessage(InternalError, "Wrong key or corrupt data"):
+            self.run_task("badpass")
+        self.assertEqual("Check passphrase and try again", self.task.message)
+
+        # Run task with the correct passphrase
+        self.run_task("cla")
+        self.assertEqual("", self.task.message)


### PR DESCRIPTION
## What does this pull request do?

Reset the task last message at the start of task.run
Added `Check passphrase and try again` message when diversity passphrase is incorrect

## Any other changes that would benefit highlighting?

Currently the OBIEE extracts seem to failing with the error message `An error occurred creating the zip file` however the extract seems to be downloadable.

https://docs.celeryproject.org/en/3.0/userguide/tasks.html#instantiation states that:
> A task is not instantiated for every request, but is registered in the task registry as a global instance.

So this means that the same instance of the OBIEEExportTask is being used to handle multiple exports which means unless explicitly reset instance properties such as `message` retain their values through multiple exports.

The current issue is cause by when one export fails due to a legitimate error such as invalid passphrase, all subsequent successful exports will have the same message because `self.message` is only set when there is an error.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
