### PR TITLE
LGA-1441 web and phone 72 hours SLA

### DIFF
--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -347,7 +347,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, CallCentreFixedOperat
     def __call__(self, runner, mocked_now, *args, **kwargs):
         self.mocked_now = mocked_now
         self.mocked_now.return_value = datetime.datetime(2015, 3, 24, 10, 0, 0, 0).replace(tzinfo=timezone.utc)
-        self.expected_sla_72h = datetime.datetime(2015, 4, 9, 13, 30, 0, 0)
+        self.expected_sla_72h = datetime.datetime(2015, 4, 7, 13, 30, 0, 0)
         self.default_dt = self.mocked_now().replace(day=30)
 
         super(CallMeBackFormTestCase, self).__call__(runner, *args, **kwargs)
@@ -533,6 +533,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, CallCentreFixedOperat
                 "sla_480": (case.created + datetime.timedelta(hours=8)).isoformat(),
                 "sla_15": (case.created + datetime.timedelta(minutes=15)).isoformat(),
                 "sla_30": (case.created + datetime.timedelta(minutes=30)).isoformat(),
+                "sla_72h": timezone.make_aware(self.expected_sla_72h, created.tzinfo).isoformat(),
             },
         )
 
@@ -554,6 +555,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, CallCentreFixedOperat
                 "sla_480": (case.created + datetime.timedelta(hours=8)).isoformat(),
                 "sla_15": (case.created + datetime.timedelta(minutes=15)).isoformat(),
                 "sla_30": (case.created + datetime.timedelta(minutes=30)).isoformat(),
+                "sla_72h": timezone.make_aware(self.expected_sla_72h, created.tzinfo).isoformat(),
             },
         )
 

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -16,6 +16,7 @@ from call_centre.forms import (
     StopCallMeBackForm,
 )
 from cla_common.constants import CASE_SOURCE
+from call_centre.tests.test_utils import CallCentreFixedOperatingHours
 
 
 def _mock_datetime_now_with(date, *mocks):
@@ -336,7 +337,7 @@ class DeclineHelpCaseFormTestCase(EventSpecificLogFormTestCaseMixin, TestCase):
     FORM = DeclineHelpCaseForm
 
 
-class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
+class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, CallCentreFixedOperatingHours, TestCase):
     FORM = CallMeBackForm
 
     def _strftime(self, date):
@@ -346,6 +347,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
     def __call__(self, runner, mocked_now, *args, **kwargs):
         self.mocked_now = mocked_now
         self.mocked_now.return_value = datetime.datetime(2015, 3, 24, 10, 0, 0, 0).replace(tzinfo=timezone.utc)
+        self.expected_sla_72h = datetime.datetime(2015, 4, 9, 13, 30, 0, 0)
         self.default_dt = self.mocked_now().replace(day=30)
 
         super(CallMeBackFormTestCase, self).__call__(runner, *args, **kwargs)
@@ -416,6 +418,7 @@ class CallMeBackFormTestCase(BaseCaseLogFormTestCaseMixin, TestCase):
                     "sla_480": (_dt + datetime.timedelta(hours=8)).isoformat(),
                     "sla_15": (_dt + datetime.timedelta(minutes=15)).isoformat(),
                     "sla_30": (_dt + datetime.timedelta(minutes=30)).isoformat(),
+                    "sla_72h": timezone.make_aware(self.expected_sla_72h, _dt.tzinfo).isoformat(),
                 },
             )
 

--- a/cla_backend/apps/call_centre/tests/test_utils.py
+++ b/cla_backend/apps/call_centre/tests/test_utils.py
@@ -1,7 +1,7 @@
-import datetime
 from unittest import TestCase
 import mock
 import jsonpatch
+from django.conf import settings
 from core.utils import format_patch
 from cla_common.call_centre_availability import OpeningHours
 from legalaid.utils import sla
@@ -28,11 +28,7 @@ class CallCentreFixedOperatingHours(object):
     def setUp(self):
         super(CallCentreFixedOperatingHours, self).setUp()
 
-        hours = {
-            "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
-            "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
-        }
-        operator_hours = OpeningHours(**hours)
+        operator_hours = OpeningHours(**settings.OPERATOR_HOURS)
 
         self.operator_hours_patcher = mock.patch.object(sla, "operator_hours", operator_hours)
         self.operator_hours_patcher.start()

--- a/cla_backend/apps/call_centre/tests/test_utils.py
+++ b/cla_backend/apps/call_centre/tests/test_utils.py
@@ -1,7 +1,10 @@
+import datetime
 from unittest import TestCase
-
+import mock
 import jsonpatch
 from core.utils import format_patch
+from cla_common.call_centre_availability import OpeningHours
+from legalaid.utils import sla
 
 
 class FormatPatchTestCase(TestCase):
@@ -19,3 +22,20 @@ class FormatPatchTestCase(TestCase):
         formatted = format_patch(patch)
         self.assertIsInstance(formatted, basestring)
         self.assertEqual(formatted, "Changed foo to 2")
+
+
+class CallCentreFixedOperatingHours(object):
+    def setUp(self):
+        super(CallCentreFixedOperatingHours, self).setUp()
+
+        hours = {
+            "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
+            "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
+        }
+        operator_hours = OpeningHours(**hours)
+
+        self.operator_hours_patcher = mock.patch.object(sla, "operator_hours", operator_hours)
+        self.operator_hours_patcher.start()
+
+    def tearDown(self):
+        self.operator_hours_patcher.stop()

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -14,9 +14,12 @@ from core.tests.mommy_utils import make_recipe
 from core.tests.test_base import SimpleResourceAPIMixin
 from legalaid.models import Case, PersonalDetails
 from legalaid.tests.views.test_base import CLACheckerAuthBaseApiTestMixin
+from call_centre.tests.test_utils import CallCentreFixedOperatingHours
 
 
-class BaseCaseTestCase(CLACheckerAuthBaseApiTestMixin, SimpleResourceAPIMixin, APITestCase):
+class BaseCaseTestCase(
+    CLACheckerAuthBaseApiTestMixin, CallCentreFixedOperatingHours, SimpleResourceAPIMixin, APITestCase
+):
     LOOKUP_KEY = "reference"
     API_URL_BASE_NAME = "case"
     RESOURCE_RECIPE = "legalaid.case"
@@ -237,6 +240,7 @@ class CallMeBackCaseTestCase(BaseCaseTestCase):
             ),
         )
         _dt = timezone.localtime(self._default_dt)
+        expected_sla_72h = datetime.datetime(2015, 4, 9, 13, 30, 0, 0)
         self.assertDictEqual(
             log.context,
             {
@@ -245,6 +249,7 @@ class CallMeBackCaseTestCase(BaseCaseTestCase):
                 "sla_480": (_dt + datetime.timedelta(hours=8)).isoformat(),
                 "sla_15": (_dt + datetime.timedelta(minutes=15)).isoformat(),
                 "sla_30": (_dt + datetime.timedelta(minutes=30)).isoformat(),
+                "sla_72h": timezone.make_aware(expected_sla_72h, _dt.tzinfo).isoformat(),
             },
         )
 

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -240,7 +240,7 @@ class CallMeBackCaseTestCase(BaseCaseTestCase):
             ),
         )
         _dt = timezone.localtime(self._default_dt)
-        expected_sla_72h = datetime.datetime(2015, 4, 9, 13, 30, 0, 0)
+        expected_sla_72h = datetime.datetime(2015, 4, 7, 13, 30, 0, 0)
         self.assertDictEqual(
             log.context,
             {

--- a/cla_backend/apps/cla_eventlog/management/commands/add_72h_to_context.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/add_72h_to_context.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+from django.core.management.base import BaseCommand
+from cla_eventlog.models import Log
+from cla_common import call_centre_availability
+from legalaid.utils.sla import get_sla_time
+from django.utils import timezone
+
+
+class CallCentreAvailabilityHistoricCurrentDateTime(object):
+    def __init__(self, start_time):
+        self.start_time = start_time
+        self.orig_current_datetime = call_centre_availability.current_datetime
+
+    def get_current_datetime(self):
+        now = self.start_time
+        if timezone.is_naive(now):
+            return now
+        else:
+            return timezone.make_naive(now, self.start_time.tzinfo)
+
+    def __enter__(self):
+        call_centre_availability.current_datetime = self.get_current_datetime
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        call_centre_availability.current_datetime = self.orig_current_datetime
+
+
+class Command(BaseCommand):
+    help = "Add 72 working hours to the event_log context to be used for sla reporting."
+
+    def handle(self, *args, **options):
+        logs = self.get_logs()
+        for log in logs:
+            context = log.context
+            context["sla_72h"] = self.get_72_working_hours_sla(log.case.requires_action_at)
+            self.stdout.write(
+                "Updating {} from requires_action_at {} to sla_72h {}".format(
+                    log, log.case.requires_action_at, log.context["sla_72h"]
+                )
+            )
+            # Do update at sql level to avoid affecting auto updating fields and model signals
+            Log.objects.filter(pk=log.pk).update(context=context)
+
+    def get_72_working_hours_sla(self, start_time):
+        start_time = timezone.localtime(start_time)
+        sla2_minutes = 72 * 60
+        with CallCentreAvailabilityHistoricCurrentDateTime(start_time):
+            return get_sla_time(start_time, sla2_minutes)
+
+    def get_logs(self):
+        return Log.objects.filter(code="CB1", type="outcome").exclude(context__contains="sla_72h")

--- a/cla_backend/apps/cla_eventlog/models.py
+++ b/cla_backend/apps/cla_eventlog/models.py
@@ -61,6 +61,9 @@ class Log(TimeStampedModel):
         return False
 
     def save(self, *args, **kwargs):
+        if kwargs.pop("save_model_only", False):
+            return super(Log, self).save(*args, **kwargs)
+
         if self.is_consecutive_outcome_today():
             logger.warning("LGA-125 Preventing save of consecutive duplicate outcome code on same day")
             return

--- a/cla_backend/apps/cla_eventlog/tests/test_commands.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_commands.py
@@ -1,0 +1,130 @@
+import datetime
+import time
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta, MO, TU
+
+from core.tests.mommy_utils import make_recipe, make_user
+from cla_eventlog import event_registry
+from cla_eventlog.models import Log
+from legalaid.forms import get_sla_time
+from cla_eventlog.management.commands.add_72h_to_context import Command
+from cla_common.call_centre_availability import OpeningHours
+
+
+class Add72workingHoursToContextCommandTestCase(TestCase):
+    def setUp(self):
+        super(Add72workingHoursToContextCommandTestCase, self).setUp()
+        self.instance = Command()
+
+        hours = {
+            "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
+            "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
+        }
+        operator_hours = OpeningHours(**hours)
+        from legalaid.utils import sla
+
+        self.operator_hours_patcher = mock.patch.object(sla, "operator_hours", operator_hours)
+        self.operator_hours_patcher.start()
+
+    def tearDown(self):
+        self.operator_hours_patcher.stop()
+
+    def create_callback(self, requires_action_at):
+        case = make_recipe("legalaid.case")
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        event = event_registry.get_event("call_me_back")()
+        event.get_log_code(case=case)
+        log = event.process(
+            case,
+            created_by=user,
+            notes="",
+            context={
+                "requires_action_at": requires_action_at,
+                "sla_15": get_sla_time(requires_action_at, 15),
+                "sla_30": get_sla_time(requires_action_at, 30),
+                "sla_120": get_sla_time(requires_action_at, 120),
+                "sla_480": get_sla_time(requires_action_at, 480),
+            },
+        )
+        case.set_requires_action_at(requires_action_at)
+        return log
+
+    def test_add_72h_to_context__updated_fields(self):
+        now = datetime.datetime.now()
+        now_tz = timezone.make_aware(now, timezone.get_default_timezone())
+        log = self.create_callback(now_tz)
+        self.assertNotIn("sla_72h", log.context)
+        # Sleep for enough time to test modified hasn't changed
+        time.sleep(3)
+        self.instance.execute()
+        log_updated = Log.objects.get(pk=log.pk)
+        self.assertIn("sla_72h", log_updated.context)
+
+        self.assertEqual(log.modified, log_updated.modified)
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    def test_add_72h_to_context__sla_in_the_past(self, mock_common_datetime, timezone_mock):
+        now = datetime.datetime(year=2020, month=10, day=5, hour=9, minute=0)
+        expected = datetime.datetime(year=2020, month=10, day=13, hour=11, minute=30)
+        expected = timezone.make_aware(expected, timezone.get_default_timezone())
+        now_tz = timezone.make_aware(now, timezone.get_default_timezone())
+        mock_common_datetime.return_value = now
+        timezone_mock.return_value = now_tz
+        log = self.create_callback(now_tz)
+        self.assertNotIn("sla_72h", log.context)
+        self.instance.execute()
+        log = Log.objects.get(pk=log.pk)
+        self.assertIn("sla_72h", log.context)
+        self.assertEqual(log.context["sla_72h"], expected.isoformat())
+
+    def get_last_monday(self):
+        today = datetime.date.today()
+        offset = -1
+        if today.isoweekday() == 1:
+            # If today is Monday then a offset of -1 will return today's date
+            # so we need to use an offset of -2 in that case to get the previous monday
+            offset = -2
+
+        last_monday = today + relativedelta(weekday=MO(offset))
+        return last_monday
+
+    def get_next_tuesday(self):
+        today = datetime.date.today()
+        offset = +1
+        if today.isoweekday() == 2:
+            # If today is Tuesday then a offset of +1 will return today's date
+            # so we need to use an offset of +2 in that case to get the next tuesday
+            offset = +2
+
+        next_tuesday = today + relativedelta(weekday=TU(offset))
+        return next_tuesday
+
+    @mock.patch("django.utils.timezone.now")
+    @mock.patch("cla_common.call_centre_availability.current_datetime")
+    @mock.patch("cla_common.call_centre_availability.bank_holidays", return_value=[])
+    def test_add_72h_to_context__sla_in_the_future(self, mock_bank_holidays, mock_common_datetime, timezone_mock):
+        now = datetime.datetime.combine(self.get_last_monday(), datetime.time(hour=9, minute=0))
+        expected = datetime.datetime.combine(self.get_next_tuesday(), datetime.time(hour=11, minute=30))
+        expected = timezone.make_aware(expected, timezone.get_default_timezone())
+        now_tz = timezone.make_aware(now, timezone.get_default_timezone())
+        mock_common_datetime.return_value = now
+        timezone_mock.return_value = now_tz
+        log = self.create_callback(now_tz)
+        self.assertNotIn("sla_72h", log.context)
+        self.instance.execute()
+        log = Log.objects.get(pk=log.pk)
+        self.assertIn("sla_72h", log.context)
+
+        expected_str = expected.isoformat()
+        if expected.utcoffset().total_seconds() == 0:
+            # Strangely log.context["sla_72h"] falls in a 0 offset timezone
+            # it does not include the timezone offset (should be 00:00Z)
+            # so we have to set our expected datetime string representation to match it
+            expected_str = expected.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.assertEqual(log.context["sla_72h"], expected_str)
+
+        self.assertEqual(log.modified, log.modified)

--- a/cla_backend/apps/cla_eventlog/tests/test_commands.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_commands.py
@@ -10,26 +10,13 @@ from cla_eventlog import event_registry
 from cla_eventlog.models import Log
 from legalaid.forms import get_sla_time
 from cla_eventlog.management.commands.add_72h_to_context import Command
-from cla_common.call_centre_availability import OpeningHours
+from call_centre.tests.test_utils import CallCentreFixedOperatingHours
 
 
-class Add72workingHoursToContextCommandTestCase(TestCase):
+class Add72workingHoursToContextCommandTestCase(CallCentreFixedOperatingHours, TestCase):
     def setUp(self):
         super(Add72workingHoursToContextCommandTestCase, self).setUp()
         self.instance = Command()
-
-        hours = {
-            "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
-            "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
-        }
-        operator_hours = OpeningHours(**hours)
-        from legalaid.utils import sla
-
-        self.operator_hours_patcher = mock.patch.object(sla, "operator_hours", operator_hours)
-        self.operator_hours_patcher.start()
-
-    def tearDown(self):
-        self.operator_hours_patcher.stop()
 
     def create_callback(self, requires_action_at):
         case = make_recipe("legalaid.case")

--- a/cla_backend/apps/legalaid/forms.py
+++ b/cla_backend/apps/legalaid/forms.py
@@ -24,6 +24,7 @@ class BaseCallMeBackForm(BaseCaseLogForm):
             "sla_30": get_sla_time(_dt, 30),
             "sla_120": get_sla_time(_dt, 120),
             "sla_480": get_sla_time(_dt, 480),
+            "sla_72h": get_sla_time(_dt, 4320),
         }
 
     def get_notes(self):

--- a/cla_backend/apps/legalaid/utils/sla.py
+++ b/cla_backend/apps/legalaid/utils/sla.py
@@ -37,9 +37,10 @@ def get_next_business_day(start_date):
 
 
 def get_sla_time(start_time, minutes_delta):
-    end_of_business_day = operator_hours.time_slots(start_time.date())
-    if end_of_business_day:
-        end_of_business_day = end_of_business_day[-1] + timedelta(minutes=SLOT_INTERVAL_MINS)
+    time_slots_today = operator_hours.time_slots(start_time.date())
+    end_of_business_day = None
+    if time_slots_today:
+        end_of_business_day = time_slots_today[-1] + timedelta(minutes=SLOT_INTERVAL_MINS)
         end_of_business_day = timezone.make_aware(end_of_business_day, timezone.get_default_timezone())
 
     next_business_day = get_next_business_day(start_time.date())

--- a/cla_backend/apps/legalaid/utils/sla.py
+++ b/cla_backend/apps/legalaid/utils/sla.py
@@ -37,6 +37,11 @@ def get_next_business_day(start_date):
 
 
 def get_sla_time(start_time, minutes_delta):
+    end_of_business_day = operator_hours.time_slots(start_time.date())
+    if end_of_business_day:
+        end_of_business_day = end_of_business_day[-1] + timedelta(minutes=SLOT_INTERVAL_MINS)
+        end_of_business_day = timezone.make_aware(end_of_business_day, timezone.get_default_timezone())
+
     next_business_day = get_next_business_day(start_time.date())
     start_of_next_business_day = operator_hours.time_slots(next_business_day.date())[0]
     start_of_next_business_day = timezone.make_aware(start_of_next_business_day, timezone.get_default_timezone())
@@ -45,6 +50,10 @@ def get_sla_time(start_time, minutes_delta):
         start_time = start_of_next_business_day
 
     simple_delta = start_time + timedelta(minutes=minutes_delta)
+    if end_of_business_day and (simple_delta > end_of_business_day):
+        minutes_today = (end_of_business_day - start_time).total_seconds() / 60
+        return get_sla_time(start_of_next_business_day, minutes_delta - minutes_today)
+
     in_business_hours = is_in_business_hours(simple_delta)
     if not in_business_hours:
         remainder_delta = get_remainder_from_end_of_day(start_time.date(), simple_delta)

--- a/cla_backend/apps/reports/sql/MICB1sSLA.sql
+++ b/cla_backend/apps/reports/sql/MICB1sSLA.sql
@@ -74,6 +74,7 @@ WITH
         ,trim((log.context->'requires_action_at')::text, '"')::timestamptz + interval '30 minutes' as callback_window_end
         ,trim((log.context->'sla_120')::text, '"')::timestamptz as sla_120
         ,trim((log.context->'sla_480')::text, '"')::timestamptz as sla_480
+        ,trim((log.context->'sla_72h')::text, '"')::timestamptz as sla_72h
         ,operator_first_log_after_cb1.rn
         ,operator_first_view_after_cb1.rn
         ,c.source
@@ -128,9 +129,9 @@ select
    END as missed_sla_1
   ,CASE
    -- User not contacted and current time is after SLA 2
-   WHEN source IN ('WEB', 'PHONE') AND cs_code IS NULL AND %(now)s > callback_window_end + interval '72 hours' THEN TRUE
+   WHEN source IN ('WEB', 'PHONE') AND cs_code IS NULL AND %(now)s > sla_72h THEN TRUE
    -- User contacted and contact time is after SLA 2
-   WHEN source IN ('WEB', 'PHONE') AND cs_code IS NOT NULL AND operator_first_log_after_cb1__created > callback_window_end + interval '72 hours'  THEN TRUE
+   WHEN source IN ('WEB', 'PHONE') AND cs_code IS NOT NULL AND operator_first_log_after_cb1__created > sla_72h  THEN TRUE
    -- Everything else that is a web / phone case is False
    WHEN source IN ('WEB', 'PHONE') THEN FALSE
    -- User has NOT been contacted and current time is after the SLA2 window for SMS and VOICE MAIL

--- a/cla_backend/apps/reports/tests/test_mi_sla_report.py
+++ b/cla_backend/apps/reports/tests/test_mi_sla_report.py
@@ -2,17 +2,18 @@
 from contextlib import contextmanager
 import datetime
 
-from cla_common.call_centre_availability import OpeningHours
 from django.test import TestCase
 from django.utils import timezone
 import mock
 
 from cla_common.constants import CASE_SOURCE
+from cla_common import call_centre_availability
 from core.tests.mommy_utils import make_recipe, make_user
 from cla_eventlog import event_registry
 from cla_eventlog.models import Log
 from legalaid.forms import get_sla_time
 from reports.forms import MICB1Extract
+from call_centre.tests.test_utils import CallCentreFixedOperatingHours
 
 
 def _make_datetime(year=None, month=None, day=None, hour=0, minute=0, second=0):
@@ -35,13 +36,64 @@ def patch_field(cls, field_name, dt):
         yield
 
 
-class MiSlaTestCaseBase(TestCase):
+class MiSlaTestCaseBase(CallCentreFixedOperatingHours):
     source = None
     requires_action_at_minutes_offset = 60
 
+    def setUp(self):
+        super(MiSlaTestCaseBase, self).setUp()
+        self.current_case = None
+        self.now = self.get_default_dt()
+
+        self.timezone_mock = mock.patch.object(timezone, "now", lambda: self.now)
+        self.timezone_mock.start()
+
+        now_naive = timezone.make_naive(self.now, timezone.get_current_timezone())
+        self.cla_common_datetime_mock = mock.patch.object(
+            call_centre_availability, "current_datetime", lambda: now_naive
+        )
+        self.cla_common_datetime_mock.start()
+
+    def tearDown(self):
+        super(MiSlaTestCaseBase, self).tearDown()
+        self.timezone_mock.stop()
+        self.cla_common_datetime_mock.stop()
+
+    def get_default_dt(self):
+        raise NotImplementedError()
+
+    def get_requires_action_at(self):
+        raise NotImplementedError
+
+    def get_sla1_datetime(self):
+        raise NotImplementedError()
+
+    def get_sla2_datetime(self):
+        raise NotImplementedError()
+
+    def move_time_forward_minutes_before_sla1(self, minutes):
+        return self._move_time_forward(self.get_sla1_datetime(), -minutes)
+
+    def move_time_forward_minutes_after_sla1(self, minutes):
+        return self._move_time_forward(self.get_sla1_datetime(), minutes)
+
+    def move_time_forward_minutes_before_sla2(self, minutes):
+        return self._move_time_forward(self.get_sla2_datetime(), -minutes)
+
+    def move_time_forward_minutes_after_sla2(self, minutes):
+        return self._move_time_forward(self.get_sla2_datetime(), minutes)
+
+    def _move_time_forward(self, dt, minutes_forward):
+        self.now = dt + datetime.timedelta(minutes=minutes_forward)
+        self.timezone_mock.return_value = self.now
+        self.cla_common_datetime_mock.return_value = timezone.make_naive(dt, dt.tzinfo)
+
+        return self.now
+
     def make_case(self, dt, **kwargs):
         with patch_field(Log, "created", dt - datetime.timedelta(minutes=1)):
-            return make_recipe("legalaid.case", source=self.source, **kwargs)
+            self.current_case = make_recipe("legalaid.case", source=self.source, **kwargs)
+            return self.current_case
 
     def schedule_callback(self, case, user, created, requires_action_at=None):
         requires_action_at = requires_action_at or created + datetime.timedelta(minutes=35)
@@ -61,6 +113,7 @@ class MiSlaTestCaseBase(TestCase):
                     "sla_30": get_sla_time(sla_base_time, 30),
                     "sla_120": get_sla_time(sla_base_time, 120),
                     "sla_480": get_sla_time(sla_base_time, 480),
+                    "sla_72h": get_sla_time(sla_base_time, 4320),
                 },
             )
             case.set_requires_action_at(requires_action_at)
@@ -95,235 +148,351 @@ class MiSlaTestCaseBase(TestCase):
         )
         return self.get_report(date_range)
 
+    def test_current_time_within_sla1(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
 
-class MiSlaTestCaseWeb(MiSlaTestCaseBase):
-    source = CASE_SOURCE.WEB
+        # Create a callback that is due now 1 hour from now
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-    def test_call_answered_within_sla1_window(self):
-        values = self.create_and_get_report(25)
+        # Move current time to 1 minute before SLA1
+        now_tz = self.move_time_forward_minutes_before_sla1(minutes=1)
+
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_call_answered_after_sla1_window(self):
-        values = self.create_and_get_report(35)
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertFalse(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    def test_current_time_after_sla1(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+
+        # Create a callback that is due now 1 hour from now
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+
+        # Move current time to 1 minute after SLA1
+        now_tz = self.move_time_forward_minutes_after_sla1(minutes=1)
+
+        # Generate report without a callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_call_answered_before_sla1_window(self):
-        values = self.create_and_get_report(-5)
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_call_answered_after_sla2_window(self):
-        values = self.create_and_get_report(75 * 60)
+    def test_current_time_before_sla2(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+
+        # Create a callback that is due now 1 hour from now
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+
+        # Move current time to 1 minute before SLA2
+        self.move_time_forward_minutes_before_sla2(minutes=1)
+
+        # Generate report without a callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    def test_current_time_after_sla2(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create a callback that is due now
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+
+        # Move current time to 1 minute after SLA2
+        now_tz = self.move_time_forward_minutes_after_sla2(minutes=1)
+
+        # Generate report without a callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
         self.assertTrue(values["missed_sla_1"])
         self.assertTrue(values["missed_sla_2"])
 
-    def test_cb1_uncalled_and_current_time_before_sla1(self):
-        # SLA 1 miss is FALSE - Current time before SLA1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertTrue(values["missed_sla_2"])
 
-        # 9:01 tomorrow
-        created = _make_datetime(hour=9, minute=1) + datetime.timedelta(days=1)
-        case = self.make_case(created)
+    def test_cb2_current_time_within_sla1(self):
+        case = self.make_case(self.now, created=self.now)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+        # Move current time to 1 minute before SLA1
+        self.move_time_forward_minutes_before_sla1(minutes=1)
+        # Create  CB2
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=2))
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_cb1_uncalled_and_current_time_after_sla1(self):
-        # SLA 1 miss is TRUE - Current time is after SLA1 window and CB2 hasn't been scheduled
-        # SLA 2 miss is FALSE - Current time is within sla2 window
-
-        # 9:01 yesterday
-        created = _make_datetime(hour=9, minute=1) - datetime.timedelta(days=1)
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=2))
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    def test_cb2_created_before_sla1_and_current_time_before_sla1(self):
-        # SLA 1 miss is TRUE - CB2 is created before SLA1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
-
-        # 9:01 tomorrow
-        created = _make_datetime(hour=9, minute=1) + datetime.timedelta(days=1)
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=3)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        # Create CB 2 before SLA1 window
-        cb2_created = requires_action_at + datetime.timedelta(minutes=-20)
-        self.schedule_callback(case, user, created, cb2_created)
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    def test_cb2_created_WITHIN_sla1_window_and_current_time_WITHIN_sla2_window(self):
-        # SLA 1 miss is FALSE - CB2 created within sla1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
-
-        # 9:01 yesterday
-        created = _make_datetime(hour=9, minute=1) - datetime.timedelta(days=1)
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        # Create CB2 within SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=25))
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=1))
-        values = self.get_report(date_range)
-
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_cb2_created_BEFORE_sla1_window_and_current_time_WITHIN_sla2_window(self):
-        # SLA 1 miss is TRUE - CB2 created before sla1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
-
-        # 9:01 yesterday
-        created = _make_datetime(hour=9, minute=1) - datetime.timedelta(days=1)
-        case = self.make_case(created)
+    def test_cb2_current_time_after_sla1(self):
+        case = self.make_case(self.now, created=self.now)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+        # Move current time 1 minute after SLA1
+        now_tz = self.move_time_forward_minutes_after_sla1(minutes=1)
+        # Create  CB2
+        self.schedule_callback(case, user, created=now_tz, requires_action_at=self.get_requires_action_at())
 
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        # Create CB2 before SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=-5))
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=1))
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_cb2_created_AFTER_sla1_window_and_current_time_WITHIN_sla2_window(self):
-        # SLA 1 miss is TRUE  - CB2 created after sla1 window
-        # SLA 2 miss is FALSE - Current time is within sla2 window
+        # Start a call
+        self.start_call(case, user, now_tz)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
 
-        # 9:01 yesterday
-        created = _make_datetime(hour=9, minute=1) - datetime.timedelta(days=1)
-        case = self.make_case(created)
+    def test_cb2_current_time_before_sla2(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+        # Move current time 1 minute before SLA2
+        self.move_time_forward_minutes_before_sla2(minutes=1)
+        # Create  CB2
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    def test_cb2_current_time_after_sla2(self):
+        case = self.make_case(self.now, created=self.now)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
 
         # Create CB1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+        # Move current time 1 minute after SLA2
+        self.move_time_forward_minutes_after_sla2(minutes=1)
+        # Create  CB2
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-        # Create CB2 after SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=31))
-
-        date_range = (created - datetime.timedelta(days=2), created + datetime.timedelta(days=1))
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    def test_cb2_created_AFTER_sla1_window_and_current_time_AFTER_sla2_window(self):
-        # SLA 1 miss is TRUE  - CB2 created after sla1 window
-        # SLA 2 miss is TRUE  - Current time is after sla2 window
-
-        # 9:01 4 days ago
-        created = _make_datetime(hour=9, minute=1) - datetime.timedelta(days=4)
-        case = self.make_case(created)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
-
-        # Create CB2 after SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=31))
-
-        date_range = (created - datetime.timedelta(days=5), created + datetime.timedelta(days=5))
-        values = self.get_report(date_range)
-
         self.assertTrue(values["missed_sla_1"])
         self.assertTrue(values["missed_sla_2"])
 
-    def test_cb2_created_WITHIN_sla1_window_and_call_answered_WITHIN_sla2_window(self):
-        # SLA 1 miss is FALSE  - CB2 created within sla1 window
-        # SLA 2 miss is FALSE  - Call answered within SLA2 window
-        created = _make_datetime(2015, 1, 2, 9, 1, 0)
-        case = self.make_case(created)
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertTrue(values["missed_sla_2"])
+
+    def test_cb3_current_time_within_sla1(self):
+        case = self.make_case(self.now, created=self.now)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
+        # Move current time to 2 minute before SLA1
+        self.move_time_forward_minutes_before_sla1(minutes=2)
+        # Create  CB2
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-        # Create CB2 within SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=25))
+        # Move current time to 1 minute before SLA1
+        self.move_time_forward_minutes_before_sla1(minutes=1)
+        # Create  CB3
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
 
-        # Start call
-        self.start_call(case, user, requires_action_at + datetime.timedelta(minutes=60))
-
-        date_range = (_make_datetime(2015, 1, 1), _make_datetime(2015, 2, 1))
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertFalse(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
-    def test_cb3_created_WITHIN_sla1_window_and_call_answered_WITHIN_sla2_window(self):
-        # SLA 1 miss is FALSE  - CB3 created within sla1 window
-        # SLA 2 miss is FALSE  - Call answered within SLA2 window
-        created = _make_datetime(2015, 1, 2, 9, 1, 0)
-        case = self.make_case(created)
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertFalse(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+
+class MiSlaTestCaseWeb(MiSlaTestCaseBase, TestCase):
+    source = CASE_SOURCE.WEB
+
+    # fmt: off
+    """
+    CB1
+    +--------------+-------------------------------+---------------------------------------------+--------------------------------+
+    |              |                               |                                             | Call answered                  |
+    |              |                               |                                             | after 30m                      |
+    |              | Call answered                 | Call answered                               | AND                            |
+    |              | Within 30m window             | before 30m window                           | current time within 72h window |
+    +--------------+-------------------------------+---------------------------------------------+--------------------------------+
+    | SLA 1 missed |             FALSE             |                     TRUE                    |              TRUE              |
+    +--------------+-------------------------------+---------------------------------------------+--------------------------------+
+    | SLA 2 missed |             FALSE             |                    FALSE                    |              FALSE             |
+    +--------------+-------------------------------+---------------------------------------------+--------------------------------+
+    | test         | test_current_time_within_sla1 | test_current_time_before_requires_action_at | test_current_time_after_sla1   |
+    +--------------+-------------------------------+---------------------------------------------+--------------------------------+
+
+    CB2
+    +--------------+-----------------------------------+-------------------------------------------------+----------------------------------+----------------------------------+----------------------------------+-----------------------------------+
+    |              | CB2 Scheduled                     | CB2 Scheduled                                   | CB2 Scheduled                    | CB2 Scheduled                    | Call answered                    | CB2 Scheduled                     |
+    |              | within 30m window                 | before 30m window                               | after 30m window                 | after 30m window                 | after 72 window                  | within 30m window                 |
+    |              | AND                               | AND                                             | AND                              | AND                              |                                  | AND                               |
+    |              | current time within 72h window    | current time within 72h window                  | current time within 72h window   | current time after 72h window    |                                  | call answered within 72 window    |
+    +--------------+-----------------------------------+-------------------------------------------------+----------------------------------+----------------------------------+----------------------------------+-----------------------------------+
+    | SLA 1 missed |               FALSE               |                       TRUE                      |               TRUE               |               TRUE               |               TRUE               |               FALSE               |
+    +--------------+-----------------------------------+-------------------------------------------------+----------------------------------+----------------------------------+----------------------------------+-----------------------------------+
+    | SLA 2 missed |               FALSE               |                      FALSE                      |               FALSE              |               TRUE               |               TRUE               |               FALSE               |
+    +--------------+-----------------------------------+-------------------------------------------------+----------------------------------+----------------------------------+----------------------------------+-----------------------------------+
+    | test         | test_cb2_current_time_within_sla1 | test_cb2_current_time_before_requires_action_at | test_cb2_current_time_after_sla1 | test_cb2_current_time_after_sla2 | test_cb2_current_time_after_sla2 | test_cb2_current_time_within_sla1 |
+    +--------------+-----------------------------------+-------------------------------------------------+----------------------------------+----------------------------------+----------------------------------+-----------------------------------+
+
+    CB3
+    +--------------+-----------------------------------+
+    |              | CB3 Scheduled                     |
+    |              | within 30m window                 |
+    |              | AND                               |
+    |              | call answered within 72 window    |
+    +--------------+-----------------------------------+
+    | SLA 1 missed |               FALSE               |
+    +--------------+-----------------------------------+
+    | SLA 2 missed |               FALSE               |
+    +--------------+-----------------------------------+
+    | test         | test_cb3_current_time_within_sla1 |
+    +--------------+-----------------------------------+
+    """
+    # fmt: on
+
+    def get_default_dt(self):
+        return _make_datetime(year=2020, month=9, day=7, hour=9, minute=0)
+
+    def get_requires_action_at(self):
+        return self.now + datetime.timedelta(hours=1)
+
+    def get_sla1_datetime(self):
+        return self.get_requires_action_at() + datetime.timedelta(minutes=30)
+
+    def get_sla2_datetime(self):
+        return _make_datetime(year=2020, month=9, day=15, hour=12, minute=30)
+
+    def test_current_time_before_requires_action_at(self):
+        case = self.make_case(self.now, created=self.now)
         user = make_user()
         make_recipe("call_centre.operator", user=user)
 
-        # Create CB 1
-        requires_action_at = created + datetime.timedelta(hours=1)
-        self.schedule_callback(case, user, created, requires_action_at)
+        # Create a callback that is due now 1 hour from now
+        requires_action_at = self.get_requires_action_at()
+        self.schedule_callback(case, user, created=self.now, requires_action_at=requires_action_at)
 
-        # Create CB2 within SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=25))
-
-        # Create CB3 within SLA1 window
-        self.schedule_callback(case, user, requires_action_at + datetime.timedelta(minutes=28))
-
-        # Start call
-        self.start_call(case, user, requires_action_at + datetime.timedelta(minutes=60 * 60))
-
-        date_range = (_make_datetime(2015, 1, 1), _make_datetime(2015, 2, 1))
+        # Move current time to 5 minute before requires_action_at
+        self._move_time_forward(requires_action_at, minutes_forward=-5)
+        # Generate report without a callback
+        date_range = (self.now - datetime.timedelta(days=2), self.now + datetime.timedelta(days=2))
         values = self.get_report(date_range)
-
         self.assertFalse(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (self.now - datetime.timedelta(days=2), self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        # Contacting customer before the requires_action_at will result in a failure to meet SLA
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+    def test_cb2_current_time_before_requires_action_at(self):
+        case = self.make_case(self.now, created=self.now)
+        user = make_user()
+        make_recipe("call_centre.operator", user=user)
+        # Create CB1
+        requires_action_at = self.get_requires_action_at()
+        self.schedule_callback(case, user, created=self.now, requires_action_at=requires_action_at)
+
+        # Move current time to 5 minute before requires_action_at
+        self._move_time_forward(requires_action_at, minutes_forward=-5)
+
+        # Create  CB2
+        self.schedule_callback(case, user, created=self.now, requires_action_at=self.get_requires_action_at())
+
+        # Generate report without a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
+        self.assertFalse(values["missed_sla_2"])
+
+        # Start a call
+        self.start_call(case, user, self.now)
+        # Generate report with a successful callback
+        date_range = (case.created, self.now + datetime.timedelta(days=2))
+        values = self.get_report(date_range)
+        self.assertTrue(values["missed_sla_1"])
         self.assertFalse(values["missed_sla_2"])
 
 
@@ -331,10 +500,8 @@ class MiSlaTestCasePhone(MiSlaTestCaseWeb):
     source = CASE_SOURCE.PHONE
 
 
-class MiSlaTestCaseSMS(MiSlaTestCaseBase):
+class MiSlaTestCaseSMS(MiSlaTestCaseBase, TestCase):
     source = CASE_SOURCE.SMS
-    SLA1_MINUTES = 120
-    SLA2_MINUTES = 480
 
     # fmt: off
     """
@@ -354,299 +521,17 @@ class MiSlaTestCaseSMS(MiSlaTestCaseBase):
     """
     # fmt: on
 
-    def setUp(self):
-        super(MiSlaTestCaseSMS, self).setUp()
-        hours = {"weekday": (datetime.time(9, 0), datetime.time(20, 0))}
-        operator_hours = OpeningHours(**hours)
-        from legalaid.utils import sla
+    def get_default_dt(self):
+        return _make_datetime(year=2020, month=9, day=7, hour=9, minute=0)
 
-        self.operator_hours_patcher = mock.patch.object(sla, "operator_hours", operator_hours)
-        self.operator_hours_patcher.start()
+    def get_requires_action_at(self):
+        return self.now + datetime.timedelta(hours=1)
 
-    def tearDown(self):
-        super(MiSlaTestCaseSMS, self).tearDown()
-        self.operator_hours_patcher.stop()
+    def get_sla1_datetime(self):
+        return _make_datetime(year=2020, month=9, day=7, hour=11, minute=0)
 
-    def move_time_forward_minutes_before_sla1(self, dt, timezone_mock, naive_mock, minutes):
-        move_minutes = self.SLA1_MINUTES - minutes
-        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
-
-    def move_time_forward_minutes_after_sla1(self, dt, timezone_mock, naive_mock, minutes):
-        move_minutes = self.SLA1_MINUTES + minutes
-        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
-
-    def move_time_forward_minutes_before_sla2(self, dt, timezone_mock, naive_mock, minutes):
-        move_minutes = self.SLA2_MINUTES - minutes
-        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
-
-    def move_time_forward_minutes_after_sla2(self, dt, timezone_mock, naive_mock, minutes):
-        move_minutes = self.SLA2_MINUTES + minutes
-        return self._move_time_forward(dt, timezone_mock, naive_mock, move_minutes)
-
-    def _move_time_forward(self, dt, timezone_mock, naive_mock, minutes_forward):
-        dt += datetime.timedelta(minutes=minutes_forward)
-        timezone_mock.return_value = dt
-        if naive_mock:
-            naive_mock.return_value = timezone.make_naive(dt, dt.tzinfo)
-
-        return dt
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_current_time_before_sla1(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create a callback that is due now
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Move current time to 1 minute before SLA1
-        self.move_time_forward_minutes_before_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-        # Generate report without a callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertFalse(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertFalse(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_current_time_after_sla1(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create a callback that is due now
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Move current time to 1 minute after SLA1
-        now_tz = self.move_time_forward_minutes_after_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-
-        # Generate report without a callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_current_time_before_sla2(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create a callback that is due now
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Move current time to 1 minute before SLA2
-        now_tz = self.move_time_forward_minutes_before_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-
-        # Generate report without a callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_current_time_after_sla2(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create a callback that is due now
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Move current time to 1 minute after SLA2
-        now_tz = self.move_time_forward_minutes_after_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-
-        # Generate report without a callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertTrue(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertTrue(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_cb2_current_time_before_sla1(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create CB1
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-        # Move current time to 1 minute before SLA1
-        now_tz = self.move_time_forward_minutes_before_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-        # Create  CB2
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Generate report without a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertFalse(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertFalse(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_cb2_current_time_after_sla1(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create CB1
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-        # Move current time 1 minute after SLA1
-        now_tz = self.move_time_forward_minutes_after_sla1(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-        # Create  CB2
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Generate report without a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_cb2_current_time_before_sla2(self, mock_common_datetime, timezone_mock):
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, timezone.get_current_timezone())
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-        # Create CB1
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-        # Move current time 1 minute before SLA2
-        now_tz = self.move_time_forward_minutes_before_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-        # Create  CB2
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Generate report without a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertFalse(values["missed_sla_2"])
-
-    @mock.patch("django.utils.timezone.now")
-    @mock.patch("cla_common.call_centre_availability.current_datetime")
-    def test_cb2_current_time_after_sla2(self, mock_common_datetime, timezone_mock):
-        # Scenario: SLA2 is missed eventhough a successful callback was attempted after the SLA2 window
-
-        now_tz = _make_datetime(year=2020, month=9, day=9, hour=9, minute=0)
-        timezone_mock.return_value = now_tz
-        # Mock the current datetime used for the call centre availability checks
-        mock_common_datetime.return_value = timezone.make_naive(now_tz, now_tz.tzinfo)
-
-        case = self.make_case(now_tz, created=now_tz)
-        user = make_user()
-        make_recipe("call_centre.operator", user=user)
-
-        # Move current time 1 hour forward
-        now_tz = self._move_time_forward(now_tz, timezone_mock, mock_common_datetime, minutes_forward=60)
-
-        # Create CB1
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-        # Move current time 1 minute after SLA2
-        now_tz = self.move_time_forward_minutes_after_sla2(now_tz, timezone_mock, mock_common_datetime, minutes=1)
-        # Create  CB2
-        self.schedule_callback(case, user, created=now_tz, requires_action_at=now_tz)
-
-        # Generate report without a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertTrue(values["missed_sla_2"])
-
-        # Start a call
-        self.start_call(case, user, now_tz)
-        # Generate report with a successful callback
-        date_range = (now_tz - datetime.timedelta(days=2), now_tz + datetime.timedelta(days=2))
-        values = self.get_report(date_range)
-        self.assertTrue(values["missed_sla_1"])
-        self.assertTrue(values["missed_sla_2"])
+    def get_sla2_datetime(self):
+        return _make_datetime(year=2020, month=9, day=7, hour=17, minute=0)
 
 
 class MiSlaTestCaseVoiceMail(MiSlaTestCaseSMS):

--- a/cla_backend/settings/testing.py
+++ b/cla_backend/settings/testing.py
@@ -1,7 +1,6 @@
 from datetime import date, time
 from .base import *
 
-
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
@@ -20,6 +19,8 @@ DATABASES["default"]["ENGINE"] = "cla_backend.apps.reports.db.backend"
 ALLOWED_HOSTS = ["*"]
 
 TEST_OUTPUT_DIR = "test-reports"
+
+OPERATOR_HOURS = {"weekday": (time(9, 0), time(20, 0)), "saturday": (time(9, 0), time(12, 30))}
 
 
 class DisableMigrations(object):


### PR DESCRIPTION
## What does this pull request do?

- Introduces 72 hour sla(sla_72h) in the callback event context.
 - Added django command that updates previous callback events to include the sla_72h in the Log.context json field
    - **This will update all existing cases, please review carefully as it should not create any case logs or external communications**
 - Updated legalaid.utils.sla.get_sla_time so that it calculates working hours in some edge cases
    - When the start_time is within current working hours (i.e. 5PM) but the `minutes_delta` would  take you into the next working day, it would include the hours in between in the return sla
    - **Please carefully review this change as this method underpins the entire reporting**
- Updates previous tests that asserted the values of Log.context.
- Rewrote/restructured tests cla_backend/apps/reports/tests/test_mi_sla_report.py
   - Updated MiSlaTestCaseBase to include common shared test scenarios
     - These tests were mostly already present on MiSlaTestCaseSMS and added in https://github.com/ministryofjustice/cla_backend/pull/670 
   - Changes allow for tests to use fix times in test which are required when calculating expected results for 72 working hours period, I believe changes also make it easier to follow/reason with tests now
   - MiSlaTestCaseWeb now only contains two tests in addition to what is in MiSlaTestCaseBase

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
