### PR TITLE
LGA-1368 migrate cron jobs

### DIFF
--- a/cla_backend/apps/cla_butler/management/commands/housekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/housekeeping.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from django.core.management.base import BaseCommand
 
-from cla_butler.stack import is_first_instance, InstanceNotInAsgException, StackException
 from cla_butler.tasks import DeleteOldData
 
 
@@ -13,20 +12,4 @@ class Command(BaseCommand):
         parser.add_argument("--force", action="store_true", dest="force", help="Force running of housekeeping task")
 
     def handle(self, *args, **options):
-        if self.should_run_housekeeping(**options):
-            DeleteOldData().run()
-        else:
-            self.stdout.write("Not doing housekeeping because running on secondary instance")
-
-    def should_run_housekeeping(self, **options):
-        if options.get("force", False):
-            return True
-
-        try:
-            return is_first_instance()
-        except InstanceNotInAsgException:
-            self.stderr.write("EC2 instance not in an ASG")
-            return True
-        except StackException:
-            self.stderr.write("Not running on EC2 instance")
-            return True
+        DeleteOldData().run()

--- a/cla_backend/apps/cla_butler/management/commands/housekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/housekeeping.py
@@ -12,4 +12,5 @@ class Command(BaseCommand):
         parser.add_argument("--force", action="store_true", dest="force", help="Force running of housekeeping task")
 
     def handle(self, *args, **options):
+        self.stdout.write("Deleting public diagnosis that are more than a day old")
         DeleteOldData().run()

--- a/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
+++ b/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
@@ -16,6 +16,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
+        self.stdout.write("Checking for missing outcome codes")
         self.check_for_missing_outcome_codes()
 
     @staticmethod

--- a/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
+++ b/cla_backend/apps/cla_butler/management/commands/monitor_missing_outcome_codes.py
@@ -2,8 +2,6 @@
 import logging
 from django.core.management.base import BaseCommand
 
-from cla_butler.stack import is_first_instance, InstanceNotInAsgException, StackException
-
 from cla_eventlog.constants import LOG_LEVELS, LOG_TYPES
 from cla_eventlog.models import Log
 from legalaid.models import Case
@@ -18,10 +16,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        if self.should_run_housekeeping(**options):
-            self.check_for_missing_outcome_codes()
-        else:
-            logger.info("Skip check_for_missing_outcome_codes because running on secondary instance")
+        self.check_for_missing_outcome_codes()
 
     @staticmethod
     def check_for_missing_outcome_codes():
@@ -39,16 +34,3 @@ class Command(BaseCommand):
             )
         else:
             logger.info("LGA-275 No cases found missing denormalized outcome codes")
-
-    @staticmethod
-    def should_run_housekeeping(**options):
-        if options.get("force", False):
-            return True
-        try:
-            return is_first_instance()
-        except InstanceNotInAsgException:
-            logger.info("EC2 instance not in an ASG")
-            return True
-        except StackException:
-            logger.info("Not running on EC2 instance")
-            return True

--- a/cla_backend/apps/cla_butler/management/commands/monitor_multiple_outcome_codes.py
+++ b/cla_backend/apps/cla_butler/management/commands/monitor_multiple_outcome_codes.py
@@ -3,7 +3,6 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db.models import Count, Max, Min
 from django.utils.timezone import now
-from cla_butler.stack import is_first_instance, InstanceNotInAsgException, StackException
 from cla_eventlog.models import Log
 
 logger = logging.getLogger(__name__)
@@ -16,10 +15,8 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        if self.should_run_housekeeping(**options):
-            self.check_for_multiple_outcome_codes()
-        else:
-            logger.debug("LGA-294 Skip check_for_multiple_outcome_codes: running on secondary instance")
+        logger.error("Running monitor_multiple_outcome_codes cron job")
+        self.check_for_multiple_outcome_codes()
 
     @staticmethod
     def check_for_multiple_outcome_codes():
@@ -68,16 +65,3 @@ class Command(BaseCommand):
                 logger.warning("LGA-294 investigation. Multiple outcome codes today for case: {}".format(i))
         else:
             logger.info("LGA-294 No multiple outcome codes found for today")
-
-    @staticmethod
-    def should_run_housekeeping(**options):
-        if options.get("force", False):
-            return True
-        try:
-            return is_first_instance()
-        except InstanceNotInAsgException:
-            logger.info("EC2 instance not in an ASG")
-            return True
-        except StackException:
-            logger.info("Not running on EC2 instance")
-            return True

--- a/cla_backend/apps/cla_butler/management/commands/monitor_multiple_outcome_codes.py
+++ b/cla_backend/apps/cla_butler/management/commands/monitor_multiple_outcome_codes.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        logger.error("Running monitor_multiple_outcome_codes cron job")
+        self.stdout.write("Checking for multiple outcome codes")
         self.check_for_multiple_outcome_codes()
 
     @staticmethod

--- a/cla_backend/apps/cla_butler/management/commands/reverthousekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/reverthousekeeping.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import os
-import logging
+
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.core.management.base import BaseCommand
@@ -52,8 +52,6 @@ MODELS = [
     LogEntry,
 ]
 
-logger = logging.getLogger("django")
-
 
 class Command(BaseCommand):
 
@@ -63,7 +61,6 @@ class Command(BaseCommand):
         parser.add_argument("directory", nargs=1)
 
     def handle(self, *args, **options):
-        logger.info("Running monitor_multiple_outcome_codes cron job")
         path = os.path.join(settings.TEMP_DIR, args[0])
         filewriter = QuerysetToFile(path)
 

--- a/cla_backend/apps/cla_butler/management/commands/reverthousekeeping.py
+++ b/cla_backend/apps/cla_butler/management/commands/reverthousekeeping.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import os
-
+import logging
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.core.management.base import BaseCommand
@@ -52,6 +52,8 @@ MODELS = [
     LogEntry,
 ]
 
+logger = logging.getLogger("django")
+
 
 class Command(BaseCommand):
 
@@ -61,6 +63,7 @@ class Command(BaseCommand):
         parser.add_argument("directory", nargs=1)
 
     def handle(self, *args, **options):
+        logger.info("Running monitor_multiple_outcome_codes cron job")
         path = os.path.join(settings.TEMP_DIR, args[0])
         filewriter = QuerysetToFile(path)
 

--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -14,9 +14,3 @@ harakiri=20
 logger-req=stdio
 logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(method)", "uri": "%(uri)", "proto": "%(proto)", "status": %(status), "referer": "%(referer)", "user_agent": "%(uagent)", "remote_addr": "%(addr)", "http_host": "%(host)", "pid": %(pid), "worker_id": %(wid), "core": %(core), "async_switches": %(switches), "io_errors": %(ioerr), "rq_size": %(cl), "rs_time_ms": %(msecs), "rs_size": %(size), "rs_header_size": %(hsize), "rs_header_count": %(headers)}
 post-buffering=1
-
-# Cronjobs moved here inside container for logging compatibility
-# https://github.com/ministryofjustice/cla_backend-deploy/commit/5f81cde78924bbf2dc554b23240c619dcfebd8f2
-# cron2=minute=0,hour=5,unique=1 python /home/app/django/manage.py housekeeping
-# cron2=minute=15,hour=2,unique=1,harakiri=30 python /home/app/django/manage.py monitor_missing_outcome_codes
-# cron2=minute=-15,unique=1,harakiri=30 python /home/app/django/manage.py monitor_multiple_outcome_codes

--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: house-keeping
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "0 5 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: housekeeping
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["python", "manage.py", "housekeeping"]
+            env:
+              {{ include "cla-backend.app.vars" . | nindent 12 }}
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: monitor-missing-outcome-codes
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "15 2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: housekeeping
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["python", "manage.py", "monitor_missing_outcome_codes"]
+            env:
+              {{ include "cla-backend.app.vars" . | nindent 12 }}
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: monitor-multiple-outcome-codes
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: housekeeping
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["python", "manage.py", "monitor_multiple_outcome_codes"]
+            env:
+              {{ include "cla-backend.app.vars" . | nindent 12 }}
+          restartPolicy: OnFailure

--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -31,7 +31,7 @@ spec:
       template:
         spec:
           containers:
-          - name: housekeeping
+          - name: monitor-missing-outcome-codes
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             command: ["python", "manage.py", "monitor_missing_outcome_codes"]
             env:
@@ -51,7 +51,7 @@ spec:
       template:
         spec:
           containers:
-          - name: housekeeping
+          - name: monitor-multiple-outcome-codes
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             command: ["python", "manage.py", "monitor_multiple_outcome_codes"]
             env:


### PR DESCRIPTION
## What does this pull request do?

Move cronjobs from running inside of the uswgi process to Kubernetes cronjobs
Removed checking of EC2 instance inside cla_butler management commands

## Any other changes that would benefit highlighting?

There were additional checks being done to stop the cla_butler management commands running on the second EC2 instance. These checks have now been removed because we are no longer using EC2 and concurrency of the process running these jobs now is set to 1 and controlled (it's not running inside multiple uwsgi process)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
