### PR TITLE
LGA-1432 - Add pingdom dynamic IP address to whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,8 @@ jobs:
           name: Deploy to << parameters.namespace >>
           command: |
             source .circleci/define_build_environment_variables << parameters.namespace >>
-            export PINGDOM_IPS=`python bin/pingdom_ips.py`
+            pip3 install requests
+            export PINGDOM_IPS=`python3 bin/pingdom_ips.py`
             ./bin/<< parameters.namespace >>_deploy.sh
             echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
       - slack/notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
           name: Deploy to << parameters.namespace >>
           command: |
             source .circleci/define_build_environment_variables << parameters.namespace >>
+            export PINGDOM_IPS=`python bin/pingdom_ips.py`
             ./bin/<< parameters.namespace >>_deploy.sh
             echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
       - slack/notify:

--- a/bin/local_deploy.sh
+++ b/bin/local_deploy.sh
@@ -9,6 +9,7 @@ docker build -t cla_backend_local "$ROOT/../"
 helm upgrade cla-backend \
   $HELM_DIR \
   --values ${HELM_DIR}/values-dev.yaml \
+  --set-string pingdomIPs=$PINGDOM_IPS \
   --install \
   --force \
   --debug

--- a/bin/pingdom_ips.py
+++ b/bin/pingdom_ips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import re
 import requests
 import sys

--- a/bin/pingdom_ips.py
+++ b/bin/pingdom_ips.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python2
+import re
+import requests
+import sys
+
+
+def get_pingdom_probe_ips():
+    ip_list = []
+    pingdom_link = "https://my.pingdom.com/probes/ipv4"
+    pingdom_ips = requests.get(pingdom_link).text.split()
+    parsed_pingdom_ip_list = ["".join([ip.strip(), "/32"]) for ip in pingdom_ips]
+    regex = r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}/32$"
+
+    for ip in parsed_pingdom_ip_list:
+        if re.match(regex, ip) is not None:
+            ip_list.append(ip)
+    return ip_list
+
+
+if __name__ == "__main__":
+    ips = r"\,".join(get_pingdom_probe_ips())
+    sys.stdout.write(ips)

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -12,4 +12,5 @@ helm upgrade $RELEASE_NAME \
   --set secretName=tls-certificate \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
+  --set-string pingdomIPs=$PINGDOM_IPS \
   --install

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -12,4 +12,5 @@ helm upgrade $RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
+  --set-string pingdomIPs=$PINGDOM_IPS \
   --install

--- a/bin/uat_deploy.sh
+++ b/bin/uat_deploy.sh
@@ -12,4 +12,5 @@ helm upgrade $RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
+  --set-string pingdomIPs=$PINGDOM_IPS \
   --install

--- a/helm_deploy/cla-backend/templates/_helpers.tpl
+++ b/helm_deploy/cla-backend/templates/_helpers.tpl
@@ -7,7 +7,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "cla-backend.whitelist" -}}
-{{ join "," .Values.ingress.whitelist }}
+{{ join "," .Values.ingress.whitelist }},{{- .Values.pingdomIPs }}
 {{- end -}}
 
 {{/*

--- a/helm_deploy/cla-backend/values-dev.yaml
+++ b/helm_deploy/cla-backend/values-dev.yaml
@@ -14,6 +14,9 @@ service:
   type: NodePort
   port: 80
 
+ingress:
+  enabled: false
+
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:
   DEBUG:


### PR DESCRIPTION
## What does this pull request do?

Add Pingdom IP addresses to the whitelist

## Any other changes that would benefit highlighting?

Pingdom servers IP addresses will vary and can't be part of the static whitelist.
This adds some extra steps to the circleci job to get those dynamic pingdom IPs and add it as a variable to helm  install

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
