### PR TITLE
LGA-1474 - UAT env names

### DIFF
--- a/bin/uat_deploy.sh
+++ b/bin/uat_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_UAT_NAMESPACE} \
   --values ${HELM_DIR}/values-uat.yaml \
   --set fullnameOverride=$RELEASE_NAME \
+  --set environment=$RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \


### PR DESCRIPTION
## What does this pull request do?

This value is used for the CLA_ENV env var, and therefore for Sentry
reporting.
On UAT, we want to know not just that it's UAT, but which specific
release (and therefore which code branch) it is. This information is
already available as $RELEASE_NAME

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
