### PR TITLE
LGA-1373 make k8s epic branch deployable to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
                 - epic/LGA-959-kubernetes
       - deploy:
           name: staging_deploy
@@ -239,6 +238,7 @@ workflows:
           filters:
             branches:
               only:
+                - epic/LGA-959-kubernetes
                 - master
       - deploy:
           name: production_deploy
@@ -246,3 +246,4 @@ workflows:
           requires:
             - production_deploy_approval
           context: laa-cla-backend
+


### PR DESCRIPTION
## What does this pull request do?

Make epic/LGA-959-kubernetes branch deployable to production

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
