### PR TITLE
LGA-1238 - Make Case.exempt_user and Case.exempt_user_reason fields readonly

### DIFF
--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -347,6 +347,7 @@ class CaseSerializerBase(PartialUpdateExcludeReadonlySerializerMixin, ClaModelSe
         model = Case
         fields = ()
         exclude = ("audit_log",)
+        read_only_fields = ("exempt_user", "exempt_user_reason")
 
 
 class CaseSerializerFull(CaseSerializerBase):


### PR DESCRIPTION
## What does this pull request do?

Make Case.exempt_user and Case.exempt_user_reason fields readonly

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
