### PR TITLE
LGA-1481 - Persistent UAT env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,8 @@ jobs:
     parameters:
       namespace:
         type: string
+      dynamic_hostname:
+        type: boolean
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
     shell: /bin/sh -leo pipefail
@@ -163,7 +165,7 @@ jobs:
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |
-            source .circleci/define_build_environment_variables << parameters.namespace >>
+            source .circleci/define_build_environment_variables << parameters.namespace >> << parameters.dynamic_hostname >>
             pip3 install requests
             export PINGDOM_IPS=`python3 bin/pingdom_ips.py`
             ./bin/<< parameters.namespace >>_deploy.sh
@@ -210,12 +212,25 @@ workflows:
       - deploy:
           name: uat_deploy
           namespace: uat
+          dynamic_hostname: true
           requires:
             - build
           filters:
             branches:
               ignore:
                 - master
+          context: laa-cla-backend
+
+      - static_uat_deploy_approval:
+          type: approval
+          requires:
+            - build
+      - deploy:
+          name: static_uat_deploy
+          namespace: uat
+          dynamic_hostname: false
+          requires:
+            - static_uat_deploy_approval
           context: laa-cla-backend
 
       - staging_deploy_approval:
@@ -229,6 +244,7 @@ workflows:
       - deploy:
           name: staging_deploy
           namespace: staging
+          dynamic_hostname: false
           requires:
             - staging_deploy_approval
           context: laa-cla-backend
@@ -253,7 +269,7 @@ workflows:
       - deploy:
           name: production_deploy
           namespace: production
+          dynamic_hostname: false
           requires:
             - production_deploy_approval
           context: laa-cla-backend
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ workflows:
       - deploy:
           name: training_deploy
           namespace: training
+          dynamic_hostname: false
           requires:
             - production_deploy_approval
           context: laa-cla-backend

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 NAMESPACE=$1
+DYNAMIC_HOSTNAME=$2
 
 # These variables are required in multiple places such as
 # tag_and_push_docker_image as well as the bin/<NAMESPACE>_deploy.sh scripts
@@ -28,7 +29,7 @@ case $NAMESPACE in
 esac
 
 export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
-if [ $NAMESPACE == "uat" ]; then
+if [ $DYNAMIC_HOSTNAME = true ]; then
   export RELEASE_NAME=${CLEANED_BRANCH_NAME}
   export RELEASE_HOST=${RELEASE_NAME}-${NAMESPACE_HOST}
 else


### PR DESCRIPTION
## What does this pull request do?
Adds a "static UAT deploy" step to the Circle pipeline, with its own approval step.
Modifies the `define_build_environment_variables` script to take a second argument and use it as `DYNAMIC_HOSTNAME` to decouple the multideploy UAT behaviour from the UAT namespace (as the new release needs to be in the latter but not use the former), and modifies the pipeline to have this as a build job parameter and pass it through.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
