### PR TITLE
LGA-1396 - Fix allocations across days

### DIFF
--- a/cla_backend/apps/cla_provider/helpers.py
+++ b/cla_backend/apps/cla_provider/helpers.py
@@ -30,7 +30,6 @@ class ProviderDistributionHelper(object):
             .filter(assigned_out_of_hours=False)
             .exclude(log__code="MANREF")
             .exclude(provider=None)
-            .filter(provider_assigned_at__gte=self.date)
         )
 
         if last_update and last_update.modified > self.date:

--- a/cla_backend/apps/cla_provider/tests/test_helpers.py
+++ b/cla_backend/apps/cla_provider/tests/test_helpers.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import datetime
 from decimal import Decimal
 from cla_common.call_centre_availability import on_bank_holiday
-from unittest import skip
 
 from django.test import TestCase
 from django.utils import timezone
@@ -455,7 +454,6 @@ class ProviderAllocationHelperTestCase(TestCase):
         self.assertEqual(provider1.case_set.count(), 75)
         self.assertEqual(provider2.case_set.count(), 25)
 
-    @skip("Allocation only considers the distribution from the same day")
     @mock.patch("cla_common.call_centre_availability.OpeningHours.available", return_value=True)
     def test_allocation_with_low_volume_per_day(self, mock_openinghours_available):
         base_datetime = timezone.make_aware(


### PR DESCRIPTION
## What does this pull request do?
Removes the constraint that only considers the current day when deciding whether to balance up the allocations or allocate randomly.
There is already a constraint in there to limit it to allocations since the weightings were changed.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
