### PR TITLE
LGA-1460 - uwsgi graceful termination workaround

### DIFF
--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -14,3 +14,4 @@ harakiri=20
 logger-req=stdio
 logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(method)", "uri": "%(uri)", "proto": "%(proto)", "status": %(status), "referer": "%(referer)", "user_agent": "%(uagent)", "remote_addr": "%(addr)", "http_host": "%(host)", "pid": %(pid), "worker_id": %(wid), "core": %(core), "async_switches": %(switches), "io_errors": %(ioerr), "rq_size": %(cl), "rs_time_ms": %(msecs), "rs_size": %(size), "rs_header_size": %(hsize), "rs_header_count": %(headers)}
 post-buffering=1
+die-on-term=True

--- a/helm_deploy/cla-backend/templates/deployment.yaml
+++ b/helm_deploy/cla-backend/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 30
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -46,6 +47,10 @@ spec:
               httpHeaders:
                 - name: Host
                   value: "{{ .Values.host }}"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
## What does this pull request do?
Add preStop lifecycle hook and terminationGracePeriod to allow enough time for uwsgi finish processing requests

Changes explained:

- **die-on-term** - respect the convention of shutting down the instance
- **preStop** - Sleep for 30 seconds. Called before receiving SIGTERM. Aim here is to sleep enough time for the current requests to finish.
- **terminationGracePeriodSeconds** - Amount of time kubernetes waits before sending us the SIGKILL signal.

Important note from the [kubernetes documentation ](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace)on how the preStop and terminationGracePeriodSeconds interact:

> It’s important to note that this(_terminationGracePeriodSeconds_) happens in parallel to the preStop hook and the SIGTERM signal. Kubernetes does not wait for the preStop hook to finish.
If your app finishes shutting down and exits before the terminationGracePeriod is done, Kubernetes moves to the next step immediately.


## Any other changes that would benefit highlighting?

uwsgi seems to be brutally reloading when receiving the SIGTERM signal which kills any current requests.
This workaround attempts to give it enough time to finish processing the current requests

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
