### PR TITLE
LGA-1370 - Create fox admin ingress

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -11,7 +11,7 @@ export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
 
 case $NAMESPACE in
   production)
-      export NAMESPACE_HOST="${PRODUCTION_HOST_DEFAULT}"
+      export NAMESPACE_HOST="${PRODUCTION_HOST}"
       ;;
   uat)
       export NAMESPACE_HOST="${UAT_HOST}"

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --set fullnameOverride=$RELEASE_NAME \
   --set host=$RELEASE_HOST \
+  --set secretName=tls-certificate
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --install

--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -20,13 +20,8 @@ spec:
   tls:
     - hosts:
        - "{{ .Values.host }}"
-      {{- if .Values.ingress.tls }}
-      {{- range .Values.ingress.tls }}
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-      {{- end }}
+      {{- if .Values.tlsSecretName }}
+      secretName: {{ .Values.tlsSecretName }}
       {{- end }}
   rules:
     - host: "{{ .Values.host }}"

--- a/helm_deploy/cla-backend/values-staging.yaml
+++ b/helm_deploy/cla-backend/values-staging.yaml
@@ -13,10 +13,6 @@ ingress:
   hosts:
     - host: laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
       paths: ['/']
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -13,10 +13,6 @@ ingress:
   hosts:
     - host: laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk
       paths: ['/']
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -74,16 +74,6 @@ ingress:
     - 185.38.246.208/32
     - 185.91.131.4/32
 
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  # hosts:
-    # - host: chart-example.local
-      # paths: []
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
 localPostgres:
   enabled: false
 


### PR DESCRIPTION
## What does this pull request do?

- Use PRODUCTION_HOST circle env var that contains the production fox admin domain
- Add secret name that contains the tls secret for the fox admin domain
- Removed unused .Values.ingress.tls config

## Any other changes that would benefit highlighting?

This should be merged just before switching to the kubernetes application

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
