### PR TITLE
LGA-1424 - Update cla_common

### DIFF
--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -855,7 +855,7 @@ class CallMeBackTestCase(ImplicitEventCodeViewTestCaseMixin, BaseCaseTestCase):
 
     @property
     def _default_local_dt_sla_480(self):
-        return self._default_local_dt + datetime.timedelta(days=1)
+        return self._default_local_dt + datetime.timedelta(hours=8)
 
     def get_expected_notes(self, data):
         return "Callback scheduled for %s - %s. %s" % (

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -412,7 +412,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
             {
                 "requires_action_at": _dt.isoformat(),
                 "sla_120": (_dt + datetime.timedelta(minutes=120)).isoformat(),
-                "sla_480": (_dt + datetime.timedelta(days=1)).isoformat(),
+                "sla_480": (_dt + datetime.timedelta(hours=8)).isoformat(),
                 "sla_15": (_dt + datetime.timedelta(minutes=15)).isoformat(),
                 "sla_30": (_dt + datetime.timedelta(minutes=30)).isoformat(),
             },

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -242,7 +242,7 @@ class CallMeBackCaseTestCase(BaseCaseTestCase):
             {
                 "requires_action_at": _dt.isoformat(),
                 "sla_120": (_dt + datetime.timedelta(minutes=120)).isoformat(),
-                "sla_480": (_dt + datetime.timedelta(days=1)).isoformat(),
+                "sla_480": (_dt + datetime.timedelta(hours=8)).isoformat(),
                 "sla_15": (_dt + datetime.timedelta(minutes=15)).isoformat(),
                 "sla_30": (_dt + datetime.timedelta(minutes=30)).isoformat(),
             },

--- a/cla_backend/apps/legalaid/tests/test_helpers.py
+++ b/cla_backend/apps/legalaid/tests/test_helpers.py
@@ -16,6 +16,7 @@ from legalaid.forms import get_sla_time
 
 class SLATimeHelperTestCase(TestCase):
 
+    sunday = 0
     monday = 1
     saturday = 6
     tz = timezone.get_default_timezone()
@@ -71,11 +72,11 @@ class SLATimeHelperTestCase(TestCase):
 
             self.assertTrue(bank_hol.called)
 
-    def test_get_sla_time_adding_time_on_saturday_rolls_over_to_next_working_day(self):
+    def test_get_sla_time_adding_time_on_sunday_rolls_over_to_next_working_day(self):
         with mock.patch("cla_common.call_centre_availability.bank_holidays", return_value=[]) as bank_hol:
-            saturday = self._datetime(iso_day_of_week=self.saturday, hour=12, minute=0)
-            next_monday = self._change(saturday, plus_days=2, hour=9, minute=15)
-            self.assertEqual(get_sla_time(saturday, 15), next_monday)
+            sunday = self._datetime(iso_day_of_week=self.sunday, hour=12, minute=0)
+            next_monday = self._change(sunday, plus_days=1, hour=9, minute=15)
+            self.assertEqual(get_sla_time(sunday, 15), next_monday)
             self.assertTrue(bank_hol.called)
 
     def test_get_sla_time_adding_time_before_bank_holiday_rolls_over_to_working_day_after_holiday(self):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.3.9#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@0.3.10#egg=cla_common
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?
cla_common has been updated with [new operator hours](https://github.com/ministryofjustice/cla_common/pull/98)
This PR updates cla_backend to use that version of the library, and thus the new hours. It should not be merged until we're ready to deploy this behavioural change.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
