### PR TITLE
LGA-1434 - Stop non-UAT releases using unique names

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -25,9 +25,10 @@ case $NAMESPACE in
 esac
 
 export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
-export RELEASE_NAME=${CLEANED_BRANCH_NAME}
 if [ $NAMESPACE == "uat" ]; then
+  export RELEASE_NAME=${CLEANED_BRANCH_NAME}
   export RELEASE_HOST=${RELEASE_NAME}-${NAMESPACE_HOST}
 else
+  export RELEASE_NAME=cla-backend
   export RELEASE_HOST=${NAMESPACE_HOST}
 fi

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -7,7 +7,6 @@ HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
-  --set fullnameOverride=$RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set secretName=tls-certificate \
   --set image.repository=$DOCKER_REPOSITORY \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -8,7 +8,6 @@ helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
-  --set fullnameOverride=$RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \


### PR DESCRIPTION
## What does this pull request do?
Sets $RELEASE_NAME to 'cla-backend' on staging and production, so that
the Helm chart is consistently named and therefore future releases
update the chart regardless of branch name (although the branch name
will usually be consistent for these deploy types anyway).

Removes the fullnameOverride on staging and production, as we don't want
or need our Kubernetes objects to have branch-specific names - again,
that's a UAT environment thing allowing multiple releases to exist at
once, and is detrimental on staging and production for similar reasons
to the release naming. Without the override, these releases will default
to being called 'cla-backend', from the Chart.yaml definition, and this
is what will be the basis of the naming of the deployments, ingresses
etc created for the release.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
