### PR TITLE
LGA-1439 - Additional whitelisting for UAT and training envs

### DIFF
--- a/helm_deploy/cla-backend/values-training.yaml
+++ b/helm_deploy/cla-backend/values-training.yaml
@@ -11,6 +11,8 @@ localPostgres:
 
 ingress:
   enabled: true
+  whitelist_additional:
+    - 52.49.175.131/32
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -10,6 +10,8 @@ localPostgres:
 
 ingress:
   enabled: true
+  whitelist_additional:
+    - 52.210.85.116/32
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:


### PR DESCRIPTION
## What does this pull request do?
Adds the staging cla_frontend template deploy IP to additional IPs for the UAT ingress (to be used by the static UAT release, rather than the dynamic multi-deploy ones)
Adds the training cla_frontend template deploy IP to additional IPs for the training ingress

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
