### PR TITLE
LGA-1385 - Use PRODUCTION_HOST circle env var

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -11,7 +11,7 @@ export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
 
 case $NAMESPACE in
   production)
-      export NAMESPACE_HOST="${PRODUCTION_HOST_DEFAULT}"
+      export NAMESPACE_HOST="${PRODUCTION_HOST}"
       ;;
   uat)
       export NAMESPACE_HOST="${UAT_HOST}"


### PR DESCRIPTION
## What does this pull request do?

Use PRODUCTION_HOST circle env var that contains the production fox admin domain

## Any other changes that would benefit highlighting?

This should be merged just before switching to the kubernetes application

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
