### PR TITLE
LGA-1449 - Add readiness/liveness probes to worker pods

### DIFF
--- a/cla_backend/apps/core/management/commands/worker_probes.py
+++ b/cla_backend/apps/core/management/commands/worker_probes.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.core.management.base import NoArgsCommand
+from cla_backend.celery import app as celery
+from legalaid.models import Case
+
+
+class Command(NoArgsCommand):
+    def handle_noargs(self, **options):
+        self.celery_probe()
+        self.database_probe()
+
+    def database_probe(self):
+        # Ability to connect to the db; doesn't matter if the result is True or False
+        Case.objects.exists()
+
+    def celery_probe(self):
+        # Ability to connect to the queue
+        # The following will raise an exception if it fails
+        with celery.connection_or_acquire() as conn:
+            conn.default_channel.queue_declare(queue=settings.CELERY_DEFAULT_QUEUE, passive=True).message_count

--- a/helm_deploy/cla-backend/templates/deployment-worker.yaml
+++ b/helm_deploy/cla-backend/templates/deployment-worker.yaml
@@ -19,3 +19,15 @@ spec:
           args: ["docker/run_worker.sh"]
           env:
             {{ include "cla-backend.app.vars" . | nindent 12 }}
+          readinessProbe:
+            exec:
+              command: ["python", "manage.py", "worker_probes"]
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["python", "manage.py", "worker_probes"]
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+            periodSeconds: 10


### PR DESCRIPTION
## What does this pull request do?

Add readiness/liveness probes to worker pods

## Any other changes that would benefit highlighting?

Usually the status of celery can be checked by running `celery -A cla_backend status` however there is a general issue with running any of the celery inspect commands, which is celery attempts to create `<uuid>.celery.pidbox` queues that it uses for broadcasting messages however due to the restrictive permissions on the aws sqs (cannot create new queues) this fails.

I couldn't disable these broadcasts or set the name of the queue that it broadcasts to.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
