### PR TITLE
LGA-1542 - Remove mortgage cap

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -80,7 +80,7 @@ class CapitalCalculator(object):
         if not prop:
             return
 
-        mortgage_disregard = min(prop["mortgage_left"], self.mortgage_disregard_available)
+        mortgage_disregard = prop["mortgage_left"]
 
         property_equity = prop["value"] - mortgage_disregard
         # if prop.in_joint_names:
@@ -88,10 +88,7 @@ class CapitalCalculator(object):
             property_equity * prop["share"] / 100
         )  # assuming that you filled in share with the right figure (that is, in_joint_names not required)
 
-        remaining_mortgage_disregard = self.mortgage_disregard_available - mortgage_disregard
-
         prop["equity"] = max(property_equity, 0)
-        self.mortgage_disregard_available = remaining_mortgage_disregard
 
     def _apply_SMOD_disregard(self, prop):
         if not prop or not prop["disputed"]:
@@ -113,7 +110,6 @@ class CapitalCalculator(object):
         prop["equity"] = max(prop["equity"] - self.equity_disregard_available, 0)
 
     def _reset_state(self):
-        self.mortgage_disregard_available = constants.MORTGAGE_DISREGARD
         self.SMOD_disregard_available = constants.SMOD_DISREGARD
         self.equity_disregard_available = constants.EQUITY_DISREGARD
 

--- a/cla_backend/libs/eligibility_calculator/constants.py
+++ b/cla_backend/libs/eligibility_calculator/constants.py
@@ -2,7 +2,6 @@ from .util import BetweenDict
 
 
 # Disposable capital
-MORTGAGE_DISREGARD = 10000000
 SMOD_DISREGARD = 10000000
 EQUITY_DISREGARD = 10000000
 

--- a/cla_backend/libs/eligibility_calculator/constants.py
+++ b/cla_backend/libs/eligibility_calculator/constants.py
@@ -2,6 +2,7 @@ from .util import BetweenDict
 
 
 # Disposable capital
+MORTGAGE_DISREGARD = 10000000
 SMOD_DISREGARD = 10000000
 EQUITY_DISREGARD = 10000000
 

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -13,7 +13,6 @@ from ..models import CaseData, Facts
 class MortgageCapRemovalMixin(object):
     def setUp(self):
         super(MortgageCapRemovalMixin, self).setUp()
-        super(MortgageCapRemovalMixin, self).setUp()
         if CapitalCalculator.is_post_mortgage_cap_removal():
             self.expected_results_key = "post_mortgage_cap_removal"
         else:

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -63,10 +63,10 @@ class TestCapitalCalculator(unittest.TestCase):
         calc = CapitalCalculator(properties=[self.make_property(52000000, 15000000, 100, True, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 22000000)
-        self.assertEqual(calc.main_property["equity"], 22000000)
+        self.assertEqual(capital, 17000000)
+        self.assertEqual(calc.main_property["equity"], 17000000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [22000000], "property_capital": 22000000, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [17000000], "property_capital": 17000000, "liquid_capital": 0}
         )
 
     def test_scenario_smod_3(self):
@@ -82,12 +82,10 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 500000)
+        self.assertEqual(capital, 0)
         self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 500000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 500000], "property_capital": 500000, "liquid_capital": 0}
-        )
+        self.assertEqual(calc.other_properties[0]["equity"], 0)
+        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
 
     def test_scenario_smod_4(self):
         # The applicant’s main home is worth £240,000 and her other property is worth £90,000,
@@ -103,12 +101,10 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 1000000)
-        self.assertEqual(calc.main_property["equity"], 1000000)
+        self.assertEqual(capital, 0)
+        self.assertEqual(calc.main_property["equity"], 0)
         self.assertEqual(calc.other_properties[0]["equity"], 0)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [1000000, 0], "property_capital": 1000000, "liquid_capital": 0}
-        )
+        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
 
     def test_scenario_no_smod_1(self):
         # The applicant has a home worth £150,000 and the mortgage is £75,000
@@ -124,11 +120,9 @@ class TestCapitalCalculator(unittest.TestCase):
         calc = CapitalCalculator(properties=[self.make_property(21500000, 20000000, 100, False, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 1500000)
-        self.assertEqual(calc.main_property["equity"], 1500000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [1500000], "property_capital": 1500000, "liquid_capital": 0}
-        )
+        self.assertEqual(capital, 0)
+        self.assertEqual(calc.main_property["equity"], 0)
+        self.assertDictEqual(calc.calcs, {"property_equities": [0], "property_capital": 0, "liquid_capital": 0})
 
     def test_scenario_no_smod_3(self):
         # The client has a main dwelling worth £150,000 and a second dwelling worth £100,000.
@@ -141,11 +135,11 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 5000000)
-        self.assertEqual(calc.main_property["equity"], 3000000)
+        self.assertEqual(capital, 2000000)
+        self.assertEqual(calc.main_property["equity"], 0)
         self.assertEqual(calc.other_properties[0]["equity"], 2000000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [3000000, 2000000], "property_capital": 5000000, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [0, 2000000], "property_capital": 2000000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_A12(self):
@@ -183,9 +177,9 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 800100)
+        self.assertEqual(capital, 800000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 800100], "property_capital": 800100, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [0, 800000], "property_capital": 800000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_A15(self):
@@ -193,9 +187,9 @@ class TestCapitalCalculator(unittest.TestCase):
         calc = CapitalCalculator(properties=[self.make_property(20800100, 10000100, 100, False, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 800100)
+        self.assertEqual(capital, 800000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [800100], "property_capital": 800100, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [800000], "property_capital": 800000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_A16(self):
@@ -209,9 +203,9 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 3300000)
+        self.assertEqual(capital, 800000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [2500000, 0], "property_capital": 2500000, "liquid_capital": 800000}
+            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 800000}
         )
 
     def test_laa_scenario_A17(self):
@@ -315,7 +309,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Not SMOD
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000
-        # Capital £1,000 from First, £84,000 from Second Fail
+        # Capital £0 from First, £84,000 from Second Fail
 
         # from @marco, it doesn't matter which property is the
         # main one as no SMOD applies
@@ -328,11 +322,11 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 8500000)
-        self.assertEqual(calc.main_property["equity"], 100000)
+        self.assertEqual(capital, 8400000)
+        self.assertEqual(calc.main_property["equity"], 0)
         self.assertEqual(calc.other_properties[0]["equity"], 8400000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [100000, 8400000], "property_capital": 8500000, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [0, 8400000], "property_capital": 8400000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_smod_8(self):
@@ -360,7 +354,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Second SMOD
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital £1,000 from First, Pass
+        # Capital £0, Pass
 
         calc = CapitalCalculator(
             properties=[
@@ -370,18 +364,16 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 100000)
-        self.assertEqual(calc.main_property["equity"], 100000)
+        self.assertEqual(capital, 0)
+        self.assertEqual(calc.main_property["equity"], 0)
         self.assertEqual(calc.other_properties[0]["equity"], 0)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 0}
-        )
+        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
 
     def test_laa_scenario_smod_10(self):
         # Client and Partner 1 Property each, Both SMOD
         # MV £156,000, Mortgage £89,000, SMOD, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital £84,000 from Second, Fail
+        # Capital £51,000 from Second, Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -391,11 +383,11 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 8400000)
+        self.assertEqual(capital, 5100000)
         self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 8400000)
+        self.assertEqual(calc.other_properties[0]["equity"], 5100000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 8400000], "property_capital": 8400000, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [0, 5100000], "property_capital": 5100000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_smod_11(self):
@@ -421,7 +413,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Reside in Partner's Property, Second SMOD
         # MV £156,000, Mortgage £89,000, SMOD
         # MV £129,000, Mortgage £45,000,Equity Disregard
-        # Capital £18,000 Fail
+        # Capital £0 Pass
 
         calc = CapitalCalculator(
             properties=[
@@ -431,16 +423,14 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 1800000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 1800000], "property_capital": 1800000, "liquid_capital": 0}
-        )
+        self.assertEqual(capital, 0)
+        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
 
     def test_laa_scenario_smod_13(self):
         # Client and Partner 1 Property each, Reside in Partner's Property, Both SMOD
         # MV £156,000, Mortgage £89,000, SMOD
         # MV £129,000, Mortgage £45,000, SMOD, Equity Disregard
-        # Capital £67,000 Fail
+        # Capital £51,000 Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -450,9 +440,9 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 6700000)
+        self.assertEqual(capital, 5100000)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [6700000, 0], "property_capital": 6700000, "liquid_capital": 0}
+            calc.calcs, {"property_equities": [5100000, 0], "property_capital": 5100000, "liquid_capital": 0}
         )
 
     def test_laa_scenario_smod_14(self):
@@ -476,7 +466,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client - 2 Properties, Both SMOD, High Value, Joint Owned
         # MV £340,000, Mortgage £220,500, 50%, SMOD, Equity Disregard
         # MV £210,000, Mortgage £195,000, 50%, SMOD
-        # Capital £55,000 Fail
+        # Capital £0 Pass
 
         calc = CapitalCalculator(
             properties=[
@@ -486,10 +476,8 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 5500000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 5500000], "property_capital": 5500000, "liquid_capital": 0}
-        )
+        self.assertEqual(capital, 0)
+        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
 
     def test_scenario_assets_smod_1(self):
         # The applicant has a home worth £120,000 and the mortgage is £80,000.
@@ -595,21 +583,21 @@ class TestCapitalCalculator(unittest.TestCase):
             disputed_liquid_capital=1000000 + 1200000,
         )
         capital = calc.calculate_capital()
-        self.assertEqual(calc.main_property["equity"], 100000)
-        self.assertEqual(capital, 1186789)
+        self.assertEqual(calc.main_property["equity"], 0)
+        self.assertEqual(capital, 1086789)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 1086789}
+            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 1086789}
         )
 
     def test_laa_scenario_assets_smod_A57(self):
         # Client, Partner, No Children, Passported (IS), Property
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital from property £1,000, SMOD remaining after property £16,000
+        # Capital from property £0, SMOD remaining after property £16,000
         # Undisputed Assets Savings £3000 Investments £1500 IOV £499.99 Owed £0
         # Partner Assets Savings £1,000, Investments £1,000
         # Disputed Assets Savings £0 Investments £2,500, IOV £500 Owed £0
-        # Just Pass (£7,999.99 capital and £13,000 SMOD remaining)
+        # Just Pass (£6,999.99 capital and £13,000 SMOD remaining)
         calc = CapitalCalculator(
             properties=[
                 self.make_property(15600000, 8900000, 100, False, True),
@@ -619,9 +607,9 @@ class TestCapitalCalculator(unittest.TestCase):
             disputed_liquid_capital=250000 + 50000,
         )
         capital = calc.calculate_capital()
-        self.assertEqual(capital, 799999)
+        self.assertEqual(capital, 699999)
         self.assertDictEqual(
-            calc.calcs, {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 699999}
+            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 699999}
         )
 
 
@@ -784,10 +772,10 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
                 "dependants_allowance": 0,
                 "employment_allowance": 0,
                 "partner_employment_allowance": 0,
-                "property_capital": 10000001,
-                "property_equities": [10000001],
+                "property_capital": 10000000,
+                "property_equities": [10000000],
                 "liquid_capital": 79999,
-                "disposable_capital_assets": 80000,
+                "disposable_capital_assets": 79999,
             },
         )
 
@@ -808,10 +796,10 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
                 "dependants_allowance": 0,
                 "employment_allowance": 0,
                 "partner_employment_allowance": 0,
-                "property_capital": 10000002,
-                "property_equities": [10000002],
+                "property_capital": 10000001,
+                "property_equities": [10000001],
                 "liquid_capital": 79999,
-                "disposable_capital_assets": 80001,
+                "disposable_capital_assets": 80000,
             },
         )
 
@@ -861,10 +849,10 @@ class TestApplicantSinglePensionerNotOnBenefits(CalculatorTestBase):
                 "dependants_allowance": 0,
                 "employment_allowance": 4500,
                 "partner_employment_allowance": 0,
-                "property_capital": 2,
-                "property_equities": [2],
+                "property_capital": 1,
+                "property_equities": [1],
                 "liquid_capital": 800004,
-                "disposable_capital_assets": 800006,
+                "disposable_capital_assets": 800005,
             },
         )
 

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -10,7 +10,28 @@ from ..exceptions import PropertyExpectedException
 from ..models import CaseData, Facts
 
 
-class TestCapitalCalculator(unittest.TestCase):
+class MortgageCapRemovalMixin(object):
+    def setUp(self):
+        super(MortgageCapRemovalMixin, self).setUp()
+        super(MortgageCapRemovalMixin, self).setUp()
+        if CapitalCalculator.is_post_mortgage_cap_removal():
+            self.expected_results_key = "post_mortgage_cap_removal"
+        else:
+            self.expected_results_key = "pre_mortgage_cap_removal"
+
+
+class TestCapitalCalculator(MortgageCapRemovalMixin, unittest.TestCase):
+    def _assert_calculations(self, expected_results, capital_calculator, capital):
+        self.assertEqual(capital, expected_results["capital"])
+        if "main_property_equity" in expected_results:
+            self.assertEqual(capital_calculator.main_property["equity"], expected_results["main_property_equity"])
+        if "other_properties_equity" in expected_results:
+            self.assertEqual(
+                capital_calculator.other_properties[0]["equity"], expected_results["other_properties_equity"]
+            )
+
+        self.assertDictEqual(capital_calculator.calcs, expected_results["calcs"])
+
     def test_incomplete_property_raises_exception(self):
         for i in range(5):
             prop = [24000000, 8000000, 100, True, True]
@@ -63,11 +84,19 @@ class TestCapitalCalculator(unittest.TestCase):
         calc = CapitalCalculator(properties=[self.make_property(52000000, 15000000, 100, True, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 17000000)
-        self.assertEqual(calc.main_property["equity"], 17000000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [17000000], "property_capital": 17000000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 22000000,
+                "main_property_equity": 22000000,
+                "calcs": {"property_equities": [22000000], "property_capital": 22000000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 17000000,
+                "main_property_equity": 17000000,
+                "calcs": {"property_equities": [17000000], "property_capital": 17000000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_scenario_smod_3(self):
         # The applicant’s main home is worth £240,000 and her other property is worth £90,000,
@@ -82,10 +111,22 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 500000,
+                "main_property_equity": 0,
+                "other_properties_equity": 500000,
+                "calcs": {"property_equities": [0, 500000], "property_capital": 500000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "main_property_equity": 0,
+                "other_properties_equity": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_scenario_smod_4(self):
         # The applicant’s main home is worth £240,000 and her other property is worth £90,000,
@@ -101,10 +142,19 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 1000000,
+                "main_property_equity": 1000000,
+                "calcs": {"property_equities": [1000000, 0], "property_capital": 1000000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "main_property_equity": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_scenario_no_smod_1(self):
         # The applicant has a home worth £150,000 and the mortgage is £75,000
@@ -120,9 +170,19 @@ class TestCapitalCalculator(unittest.TestCase):
         calc = CapitalCalculator(properties=[self.make_property(21500000, 20000000, 100, False, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 1500000,
+                "main_property_equity": 1500000,
+                "calcs": {"property_equities": [1500000], "property_capital": 1500000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "main_property_equity": 0,
+                "calcs": {"property_equities": [0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_scenario_no_smod_3(self):
         # The client has a main dwelling worth £150,000 and a second dwelling worth £100,000.
@@ -135,12 +195,21 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 2000000)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 2000000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 2000000], "property_capital": 2000000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 5000000,
+                "main_property_equity": 3000000,
+                "other_property_equity": 2000000,
+                "calcs": {"property_equities": [3000000, 2000000], "property_capital": 5000000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 2000000,
+                "main_property_equity": 0,
+                "other_property_equity": 2000000,
+                "calcs": {"property_equities": [0, 2000000], "property_capital": 2000000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_A12(self):
         # Testing if equity disregard applied to first property only
@@ -177,20 +246,34 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 800000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 800000], "property_capital": 800000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 800100,
+                "calcs": {"property_equities": [0, 800100], "property_capital": 800100, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 800000,
+                "calcs": {"property_equities": [0, 800000], "property_capital": 800000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_A15(self):
         # Testing if mortgage disregard capped on first property
         calc = CapitalCalculator(properties=[self.make_property(20800100, 10000100, 100, False, True)])
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 800000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [800000], "property_capital": 800000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 800100,
+                "calcs": {"property_equities": [800100], "property_capital": 800100, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 800000,
+                "calcs": {"property_equities": [800000], "property_capital": 800000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_A16(self):
         # Testing if mortgage disregard capped across all properties
@@ -203,10 +286,17 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 800000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 800000}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 3300000,
+                "calcs": {"property_equities": [2500000, 0], "property_capital": 2500000, "liquid_capital": 800000},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 800000,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 800000},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_A17(self):
         # Testing if mortgage disregard applied to second property before first
@@ -309,7 +399,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Not SMOD
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000
-        # Capital £0 from First, £84,000 from Second Fail
+        # Capital £1,000 from First, £84,000 from Second Fail
 
         # from @marco, it doesn't matter which property is the
         # main one as no SMOD applies
@@ -322,12 +412,21 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 8400000)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 8400000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 8400000], "property_capital": 8400000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 8500000,
+                "main_property_equity": 100000,
+                "other_property_equity": 8400000,
+                "calcs": {"property_equities": [100000, 8400000], "property_capital": 8500000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 8400000,
+                "main_property_equity": 0,
+                "other_property_equity": 8400000,
+                "calcs": {"property_equities": [0, 8400000], "property_capital": 8400000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_smod_8(self):
         # Client and Partner 1 Property each, First SMOD
@@ -354,7 +453,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Second SMOD
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital £0, Pass
+        # Capital £1,000 from First, Pass
 
         calc = CapitalCalculator(
             properties=[
@@ -364,16 +463,27 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 100000,
+                "main_property_equity": 100000,
+                "other_property_equity": 0,
+                "calcs": {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "main_property_equity": 0,
+                "other_property_equity": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_smod_10(self):
         # Client and Partner 1 Property each, Both SMOD
         # MV £156,000, Mortgage £89,000, SMOD, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital £51,000 from Second, Fail
+        # Capital £84,000 from Second, Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -383,12 +493,21 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 5100000)
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(calc.other_properties[0]["equity"], 5100000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 5100000], "property_capital": 5100000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 8400000,
+                "main_property_equity": 0,
+                "other_property_equity": 8400000,
+                "calcs": {"property_equities": [0, 8400000], "property_capital": 8400000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 5100000,
+                "main_property_equity": 0,
+                "other_property_equity": 5100000,
+                "calcs": {"property_equities": [0, 5100000], "property_capital": 5100000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_smod_11(self):
         # Client and Partner 1 Property each, Reside in Partner's Property, First SMOD
@@ -413,7 +532,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client and Partner 1 Property each, Reside in Partner's Property, Second SMOD
         # MV £156,000, Mortgage £89,000, SMOD
         # MV £129,000, Mortgage £45,000,Equity Disregard
-        # Capital £0 Pass
+        # Capital £18,000 Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -423,14 +542,23 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 1800000,
+                "calcs": {"property_equities": [0, 1800000], "property_capital": 1800000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_smod_13(self):
         # Client and Partner 1 Property each, Reside in Partner's Property, Both SMOD
         # MV £156,000, Mortgage £89,000, SMOD
         # MV £129,000, Mortgage £45,000, SMOD, Equity Disregard
-        # Capital £51,000 Fail
+        # Capital £67,000 Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -440,10 +568,17 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 5100000)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [5100000, 0], "property_capital": 5100000, "liquid_capital": 0}
-        )
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 6700000,
+                "calcs": {"property_equities": [6700000, 0], "property_capital": 6700000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 5100000,
+                "calcs": {"property_equities": [5100000, 0], "property_capital": 5100000, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_smod_14(self):
         # Client - 2 Properties, Both SMOD, Joint Owned
@@ -466,7 +601,7 @@ class TestCapitalCalculator(unittest.TestCase):
         # Client - 2 Properties, Both SMOD, High Value, Joint Owned
         # MV £340,000, Mortgage £220,500, 50%, SMOD, Equity Disregard
         # MV £210,000, Mortgage £195,000, 50%, SMOD
-        # Capital £0 Pass
+        # Capital £55,000 Fail
 
         calc = CapitalCalculator(
             properties=[
@@ -476,8 +611,17 @@ class TestCapitalCalculator(unittest.TestCase):
         )
         capital = calc.calculate_capital()
 
-        self.assertEqual(capital, 0)
-        self.assertDictEqual(calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0})
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 5500000,
+                "calcs": {"property_equities": [0, 5500000], "property_capital": 5500000, "liquid_capital": 0},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 0},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_scenario_assets_smod_1(self):
         # The applicant has a home worth £120,000 and the mortgage is £80,000.
@@ -583,21 +727,30 @@ class TestCapitalCalculator(unittest.TestCase):
             disputed_liquid_capital=1000000 + 1200000,
         )
         capital = calc.calculate_capital()
-        self.assertEqual(calc.main_property["equity"], 0)
-        self.assertEqual(capital, 1086789)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 1086789}
-        )
+
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 1186789,
+                "main_property_equity": 100000,
+                "calcs": {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 1086789},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 1086789,
+                "main_property_equity": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 1086789},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
     def test_laa_scenario_assets_smod_A57(self):
         # Client, Partner, No Children, Passported (IS), Property
         # MV £156,000, Mortgage £89,000, Equity Disregard
         # MV £129,000, Mortgage £45,000, SMOD
-        # Capital from property £0, SMOD remaining after property £16,000
+        # Capital from property £1,000, SMOD remaining after property £16,000
         # Undisputed Assets Savings £3000 Investments £1500 IOV £499.99 Owed £0
         # Partner Assets Savings £1,000, Investments £1,000
         # Disputed Assets Savings £0 Investments £2,500, IOV £500 Owed £0
-        # Just Pass (£6,999.99 capital and £13,000 SMOD remaining)
+        # Just Pass (£7,999.99 capital and £13,000 SMOD remaining)
         calc = CapitalCalculator(
             properties=[
                 self.make_property(15600000, 8900000, 100, False, True),
@@ -607,13 +760,23 @@ class TestCapitalCalculator(unittest.TestCase):
             disputed_liquid_capital=250000 + 50000,
         )
         capital = calc.calculate_capital()
-        self.assertEqual(capital, 699999)
-        self.assertDictEqual(
-            calc.calcs, {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 699999}
-        )
+
+        expected_results = {
+            "pre_mortgage_cap_removal": {
+                "capital": 799999,
+                "main_property_equity": 100000,
+                "calcs": {"property_equities": [100000, 0], "property_capital": 100000, "liquid_capital": 699999},
+            },
+            "post_mortgage_cap_removal": {
+                "capital": 699999,
+                "main_property_equity": 0,
+                "calcs": {"property_equities": [0, 0], "property_capital": 0, "liquid_capital": 699999},
+            },
+        }
+        self._assert_calculations(expected_results[self.expected_results_key], calc, capital)
 
 
-class CalculatorTestBase(unittest.TestCase):
+class CalculatorTestBase(MortgageCapRemovalMixin, unittest.TestCase):
     def get_default_case_data(self, **kwargs):
         """
         gives default case_data with each kwarg
@@ -761,23 +924,31 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
         7999.99 of other assets should pass.
         """
         checker = self._test_pensioner_on_benefits(30000001, 10000001, 79999)
-        self.assertTrue(checker.is_eligible())
-        self.assertDictEqual(
-            checker.calcs,
-            {
-                "pensioner_disregard": 10000000,
-                "gross_income": 0,
-                "partner_allowance": 0,
-                "disposable_income": 0,
-                "dependants_allowance": 0,
-                "employment_allowance": 0,
-                "partner_employment_allowance": 0,
+        expected_results = {
+            "pensioner_disregard": 10000000,
+            "gross_income": 0,
+            "partner_allowance": 0,
+            "disposable_income": 0,
+            "dependants_allowance": 0,
+            "employment_allowance": 0,
+            "partner_employment_allowance": 0,
+            "liquid_capital": 79999,
+        }
+        expected_property_results = {
+            "pre_mortgage_cap_removal": {
+                "property_capital": 10000001,
+                "property_equities": [10000001],
+                "disposable_capital_assets": 80000,
+            },
+            "post_mortgage_cap_removal": {
                 "property_capital": 10000000,
                 "property_equities": [10000000],
-                "liquid_capital": 79999,
                 "disposable_capital_assets": 79999,
             },
-        )
+        }
+        expected_results.update(expected_property_results[self.expected_results_key])
+        self.assertTrue(checker.is_eligible())
+        self.assertDictEqual(checker.calcs, expected_results)
 
     def test_pensioner_300k2p_house_100k1p_mort_799999_savings(self):
         """
@@ -785,23 +956,33 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
         7999.99 of other assets should fail.
         """
         checker = self._test_pensioner_on_benefits(30000002, 10000001, 79999)
-        self.assertTrue(checker.is_eligible())
-        self.assertDictEqual(
-            checker.calcs,
-            {
-                "pensioner_disregard": 10000000,
-                "gross_income": 0,
-                "partner_allowance": 0,
-                "disposable_income": 0,
-                "dependants_allowance": 0,
-                "employment_allowance": 0,
-                "partner_employment_allowance": 0,
+
+        expected_results = {
+            "pensioner_disregard": 10000000,
+            "gross_income": 0,
+            "partner_allowance": 0,
+            "disposable_income": 0,
+            "dependants_allowance": 0,
+            "employment_allowance": 0,
+            "partner_employment_allowance": 0,
+            "liquid_capital": 79999,
+        }
+        expected_property_results = {
+            "pre_mortgage_cap_removal": {
+                "property_capital": 10000002,
+                "property_equities": [10000002],
+                "disposable_capital_assets": 80001,
+            },
+            "post_mortgage_cap_removal": {
                 "property_capital": 10000001,
                 "property_equities": [10000001],
-                "liquid_capital": 79999,
                 "disposable_capital_assets": 80000,
             },
-        )
+        }
+        expected_results.update(expected_property_results[self.expected_results_key])
+
+        self.assertTrue(checker.is_eligible())
+        self.assertDictEqual(checker.calcs, expected_results)
 
 
 class TestApplicantSinglePensionerNotOnBenefits(CalculatorTestBase):
@@ -838,23 +1019,32 @@ class TestApplicantSinglePensionerNotOnBenefits(CalculatorTestBase):
         )
         is_elig, checker = self._test_pensioner(case_data)
 
-        self.assertFalse(is_elig)
-        self.assertDictEqual(
-            checker.calcs,
-            {
-                "pensioner_disregard": 0,
-                "gross_income": 90507,
-                "partner_allowance": 0,
-                "disposable_income": 31501,
-                "dependants_allowance": 0,
-                "employment_allowance": 4500,
-                "partner_employment_allowance": 0,
+        expected_results = {
+            "pensioner_disregard": 0,
+            "gross_income": 90507,
+            "partner_allowance": 0,
+            "disposable_income": 31501,
+            "dependants_allowance": 0,
+            "employment_allowance": 4500,
+            "partner_employment_allowance": 0,
+            "liquid_capital": 800004,
+        }
+        expected_property_results = {
+            "pre_mortgage_cap_removal": {
+                "property_capital": 2,
+                "property_equities": [2],
+                "disposable_capital_assets": 800006,
+            },
+            "post_mortgage_cap_removal": {
                 "property_capital": 1,
                 "property_equities": [1],
-                "liquid_capital": 800004,
                 "disposable_capital_assets": 800005,
             },
-        )
+        }
+        expected_results.update(expected_property_results[self.expected_results_key])
+
+        self.assertFalse(is_elig)
+        self.assertDictEqual(checker.calcs, expected_results)
 
     def test_pensioner_limit_10k_diregard_fail(self):
         """

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -369,8 +369,8 @@ CELERY_IMPORTS = ["reports.tasks", "notifications.tasks"]
 CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "True") == "True"
 PING_JSON_KEYS["CONTRACT_2018_ENABLED_key"] = "CONTRACT_2018_ENABLED"
 
-MORTGAGE_CAP_REMOVAL_DATE = os.environ.get("MORTGAGE_CAP_REMOVAL_DATE", "2021-01-28 00:00")
-MORTGAGE_CAP_REMOVAL_DATE = datetime.datetime.strptime(MORTGAGE_CAP_REMOVAL_DATE, "%Y-%m-%d %H:%M")
+mortgage_cap_removal_date = os.environ.get("MORTGAGE_CAP_REMOVAL_DATE", "2021-01-28 00:00")
+MORTGAGE_CAP_REMOVAL_DATE = datetime.datetime.strptime(mortgage_cap_removal_date, "%Y-%m-%d %H:%M")
 
 
 def bank_holidays_cache_adapter_factory():

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -369,6 +369,8 @@ CELERY_IMPORTS = ["reports.tasks", "notifications.tasks"]
 CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "True") == "True"
 PING_JSON_KEYS["CONTRACT_2018_ENABLED_key"] = "CONTRACT_2018_ENABLED"
 
+MORTGAGE_CAP_REMOVAL_DATE = datetime.datetime(year=2021, month=1, day=28)
+
 
 def bank_holidays_cache_adapter_factory():
     from django.core.cache import cache

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -369,7 +369,8 @@ CELERY_IMPORTS = ["reports.tasks", "notifications.tasks"]
 CONTRACT_2018_ENABLED = os.environ.get("CONTRACT_2018_ENABLED", "True") == "True"
 PING_JSON_KEYS["CONTRACT_2018_ENABLED_key"] = "CONTRACT_2018_ENABLED"
 
-MORTGAGE_CAP_REMOVAL_DATE = datetime.datetime(year=2021, month=1, day=28)
+MORTGAGE_CAP_REMOVAL_DATE = os.environ.get("MORTGAGE_CAP_REMOVAL_DATE", "2021-01-28 00:00")
+MORTGAGE_CAP_REMOVAL_DATE = datetime.datetime.strptime(MORTGAGE_CAP_REMOVAL_DATE, "%Y-%m-%d %H:%M")
 
 
 def bank_holidays_cache_adapter_factory():

--- a/helm_deploy/cla-backend/values-uat-static.yaml
+++ b/helm_deploy/cla-backend/values-uat-static.yaml
@@ -22,3 +22,5 @@ envVars:
       optional: true
   LOAD_TEST_DATA:
     value: "True"
+  MORTGAGE_CAP_REMOVAL_DATE:
+    value: "2020-01-28 00:00"


### PR DESCRIPTION
## What does this pull request do?

- Remove mortgage cap
- Introduced MORTGAGE_CAP_REMOVAL_DATE setting with the date the mortgage cap is to be removed.
- **MORTGAGE CAP WILL AUTOMATICALLY BE REMOVED AFTER THE DATE IN settings.MORTGAGE_CAP_REMOVAL_DATE**
- Updated affected unittests with dictionary of pre/post mortgage cap removal expected values.

## Any other changes that would benefit highlighting?

- Remove mortgage cap for all properties(main and additional properties)
- Mortgage cap removal is enabled on static-uat environment

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
