### PR TITLE
LGA-1450 - Sentry SDK

### DIFF
--- a/cla_backend/celery.py
+++ b/cla_backend/celery.py
@@ -4,10 +4,7 @@ import os
 
 from celery import Celery
 from django.conf import settings
-from raven.contrib.celery import register_logger_signal, register_signal
 
-# set the default Django settings module for the 'celery' program.
-from raven.scripts.runner import send_test_message
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cla_backend.settings")
 app = Celery("cla_backend")
@@ -17,20 +14,7 @@ app = Celery("cla_backend")
 app.config_from_object("django.conf:settings")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
-client = None
-if hasattr(settings, "RAVEN_CONFIG"):
-    from raven.contrib.django.models import client
-
-    register_logger_signal(client)
-    register_signal(client)
-
 
 @app.task(bind=True)
 def debug_task(self):
     print("Request: {0!r}".format(self.request))
-
-
-@app.task()
-def sentry_test_task():
-    if client:
-        send_test_message(client, {})

--- a/cla_backend/wsgi.py
+++ b/cla_backend/wsgi.py
@@ -18,11 +18,10 @@ from os.path import abspath, dirname
 from sys import path
 
 from django.core.wsgi import get_wsgi_application
-from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cla_backend.settings")
 
-application = Sentry(get_wsgi_application())
+application = get_wsgi_application()

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -148,22 +148,10 @@ envVars:
     secret:
       name: smtp
       key: host
-  RAVEN_CONFIG_DSN:
+  SENTRY_DSN:
     secret:
       name: sentry
       key: dsn
-  RAVEN_CONFIG_SITE:
-    secret:
-      name: sentry
-      key: site
-  SENTRY_IPADDRESS:
-    secret:
-      name: sentry
-      key: ip
-  SENTRY_HOSTNAME:
-    secret:
-      name: sentry
-      key: hostname
   CALL_CENTRE_NOTIFY_EMAIL_ADDRESS:
     secret:
       name: call-centre

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Django==1.7.9
 django-model-utils==2.2
 
 psycopg2==2.7.5
-raven==5.1.1
+sentry-sdk==0.18.0
 
 djangorestframework==2.3.14
 jsonfield==0.9.22


### PR DESCRIPTION
## What does this pull request do?
Switches from Raven library to Sentry SDK. Uses a kubernetes secret that is already present, making switchover from the old Sentry instance to the new one easy.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
