### PR TITLE
LGA-1433 - Fix admin images

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -85,6 +85,7 @@ AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "eu-west-1")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 AWS_DEFAULT_ACL = None
+AWS_QUERYSTRING_AUTH = False
 
 # This bucket needs to a private bucket as it will contain sensitive reports
 AWS_REPORTS_STORAGE_BUCKET_NAME = os.environ.get("AWS_REPORTS_STORAGE_BUCKET_NAME")


### PR DESCRIPTION
## What does this pull request do?
Fixes static files, which come from s3, by setting AWS_QUERYSTRING_AUTH to False.
Static files bucket is public so doesn't need signed urls. As they'd
expire, and because it makes paths harder to naively construct, we're
much better off without (right now, the signature breaks our image paths
and turning it off fixes them).

## Any other changes that would benefit highlighting?
The reports do not use signed urls for access, so are not affected by
this

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
