### PR TITLE
LGA-1572 - Add http-keepalive config

### DIFF
--- a/docker/cla_backend.ini
+++ b/docker/cla_backend.ini
@@ -15,3 +15,7 @@ logger-req=stdio
 logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(method)", "uri": "%(uri)", "proto": "%(proto)", "status": %(status), "referer": "%(referer)", "user_agent": "%(uagent)", "remote_addr": "%(addr)", "http_host": "%(host)", "pid": %(pid), "worker_id": %(wid), "core": %(core), "async_switches": %(switches), "io_errors": %(ioerr), "rq_size": %(cl), "rs_time_ms": %(msecs), "rs_size": %(size), "rs_header_size": %(hsize), "rs_header_count": %(headers)}
 post-buffering=1
 die-on-term=True
+http-timeout = 300
+http-keepalive = 60
+http-auto-chunked = 1
+add-header = Connection: keep-alive


### PR DESCRIPTION
## What does this pull request do?

http-keepalive should hopefully prevent some dropped connections that might be causing platform instability on cla-frontend and possibly cla-public, that consume the API

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
