### PR TITLE
LGA-1466 - Sentry log 404s

### DIFF
--- a/cla_backend/apps/core/views.py
+++ b/cla_backend/apps/core/views.py
@@ -4,8 +4,9 @@ from sentry_sdk import capture_message, push_scope
 
 def page_not_found(request, *args, **kwargs):
     with push_scope() as scope:
-        scope.set_tag("type", "404")
-        scope.set_extra("path", request.path)
+        scope.set_tag("path", request.path)
+        for i, part in enumerate(request.path.strip("/").split("/")):
+            scope.set_tag("path_{}".format(i), part)
 
         capture_message("Page not found", level="error")
 

--- a/cla_backend/apps/core/views.py
+++ b/cla_backend/apps/core/views.py
@@ -1,8 +1,12 @@
 from django.views import defaults
-from sentry_sdk import capture_message
+from sentry_sdk import capture_message, push_scope
 
 
-def page_not_found(*args, **kwargs):
-    capture_message("Page not found", level="error")
+def page_not_found(request, *args, **kwargs):
+    with push_scope() as scope:
+        scope.set_tag("type", "404")
+        scope.set_extra("path", request.path)
 
-    return defaults.page_not_found(*args, **kwargs)
+        capture_message("Page not found", level="error")
+
+    return defaults.page_not_found(request, *args, **kwargs)

--- a/cla_backend/apps/core/views.py
+++ b/cla_backend/apps/core/views.py
@@ -1,0 +1,8 @@
+from django.views import defaults
+from sentry_sdk import capture_message
+
+
+def page_not_found(*args, **kwargs):
+    capture_message("Page not found", level="error")
+
+    return defaults.page_not_found(*args, **kwargs)

--- a/cla_backend/urls.py
+++ b/cla_backend/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls.static import static
 
 urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+handler404 = "core.views.page_not_found"
+
 
 if settings.ADMIN_ENABLED:
     # Uncomment the next two lines to enable the admin:


### PR DESCRIPTION
## What does this pull request do?

Logs to sentry. It only creates one event, regardless of path, but the path is broken up and available as event tags so we should be able to manage the different 404s on the Sentry platform by custom grouping and ignoring rules.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
