### PR TITLE
Static UAT use cloud platform database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
             source .circleci/define_build_environment_variables << parameters.namespace >> << parameters.dynamic_hostname >>
             pip3 install requests
             export PINGDOM_IPS=`python3 bin/pingdom_ips.py`
-            ./bin/<< parameters.namespace >>_deploy.sh
+            ./bin/<< parameters.namespace >>_deploy.sh << parameters.dynamic_hostname >>
             echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
       - slack/notify:
           message: ':tada: (<< parameters.namespace >>) Deployed branch $CIRCLE_BRANCH'

--- a/bin/uat_deploy.sh
+++ b/bin/uat_deploy.sh
@@ -2,12 +2,16 @@
 set -e
 
 ROOT=$(dirname "$0")
+DYNAMIC_HOSTNAME=$1
 HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
-
+VALUES="values-uat-static.yaml"
+if [ $DYNAMIC_HOSTNAME = true ]; then
+  VALUES="values-uat.yaml"
+fi
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_UAT_NAMESPACE} \
-  --values ${HELM_DIR}/values-uat.yaml \
+  --values "${HELM_DIR}/$VALUES" \
   --set fullnameOverride=$RELEASE_NAME \
   --set environment=$RELEASE_NAME \
   --set host=$RELEASE_HOST \

--- a/helm_deploy/cla-backend/templates/deployment.yaml
+++ b/helm_deploy/cla-backend/templates/deployment.yaml
@@ -104,11 +104,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: database
-                  key: password
-                  optional: true
+              value: {{ .Values.envVars.DB_PASSWORD.value }}
             - name: POSTGRES_USER
               value: postgres
             - name: POSTGRES_DB

--- a/helm_deploy/cla-backend/values-uat-static.yaml
+++ b/helm_deploy/cla-backend/values-uat-static.yaml
@@ -1,0 +1,24 @@
+# Default values for cla-backend in a dev environment.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+environment: "uat"
+image:
+  pullPolicy: IfNotPresent
+
+localPostgres:
+  enabled: false
+
+ingress:
+  enabled: true
+  whitelist_additional:
+    - 52.210.85.116/32
+
+# Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
+envVars:
+  DEBUG:
+    value: "False"
+  REPLICA_DB_HOST:
+    secret:
+      optional: true
+  LOAD_TEST_DATA:
+    value: "True"

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -17,12 +17,20 @@ ingress:
 envVars:
   DEBUG:
     value: "False"
+  DB_PASSWORD:
+    value: "thisisapassword"
+    secret: ~
+  DB_USER:
+    value: "postgres"
+    secret: ~
+  DB_NAME:
+    value: "cla_backend"
+    secret: ~
   DB_HOST:
     secret:
       optional: true
   DB_PORT:
     secret:
-      name: database
       key: port
       optional: true
   REPLICA_DB_HOST:


### PR DESCRIPTION
## What does this pull request do?

- Move local postgress credentials from secret to values file. The database secret will be populated with the persistent cloud platform hosted postgres credentials

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
