### PR TITLE
LGA-1383 - Remove call back scheduling delay

### DIFF
--- a/cla_backend/apps/call_centre/forms.py
+++ b/cla_backend/apps/call_centre/forms.py
@@ -201,7 +201,7 @@ class CallMeBackForm(BaseCallMeBackForm):
     priority_callback = forms.BooleanField(required=False)
 
     def _is_dt_too_soon(self, dt):
-        return dt <= timezone.now() + datetime.timedelta(minutes=30)
+        return dt <= timezone.now() - datetime.timedelta(minutes=30)
 
     def _is_dt_out_of_hours(self, dt):
         _dt = dt

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -500,7 +500,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
         _test(case, self._strftime(now_utc + datetime.timedelta(minutes=180)))
 
         # datetime in the current 30 minute window
-        _test(case, self._strftime(now_utc - datetime.timedelta(minutes=14)))
+        _test(case, self._strftime(now_utc + datetime.timedelta(minutes=-14)))
 
     def test_CB4_not_allowed(self):
         case = make_recipe("legalaid.case", callback_attempt=3)


### PR DESCRIPTION
## What does this pull request do?
Allows callbacks to be scheduled in the current and next callback windows, in addition to all future windows as normal.

## Any other changes that would benefit highlighting?

Requires corresponding frontend change in order to provide its benefit. cla_public already enforces stricter rules than this (it doesn't allow callbacks within 2 hours), so its behaviour won't be affected.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
