### PR TITLE
LGA-1121-Old complaints appearing

### DIFF
--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -185,8 +185,10 @@ class DeleteOldData(Task):
         self._delete_objects(ads)
 
     def cleanup_audit(self, pks):
+        # Deleting case audit logs
         audit_logs = AuditLog.objects.filter(case__in=pks)
         audit_logs.delete()
+        # Deleting complaint audit logs
         eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
         case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
         audit_logs = AuditLog.objects.filter(complaint__in=case_complaints)

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from cla_butler.tasks import DeleteOldData
+from core.tests.mommy_utils import make_recipe
+from legalaid.models import Case
+
+
+class TasksTestCase(TestCase):
+    def setUp(self):
+        super(TasksTestCase, self).setUp()
+        self.delete_old_data = DeleteOldData()
+
+    def create_old_case():
+        # Creates a case thats three years old
+        freezer = freeze_time(timezone.now() + relativedelta(years=-3))
+        freezer.start()
+        case = make_recipe("legalaid.case")
+        freezer.stop()
+
+        return case
+
+    def test_delete_objects(self):
+        make_recipe("legalaid.case")
+        cases = Case.objects.all()
+        self.delete_old_data._delete_objects(cases)
+        cases = Case.objects.all()
+        self.assertEqual(len(cases), 0)

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -3,9 +3,11 @@ from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
-from cla_butler.tasks import DeleteOldData
+from cla_butler.tasks import DeleteOldData, get_pks
 from core.tests.mommy_utils import make_recipe
-from legalaid.models import Case
+from cla_auditlog.models import AuditLog
+from complaints.models import Complaint
+from legalaid.models import Case, EODDetails
 
 
 class TasksTestCase(TestCase):
@@ -13,18 +15,122 @@ class TasksTestCase(TestCase):
         super(TasksTestCase, self).setUp()
         self.delete_old_data = DeleteOldData()
 
-    def create_old_case():
-        # Creates a case thats three years old
-        freezer = freeze_time(timezone.now() + relativedelta(years=-3))
-        freezer.start()
-        case = make_recipe("legalaid.case")
-        freezer.stop()
-
-        return case
-
     def test_delete_objects(self):
         make_recipe("legalaid.case")
         cases = Case.objects.all()
+
+        self.assertEqual(len(cases), 1)
+
         self.delete_old_data._delete_objects(cases)
-        cases = Case.objects.all()
-        self.assertEqual(len(cases), 0)
+
+        self.assertEqual(len(Case.objects.all()), 0)
+
+    def test_cleanup_model_from_case_complaints(self):
+        case = make_recipe("legalaid.case")
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod)
+        pks = get_pks(Case.objects.all())
+
+        self.assertEqual(len(Complaint.objects.all()), 1)
+
+        self.delete_old_data.cleanup_model_from_case(pks, Complaint, "eod__case_id")
+
+        self.assertEqual(len(Complaint.objects.all()), 0)
+
+    def test_cleanup_model_from_case_eod_details(self):
+        case = make_recipe("legalaid.case")
+        make_recipe("legalaid.eod_details", case=case)
+        pks = get_pks(Case.objects.all())
+
+        self.assertEqual(len(EODDetails.objects.all()), 1)
+
+        self.delete_old_data.cleanup_model_from_case(pks, EODDetails)
+
+        self.assertEqual(len(EODDetails.objects.all()), 0)
+
+    def test_cleanup_case_audit(self):
+        log = make_recipe("cla_auditlog.audit_log")
+        make_recipe("legalaid.case", audit_log=[log])
+        pks = get_pks(Case.objects.all())
+
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
+
+        self.delete_old_data.cleanup_audit(pks)
+
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 0)
+
+    def test_cleanup_complaint_audit(self):
+        log = make_recipe("cla_auditlog.audit_log")
+        case = make_recipe("legalaid.case")
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod, audit_log=[log])
+        pks = get_pks(Case.objects.all())
+
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
+
+        self.delete_old_data.cleanup_audit(pks)
+
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 0)
+
+    def test_delete_old_data_run_case_over_two_years_successful_delete(self):
+        log = make_recipe("cla_auditlog.audit_log")
+        
+        # Creating a case thats three years old so it gets picked up properly by the delete data  
+        freezer = freeze_time(timezone.now() + relativedelta(years=-3))
+        freezer.start()
+        case = make_recipe("legalaid.case", audit_log=[log])
+        freezer.stop()
+        
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod, audit_log=[log])
+        pks = get_pks(Case.objects.all())
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
+
+        self.assertEqual(len(Case.objects.all()), 1)
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
+        self.assertEqual(len(EODDetails.objects.all()), 1)
+        self.assertEqual(len(Complaint.objects.all()), 1)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
+
+        self.delete_old_data.run()
+
+        self.assertEqual(len(Case.objects.all()), 0)
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 0)
+        self.assertEqual(len(EODDetails.objects.all()), 0)
+        self.assertEqual(len(Complaint.objects.all()), 0)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 0)
+
+
+    def test_delete_old_data_run_case_under_two_years_unsuccessful_delete(self):
+        log = make_recipe("cla_auditlog.audit_log")
+        
+        # Creating a case using current timestamp 
+        case = make_recipe("legalaid.case", audit_log=[log])
+        
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod, audit_log=[log])
+        pks = get_pks(Case.objects.all())
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
+
+        self.assertEqual(len(Case.objects.all()), 1)
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
+        self.assertEqual(len(EODDetails.objects.all()), 1)
+        self.assertEqual(len(Complaint.objects.all()), 1)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
+
+        self.delete_old_data.run()
+
+        self.assertEqual(len(Case.objects.all()), 1)
+        self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
+        self.assertEqual(len(EODDetails.objects.all()), 1)
+        self.assertEqual(len(Complaint.objects.all()), 1)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -79,13 +79,13 @@ class TasksTestCase(TestCase):
 
     def test_delete_old_data_run_case_over_two_years_successful_delete(self):
         log = make_recipe("cla_auditlog.audit_log")
-        
-        # Creating a case thats three years old so it gets picked up properly by the delete data  
+
+        # Creating a case thats three years old so it gets picked up properly by the delete data
         freezer = freeze_time(timezone.now() + relativedelta(years=-3))
         freezer.start()
         case = make_recipe("legalaid.case", audit_log=[log])
         freezer.stop()
-        
+
         eod = make_recipe("legalaid.eod_details", case=case)
         make_recipe("complaints.complaint", eod=eod, audit_log=[log])
         pks = get_pks(Case.objects.all())
@@ -107,13 +107,12 @@ class TasksTestCase(TestCase):
         case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 0)
 
-
     def test_delete_old_data_run_case_under_two_years_unsuccessful_delete(self):
         log = make_recipe("cla_auditlog.audit_log")
-        
-        # Creating a case using current timestamp 
+
+        # Creating a case using current timestamp
         case = make_recipe("legalaid.case", audit_log=[log])
-        
+
         eod = make_recipe("legalaid.eod_details", case=case)
         make_recipe("complaints.complaint", eod=eod, audit_log=[log])
         pks = get_pks(Case.objects.all())

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -66,14 +66,14 @@ class TasksTestCase(TestCase):
         make_recipe("complaints.complaint", eod=eod, audit_log=[log])
         pks = get_pks(Case.objects.all())
 
-        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list("pk", flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
 
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
 
         self.delete_old_data.cleanup_audit(pks)
 
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
 
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 0)
 
@@ -89,13 +89,13 @@ class TasksTestCase(TestCase):
         eod = make_recipe("legalaid.eod_details", case=case)
         make_recipe("complaints.complaint", eod=eod, audit_log=[log])
         pks = get_pks(Case.objects.all())
-        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list("pk", flat=True)
 
         self.assertEqual(len(Case.objects.all()), 1)
         self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
         self.assertEqual(len(EODDetails.objects.all()), 1)
         self.assertEqual(len(Complaint.objects.all()), 1)
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
 
         self.delete_old_data.run()
@@ -104,7 +104,7 @@ class TasksTestCase(TestCase):
         self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 0)
         self.assertEqual(len(EODDetails.objects.all()), 0)
         self.assertEqual(len(Complaint.objects.all()), 0)
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 0)
 
     def test_delete_old_data_run_case_under_two_years_unsuccessful_delete(self):
@@ -116,13 +116,13 @@ class TasksTestCase(TestCase):
         eod = make_recipe("legalaid.eod_details", case=case)
         make_recipe("complaints.complaint", eod=eod, audit_log=[log])
         pks = get_pks(Case.objects.all())
-        eods = EODDetails.objects.filter(case_id__in=pks).values_list('pk', flat=True)
+        eods = EODDetails.objects.filter(case_id__in=pks).values_list("pk", flat=True)
 
         self.assertEqual(len(Case.objects.all()), 1)
         self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
         self.assertEqual(len(EODDetails.objects.all()), 1)
         self.assertEqual(len(Complaint.objects.all()), 1)
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)
 
         self.delete_old_data.run()
@@ -131,5 +131,5 @@ class TasksTestCase(TestCase):
         self.assertEqual(len(AuditLog.objects.filter(case__in=pks)), 1)
         self.assertEqual(len(EODDetails.objects.all()), 1)
         self.assertEqual(len(Complaint.objects.all()), 1)
-        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list('pk', flat=True)
+        case_complaints = Complaint.objects.filter(eod_id__in=eods).values_list("pk", flat=True)
         self.assertEqual(len(AuditLog.objects.filter(complaint__in=case_complaints)), 1)

--- a/cla_backend/apps/complaints/views.py
+++ b/cla_backend/apps/complaints/views.py
@@ -95,7 +95,7 @@ class BaseComplaintViewSet(
             }
         )
         if dashboard and not show_closed:
-            complaint_events = ComplaintLog.objects.filter(content_type=sql_params['complaint_ct'], code__in=["COMPLAINT_CLOSED", "COMPLAINT_VOID"]).values_list('object_id', flat=True)
+            complaint_events = ComplaintLog.objects.filter(content_type=sql_params['complaint_ct'], code__in=["COMPLAINT_CLOSED", "COMPLAINT_VOID"]).values_list('object_id', flat=True).order_by('object_id').distinct('object_id')
             qs = qs.exclude(id__in=complaint_events)
         return qs
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,6 +2,7 @@
 
 coverage==4.5.4
 coveralls==1.8.2
+freezegun==0.3.14
 mock==1.0.1
 model-mommy==1.2.3
 unittest-xml-reporting==2.5.1


### PR DESCRIPTION
## What does this pull request do?

The was an issue with old complaints appearing in the complaints list.  What was found was a task called DeleteOldData which was a task that would regularly delete data over two years old, with a recent introduction of audit logs this was no longer working and half deleting data which meant that complaints were now being displayed.

This pull request deletes the audit logs for cases and complaints so that it can successfully delete all required data.

What this should also do on the first run is delete all data that hasn't been deleted correctly.

## Any other changes that would benefit highlighting?

I have put a distinct filter on the complaints list when no closed complaints are closed.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
