### PR TITLE
LGA-1550 - Allow CLA super users to create Article Category models

### DIFF
--- a/cla_backend/apps/knowledgebase/admin.py
+++ b/cla_backend/apps/knowledgebase/admin.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.http.response import HttpResponseRedirect
 from django.contrib import messages
-from .models import Article, ArticleCategoryMatrix, TelephoneNumber
+from .models import Article, ArticleCategoryMatrix, TelephoneNumber, ArticleCategory
 from .forms import KnowledgebaseCSVUploadForm
 
 
@@ -90,5 +90,6 @@ class ArticleCategoryMatrixAdmin(admin.ModelAdmin):
         return obj.article_category.name
 
 
+admin.site.register(ArticleCategory, admin.ModelAdmin)
 admin.site.register(Article, ArticleAdmin)
 admin.site.register(ArticleCategoryMatrix, ArticleCategoryMatrixAdmin)

--- a/cla_backend/apps/knowledgebase/management/commands/grant_cla_superusers_article_categories_permissions.py
+++ b/cla_backend/apps/knowledgebase/management/commands/grant_cla_superusers_article_categories_permissions.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Permission, Group, ContentType
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        content_type = ContentType.objects.get(app_label="knowledgebase", model="articlecategory")
+        perms = Permission.objects.filter(content_type=content_type)
+        group = Group.objects.get(name="CLA Superusers")
+        for perm in perms:
+            group.permissions.add(perm)

--- a/cla_backend/apps/knowledgebase/tests/admin/test_command.py
+++ b/cla_backend/apps/knowledgebase/tests/admin/test_command.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission, Group, ContentType
+from django.core.management import call_command
+from django.contrib.auth.models import User
+from core.tests.mommy_utils import make_user
+
+
+class ArticleCategoryClaSuperUsersPermissionCommandTest(TestCase):
+    def test_command(self):
+        group = Group.objects.get(name="CLA Superusers")
+        cla_superuser = make_user()
+        group.user_set.add(cla_superuser)
+
+        content_type = ContentType.objects.get(app_label="knowledgebase", model="articlecategory")
+        perms = [
+            "knowledgebase.{}".format(perm.codename) for perm in Permission.objects.filter(content_type=content_type)
+        ]
+        self.assertFalse(cla_superuser.has_perms(perms))
+
+        call_command("grant_cla_superusers_article_categories_permissions")
+
+        # Reload the user object
+        user = User.objects.get(pk=cla_superuser.pk)
+        self.assertTrue(user.has_perms(perms))


### PR DESCRIPTION
## What does this pull request do?

Allow CLA super users to create Article Category models.

## Any other changes that would benefit highlighting?

It seems we were adding article categories using a management command https://github.com/ministryofjustice/cla_backend/pull/629.

I cannot see any reason why these models cannot be created using the admin interface by at least users with the role `cla super users`. 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
