### PR TITLE
LGA-1476 - Add cronjob for send_to_performance_platform

### DIFF
--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -31,7 +31,7 @@ spec:
       template:
         spec:
           containers:
-          - name: monitor-missing-outcome-codes
+          - name: run-command
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             command: ["python", "manage.py", "monitor_missing_outcome_codes"]
             env:
@@ -51,9 +51,29 @@ spec:
       template:
         spec:
           containers:
-          - name: monitor-multiple-outcome-codes
+          - name: run-command
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             command: ["python", "manage.py", "monitor_multiple_outcome_codes"]
+            env:
+              {{ include "cla-backend.app.vars" . | nindent 12 }}
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-performance
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "1 1 * * 1"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: run-command
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["python", "manage.py", "send_to_performance_platform"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure


### PR DESCRIPTION
## What does this pull request do?
Adds a cronjob to the cronjobs kubernetes definition, to run the send_to_performance_platform management command, weekly on Mondays at 01:01, as we did previously via the salt stack on cla_backend-deploy.
The environment variables needed by the command are already in place.

## Any other changes that would benefit highlighting?
Also rename the containers of all the cronjob pods to be consistent,
rather than each having the name of the job

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
