### PR TITLE
LGA-1440 - SMS/VOICEMAIL use stored times

### DIFF
--- a/cla_backend/apps/call_centre/forms.py
+++ b/cla_backend/apps/call_centre/forms.py
@@ -208,14 +208,14 @@ class CallMeBackForm(BaseCallMeBackForm):
     datetime = forms.DateTimeField()
     priority_callback = forms.BooleanField(required=False)
 
-    def get_sla_offset(self, _dt):
+    def get_sla_base_time(self, _dt):
         if self.case.source in [CASE_SOURCE.SMS, CASE_SOURCE.VOICEMAIL]:
             created = self.case.created
             if timezone.is_naive(created):
                 created = timezone.make_aware(created, timezone.get_default_timezone())
             return timezone.localtime(created)
         else:
-            return super(CallMeBackForm, self).get_sla_offset(_dt)
+            return super(CallMeBackForm, self).get_sla_base_time(_dt)
 
     def _is_dt_too_soon(self, dt):
         return dt <= timezone.now() - datetime.timedelta(minutes=30)

--- a/cla_backend/apps/call_centre/forms.py
+++ b/cla_backend/apps/call_centre/forms.py
@@ -7,7 +7,15 @@ from django.forms.util import ErrorList
 from django.utils import timezone
 
 from cla_common.call_centre_availability import OpeningHours
-from cla_common.constants import GENDERS, ETHNICITIES, RELIGIONS, SEXUAL_ORIENTATIONS, DISABILITIES, OPERATOR_HOURS
+from cla_common.constants import (
+    GENDERS,
+    ETHNICITIES,
+    RELIGIONS,
+    SEXUAL_ORIENTATIONS,
+    DISABILITIES,
+    OPERATOR_HOURS,
+    CASE_SOURCE,
+)
 
 from knowledgebase.models import Article
 
@@ -199,6 +207,15 @@ class CallMeBackForm(BaseCallMeBackForm):
     # format "2013-12-29 23:59" always in UTC
     datetime = forms.DateTimeField()
     priority_callback = forms.BooleanField(required=False)
+
+    def get_sla_offset(self, _dt):
+        if self.case.source in [CASE_SOURCE.SMS, CASE_SOURCE.VOICEMAIL]:
+            created = self.case.created
+            if timezone.is_naive(created):
+                created = timezone.make_aware(created, timezone.get_default_timezone())
+            return timezone.localtime(created)
+        else:
+            return super(CallMeBackForm, self).get_sla_offset(_dt)
 
     def _is_dt_too_soon(self, dt):
         return dt <= timezone.now() - datetime.timedelta(minutes=30)

--- a/cla_backend/apps/legalaid/forms.py
+++ b/cla_backend/apps/legalaid/forms.py
@@ -12,10 +12,12 @@ class BaseCallMeBackForm(BaseCaseLogForm):
     def get_requires_action_at(self):
         raise NotImplementedError()
 
+    def get_sla_offset(self, _dt):
+        return timezone.localtime(_dt)
+
     def get_context(self):
         requires_action_at = self.get_requires_action_at()
-
-        _dt = timezone.localtime(requires_action_at)
+        _dt = self.get_sla_offset(requires_action_at)
         return {
             "requires_action_at": _dt,
             "sla_15": get_sla_time(_dt, 15),

--- a/cla_backend/apps/legalaid/forms.py
+++ b/cla_backend/apps/legalaid/forms.py
@@ -12,12 +12,12 @@ class BaseCallMeBackForm(BaseCaseLogForm):
     def get_requires_action_at(self):
         raise NotImplementedError()
 
-    def get_sla_offset(self, _dt):
+    def get_sla_base_time(self, _dt):
         return timezone.localtime(_dt)
 
     def get_context(self):
         requires_action_at = self.get_requires_action_at()
-        _dt = self.get_sla_offset(requires_action_at)
+        _dt = self.get_sla_base_time(requires_action_at)
         return {
             "requires_action_at": _dt,
             "sla_15": get_sla_time(_dt, 15),

--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -357,6 +357,9 @@ class MICB1Extract(SQLFileDateRangeReport):
 
     max_date_range = 3
 
+    def get_now(self):
+        return timezone.now()
+
     def get_headers(self):
         return [
             "LAA_Reference",
@@ -384,7 +387,13 @@ class MICB1Extract(SQLFileDateRangeReport):
             "Source",
             "Code",
             "Organisation",
+            "sla_480",
+            "cs_created",
         ]
+
+    def get_sql_params(self):
+        from_date, to_date = self.date_range
+        return {"from_date": from_date, "to_date": to_date, "now": self.get_now()}
 
 
 class MICB1ExtractAgilisys(SQLFileDateRangeReport):

--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -387,8 +387,6 @@ class MICB1Extract(SQLFileDateRangeReport):
             "Source",
             "Code",
             "Organisation",
-            "sla_480",
-            "cs_created",
         ]
 
     def get_sql_params(self):

--- a/cla_backend/apps/reports/sql/MICB1sSLA.sql
+++ b/cla_backend/apps/reports/sql/MICB1sSLA.sql
@@ -141,8 +141,6 @@ select
   ,source
   ,code
   ,organisation
-  ,sla_480
-  ,cs_created
 from all_rows
 WHERE %(from_date)s < callback_window_start AND callback_window_start < %(to_date)s
 ;

--- a/cla_backend/apps/reports/tests/test_mi_sla_report.py
+++ b/cla_backend/apps/reports/tests/test_mi_sla_report.py
@@ -333,6 +333,8 @@ class MiSlaTestCasePhone(MiSlaTestCaseWeb):
 
 class MiSlaTestCaseSMS(MiSlaTestCaseBase):
     source = CASE_SOURCE.SMS
+    SLA1_MINUTES = 120
+    SLA2_MINUTES = 480
 
     # fmt: off
     """
@@ -365,6 +367,22 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         super(MiSlaTestCaseSMS, self).tearDown()
         self.operator_hours_patcher.stop()
 
+    def move_time_forward_minutes_before_sla1(self, dt, timezone_mock, naive_mock, minutes):
+        move_minutes = self.SLA1_MINUTES - minutes
+        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
+
+    def move_time_forward_minutes_after_sla1(self, dt, timezone_mock, naive_mock, minutes):
+        move_minutes = self.SLA1_MINUTES + minutes
+        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
+
+    def move_time_forward_minutes_before_sla2(self, dt, timezone_mock, naive_mock, minutes):
+        move_minutes = self.SLA2_MINUTES - minutes
+        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
+
+    def move_time_forward_minutes_after_sla2(self, dt, timezone_mock, naive_mock, minutes):
+        move_minutes = self.SLA2_MINUTES + minutes
+        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
+
     def _move_time_forward(self, dt, timezone_mock, naive_mock, minutes_forward):
         dt += datetime.timedelta(minutes=minutes_forward)
         timezone_mock.return_value = dt
@@ -388,7 +406,7 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
         # Move current time to 1 minute before SLA1
-        self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=119)
+        self.move_time_forward_minutes_before_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
         # Generate report without a callback
         date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
@@ -418,7 +436,8 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
         # Move current time to 1 minute after SLA1
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=121)
+        now_tz = self.move_time_forward_minutes_after_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
+
         # Generate report without a callback
         date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
@@ -448,7 +467,8 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
         # Move current time to 1 minute before SLA2
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=479)
+        now_tz = self.move_time_forward_minutes_before_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
+
         # Generate report without a callback
         date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
@@ -478,7 +498,8 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
         # Move current time to 1 minute after SLA2
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=481)
+        now_tz = self.move_time_forward_minutes_after_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
+
         # Generate report without a callback
         date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
@@ -507,7 +528,7 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         # Create CB1
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
         # Move current time to 1 minute before SLA1
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=119)
+        now_tz = self.move_time_forward_minutes_before_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
         # Create  CB2
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
@@ -539,7 +560,7 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         # Create CB1
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
         # Move current time 1 minute after SLA1
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=121)
+        now_tz = self.move_time_forward_minutes_after_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
         # Create  CB2
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
@@ -571,7 +592,7 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         # Create CB1
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
         # Move current time 1 minute before SLA2
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=479)
+        now_tz = self.move_time_forward_minutes_before_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
         # Create  CB2
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
@@ -609,7 +630,7 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
         # Create CB1
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
         # Move current time 1 minute after SLA2
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=421)
+        now_tz = self.move_time_forward_minutes_after_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
         # Create  CB2
         self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 

--- a/cla_backend/apps/reports/tests/test_mi_sla_report.py
+++ b/cla_backend/apps/reports/tests/test_mi_sla_report.py
@@ -4,15 +4,19 @@ import datetime
 from django.test import TestCase
 from django.utils import timezone
 import mock
-
-from cla_common.constants import CASE_SOURCE
+from legalaid.utils import sla  # noqa: E402
+from cla_common.constants import CASE_SOURCE, OPERATOR_HOURS
+from cla_common.call_centre_availability import OpeningHours
 
 from core.tests.mommy_utils import make_recipe, make_user
 from cla_eventlog import event_registry
 from cla_eventlog.models import Log
 from legalaid.forms import get_sla_time
 from reports.forms import MICB1Extract
-from legalaid.models import Case
+
+
+OPERATOR_HOURS["weekday"] = (datetime.time(9, 0), datetime.time(20, 0))
+sla.operator_hours = OpeningHours(**OPERATOR_HOURS)
 
 
 def _make_datetime(year=None, month=None, day=None, hour=0, minute=0, second=0):
@@ -21,11 +25,17 @@ def _make_datetime(year=None, month=None, day=None, hour=0, minute=0, second=0):
     month = month if month else today.month
     day = day if day else today.day
     dt = datetime.datetime(year, month, day, hour, minute, second)
-    tz = timezone.get_current_timezone()
-    return timezone.make_aware(dt, tz)
+    return timezone.make_aware(dt, timezone.get_current_timezone())
 
 
 def mock_now(dt):
+    return dt
+
+
+def _mock_datetime_now_with(date, *mocks):
+    dt = date.replace(tzinfo=timezone.get_current_timezone())
+    for _mock in mocks:
+        _mock.return_value = dt
     return dt
 
 
@@ -40,9 +50,9 @@ class MiSlaTestCaseBase(TestCase):
     source = None
     requires_action_at_minutes_offset = 60
 
-    def make_case(self, dt):
+    def make_case(self, dt, **kwargs):
         with patch_field(Log, "created", dt - datetime.timedelta(minutes=1)):
-            return make_recipe("legalaid.case", source=self.source)
+            return make_recipe("legalaid.case", source=self.source, **kwargs)
 
     def schedule_callback(self, case, user, created, requires_action_at=None):
         requires_action_at = requires_action_at or created + datetime.timedelta(minutes=35)
@@ -331,124 +341,290 @@ class MiSlaTestCasePhone(MiSlaTestCaseWeb):
 
 class MiSlaTestCaseSMS(MiSlaTestCaseBase):
     source = CASE_SOURCE.SMS
+    # fmt: off
+    """
+    Rules used to determine if SLA1/SLA2 was missed
+    Note: A callback attempt is when the operator has clicked the start call button after successfully contacting the user
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    |           |              | Callback attempted within 2 hours | Callback attempted after 2 hours AND current time within 8h window | Callback attempted after 2 hours AND current time after 8h window |
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    | SMS       | SLA 1 missed | FALSE                             | TRUE                                                               | TRUE                                                              |
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    |           | SLA 2 missed | FALSE                             | FALSE                                                              | TRUE                                                              |
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    | Voicemail | SLA 1 missed | FALSE                             | TRUE                                                               | TRUE                                                              |
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    |           | SLA 2 missed | FALSE                             | FALSE                                                              | TRUE                                                              |
+    +-----------+--------------+-----------------------------------+--------------------------------------------------------------------+-------------------------------------------------------------------+
+    """
+    # fmt: on
 
-    def make_case(self, dt):
-        with patch_field(Case, "created", dt - datetime.timedelta(minutes=2)):
-            return super(MiSlaTestCaseSMS, self).make_case(dt)
+    def _get_current_time_to_start_of_working_day(self):
+        start_hour = OPERATOR_HOURS["weekday"][0].hour
+        start_minutes = OPERATOR_HOURS["weekday"][0].minute
 
-    def test_call_answered_within_sla1_window(self):
-        # To meet SLA1 SMS and Voice mail cases need to contacted two hours from the case creation and not the
-        # 2 hours from the callback time https://dsdmoj.atlassian.net/browse/LGA-1051
-        created = _make_datetime(2015, 1, 2, 9, 1, 0)
-        case = self.make_case(created)
-        # 90 minutes from case creation (30 + self.requires_action_at_minutes_offset)
-        # is still within the 2 hours for SLA1
-        values = self.create_and_get_report(30, case=case)
+        now_tz = _make_datetime(year=2020, month=9, day=9, hour=start_hour, minute=start_minutes)
+        return now_tz
+
+    def _move_time_forward(self, dt, timezone_mock, naive_mock, minutes_forward):
+        dt += datetime.timedelta(minutes=minutes_forward)
+        timezone_mock.return_value = dt
+        if naive_mock:
+            naive_mock.return_value = timezone.make_naive(dt, dt.tzinfo)
+
+        return dt
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_current_time_before_sla1(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create a callback that is due now
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Move current time to 1 minute before SLA1
+        self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=119)
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_call_answered_after_sla1_window(self):
-        # To meet SLA1 SMS and Voice mail cases need to contacted two hours from the case creation and not the
-        # 2 hours from the callback time https://dsdmoj.atlassian.net/browse/LGA-1051
-        created = _make_datetime(2015, 1, 2, 9, 1, 0)
-        case = self.make_case(created)
-        # 125 minutes from case creation (65 + self.requires_action_at_minutes_offset)
-        # is outside of SlA1
-        values = self.create_and_get_report(65, case=case)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    def test_uncalled_and_current_time_within_sla1(self):
-        # SLA 1 miss is FALSE - Current time before SLA1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
-
-        # Create the case 1 hour ago
-        today = datetime.datetime.now()
-        created = _make_datetime(hour=today.hour, minute=today.minute, second=today.second) - datetime.timedelta(
-            hours=1
-        )
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1 after 10 minutes of creating the case
-        requires_action_at = created + datetime.timedelta(minutes=10)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created, created + datetime.timedelta(hours=1))
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_uncalled_and_current_time_after_sla1(self):
-        # SLA 1 miss is TRUE - Uncalled and Current time is after SLA1 window
-        # SLA 2 miss is FALSE - Uncalled BUT Current time is within sla2 window
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_current_time_after_sla1(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
 
-        # Create the case 2 hours and 10 minutes ago
-        today = datetime.datetime.now()
-        created = _make_datetime(hour=today.hour, minute=today.minute, second=today.second) - datetime.timedelta(
-            hours=2, minutes=10
-        )
-        case = self.make_case(created)
+        case = self.make_case(now_tz, created=now_tz)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
+        # Create a callback that is due now
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
-        # Create CB 1 after 8 minutes of creating the case
-        requires_action_at = created + datetime.timedelta(minutes=8)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created, created + datetime.timedelta(hours=3))
+        # Move current time to 1 minute after SLA1
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=121)
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_uncalled_and_current_time_within_sla2(self):
-        # SLA 1 miss is TRUE - Uncalled and Current time is after SLA1
-        # SLA 2 miss is FALSE - Uncalled BUT Current time is within SLA2
-        # Create the case 7 hour ago
-        today = datetime.datetime.now()
-        created = _make_datetime(hour=today.hour, minute=today.minute, second=today.second) - datetime.timedelta(
-            hours=7
-        )
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1 after 60 minutes of creating the case
-        requires_action_at = created + datetime.timedelta(minutes=8)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created, created + datetime.timedelta(hours=7))
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_uncalled_and_current_time_after_sla2(self):
-        # SLA 1 miss is TRUE - Uncalled and Current time is after SLA1
-        # SLA 2 miss is TRUE - Uncalled and Current time is after SLA2
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_current_time_before_sla2(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
 
-        # Create the case 9 hour ago
-        today = datetime.datetime.now()
-        created = _make_datetime(hour=today.hour, minute=today.minute, second=today.second) - datetime.timedelta(
-            hours=9
-        )
-        case = self.make_case(created)
+        case = self.make_case(now_tz, created=now_tz)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
+        # Create a callback that is due now
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
 
-        # Create CB 1 after 60 minutes of creating the case
-        requires_action_at = created + datetime.timedelta(minutes=8)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created, created + datetime.timedelta(hours=9))
+        # Move current time to 1 minute before SLA2
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=479)
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
         values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
 
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_current_time_after_sla2(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create a callback that is due now
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Move current time to 1 minute after SLA2
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=481)
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertTrue(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertTrue(values["missed_sla_2"])
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_cb2_current_time_before_sla1(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+        # Move current time to 1 minute before SLA1
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=119)
+        # Create  CB2
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Generate report without a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertFalse(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertFalse(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_cb2_current_time_after_sla1(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+        # Move current time 1 minute after SLA1
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=121)
+        # Create  CB2
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Generate report without a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_cb2_current_time_before_sla2(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+        # Move current time 1 minute before SLA2
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=479)
+        # Create  CB2
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Generate report without a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_cb2_current_time_after_sla2(self, mock_common_datetime, timezone_mock):
+        now_tz = self._get_current_time_to_start_of_working_day()
+        timezone_mock.return_value = now_tz
+        # Mock the current datetime used for the call centre availability checks
+        mock_common_datetime.return_value = timezone.make_naive(now_tz, now_tz.tzinfo)
+
+        case = self.make_case(now_tz, created=now_tz)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+        # Move current time 1 minute after SLA2
+        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=481)
+        # Create  CB2
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
+
+        # Generate report without a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        print("sla_480", values["sla_480"])
+        print("cs_created", values["cs_created"])
+        print("NOW", now_tz)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertTrue(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertTrue(values["missed_sla_1"])
         self.assertTrue(values["missed_sla_2"])
 
 
-class MiSlaTestCaseVoiceMail(MiSlaTestCaseBase):
+class MiSlaTestCaseVoiceMail(MiSlaTestCaseSMS):
     source = CASE_SOURCE.VOICEMAIL


### PR DESCRIPTION
## What does this pull request do?

Use stored sla_120 and sla_480 times to determine if SMS/VOICEMAIL slas were met

## Any other changes that would benefit highlighting?

Rules used to determine if SLA1/SLA2 was missed
Note: A callback attempt is when the operator has clicked the start call button after successfully contacting the user

|           |              | Callback attempted within 2 hours | Callback attempted after 2 hours AND current time within 8h window | Callback attempted after 2 hours AND current time after 8h window |
|-----------|--------------|-----------------------------------|--------------------------------------------------------------------|-------------------------------------------------------------------|
| SMS       | SLA 1 missed | FALSE                             | TRUE                                                               | TRUE                                                              |
|           | SLA 2 missed | FALSE                             | FALSE                                                              | TRUE                                                              |
| Voicemail | SLA 1 missed | FALSE                             | TRUE                                                               | TRUE                                                              |
|           | SLA 2 missed | FALSE                             | FALSE                                                              | TRUE                                                              |

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
