### PR TITLE
LGA-1350 - Allocation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+test-reports
 
 # Translations
 *.mo

--- a/cla_backend/apps/cla_provider/tests/test_helpers.py
+++ b/cla_backend/apps/cla_provider/tests/test_helpers.py
@@ -10,7 +10,6 @@ import mock
 from cla_provider.models import ProviderAllocation
 from legalaid.models import Case
 
-from unittest import skip
 from core.tests.mommy_utils import make_recipe
 
 from cla_provider.helpers import ProviderAllocationHelper, ProviderDistributionHelper
@@ -235,8 +234,14 @@ class ProviderAllocationHelperTestCase(TestCase):
                 "Expected: %s, Got: %s  - not within allowed accuracy: %s" % (expected, n, accuracy)
             )
 
-    @skip("because test is flaky... waiting for Python dev to fix")
-    def test_even_allocation(self):
+    # Running this test out side of the hours defined in settings.NON_ROTA_OPENING_HOURS causes the test to fail because
+    # Case.assign_to_provider uses cla_common.call_centre_availability.OpeningHours.available to determine if the
+    # current time is within settings.NON_ROTA_OPENING_HOURS
+    #
+    # This @mock.patch ensures that all settings.NON_ROTA_OPENING_HOURS checks always return True. This should not
+    # impact the test logic as this test is only checking provider allocation distribution
+    @mock.patch("cla_common.call_centre_availability.OpeningHours.available", return_value=True)
+    def test_even_distribution(self, mock_openinghours_available):
         # Test the distribution of cases to {accuracy} accuracy over {total} cases
         total = 8000
         accuracy = Decimal("0.001")

--- a/cla_backend/apps/cla_provider/tests/test_helpers.py
+++ b/cla_backend/apps/cla_provider/tests/test_helpers.py
@@ -244,7 +244,7 @@ class ProviderAllocationHelperTestCase(TestCase):
     @mock.patch("cla_common.call_centre_availability.OpeningHours.available", return_value=True)
     def test_even_distribution(self, mock_openinghours_available):
         # Test the distribution of cases to {accuracy} accuracy over {total} cases
-        total = 8000
+        total = 80
         accuracy = Decimal("0.001")
         with mock.patch(
             "cla_common.call_centre_availability.current_datetime", datetime.datetime(2015, 7, 7, 11, 59, 0)
@@ -285,10 +285,10 @@ class ProviderAllocationHelperTestCase(TestCase):
 
             self.assertEqual(Case.objects.all().count(), total)
 
-            self.assertWithinAllowedAccuracy(5000, accuracy, provider1.case_set.count())
-            self.assertWithinAllowedAccuracy(1000, accuracy, provider2.case_set.count())
-            self.assertWithinAllowedAccuracy(1000, accuracy, provider3.case_set.count())
-            self.assertWithinAllowedAccuracy(1000, accuracy, provider4.case_set.count())
+            self.assertWithinAllowedAccuracy(50, accuracy, provider1.case_set.count())
+            self.assertWithinAllowedAccuracy(10, accuracy, provider2.case_set.count())
+            self.assertWithinAllowedAccuracy(10, accuracy, provider3.case_set.count())
+            self.assertWithinAllowedAccuracy(10, accuracy, provider4.case_set.count())
 
     # Running this test out side of the hours defined in settings.NON_ROTA_OPENING_HOURS causes the test to fail because
     # Case.assign_to_provider uses cla_common.call_centre_availability.OpeningHours.available to determine if the

--- a/cla_backend/settings/testing.py
+++ b/cla_backend/settings/testing.py
@@ -19,6 +19,8 @@ DATABASES["default"]["ENGINE"] = "cla_backend.apps.reports.db.backend"
 
 ALLOWED_HOSTS = ["*"]
 
+TEST_OUTPUT_DIR = "test-reports"
+
 
 class DisableMigrations(object):
     def __contains__(self, item):


### PR DESCRIPTION
## What does this pull request do?
Adds tests to demonstrate the allocation process across days (where currently only cases from the same day are taken into account). Skips the test that would require this to be changed.

## Any other changes that would benefit highlighting?
Follows @said-moj's fix of other tests in order to get a previous test working, and reduces its volume from 8000 cases to 80 for practicality and because there's no reason to have so many.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
