### PR TITLE
LGA-1458 Added certificate for new staging domain

### DIFF
--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$RELEASE_HOST \
+  --set secretName=tls-certificate \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \

--- a/helm_deploy/cla-backend/templates/NOTES.txt
+++ b/helm_deploy/cla-backend/templates/NOTES.txt
@@ -1,10 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
+ {{ .Values.host }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cla-backend.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/helm_deploy/cla-backend/values-staging.yaml
+++ b/helm_deploy/cla-backend/values-staging.yaml
@@ -10,9 +10,6 @@ localPostgres:
 
 ingress:
   enabled: true
-  hosts:
-    - host: laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-      paths: ['/']
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -10,9 +10,6 @@ localPostgres:
 
 ingress:
   enabled: true
-  hosts:
-    - host: laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk
-      paths: ['/']
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:


### PR DESCRIPTION
## What does this pull request do

Added certificate for new staging domain

## Any other changes that would benefit highlighting?

- Cloud platforms PR to add certificate https://github.com/ministryofjustice/cloud-platform-environments/pull/3203/files
- The ingress hostname is set in the bin/<environment>_deploy.sh scripts and stored in .Values.host
- Removed redundant Values.ingress.hosts and Values.ingress.paths as the .Values.host is set in the deploy script and used frequently
## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
