### PR TITLE
[WIP] LGA-1121 - Old complaints appearing in complaints tab on CHS

### DIFF
--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -64,8 +64,10 @@ class DeleteOldData(Task):
     data = serializers.serialize("json", SomeModel.objects.all())
     """
 
-    def run(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._setup()
+
+    def run(self, *args, **kwargs):
         self.cleanup_cases()
         self.cleanup_diagnosis()
         self.cleanup_eligibility_check()

--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -112,8 +112,7 @@ class DeleteOldData(Task):
         tokens.delete()
 
     def cleanup_cases(self):
-        two_years = self.now - relativedelta(years=2)
-        cases = Case.objects.filter(modified__lte=two_years)
+        cases = self.get_eligible_cases()
         pks = get_pks(cases)
         from_cases = Case.objects.filter(from_case_id__in=pks)
         fpks = get_pks(from_cases)
@@ -131,6 +130,10 @@ class DeleteOldData(Task):
         self.cleanup_model_from_case(pks, ReasonForContacting)
         self._delete_objects(from_cases)
         self._delete_objects(cases)
+
+    def get_eligible_cases(self):
+        two_years = self.now - relativedelta(years=2)
+        return Case.objects.filter(modified__lte=two_years)
 
     def cleanup_model_from_case(self, pks, model, attr="case_id", case_log_attr=None):
         attr_in = "{attribute}__in".format(attribute=attr)

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -3,25 +3,13 @@ from dateutil.relativedelta import relativedelta
 
 from legalaid.models import Case
 from cla_butler.tasks import DeleteOldData
-from cla_eventlog.models import Log
 
 
 class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
     def get_eligible_cases(self):
         two_years = self.now - relativedelta(years=2)
-        old_cases = []
 
-        filtered_cases = Case.objects.filter(created__lte=two_years)
-        for case in filtered_cases:
-            try:
-                latest_log = Log.objects.filter(case__id=case.id).latest("created")
-                if latest_log.created <= two_years:
-                    old_cases.append(case.id)
-            except Log.DoesNotExist:
-                # Old case without any event logs
-                old_cases.append(case.id)
-
-        return Case.objects.filter(id__in=old_cases)
+        return Case.objects.filter(created__lte=two_years).exclude(log__created__gte=two_years)
 
 
 class Command(BaseCommand):

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -28,17 +28,17 @@ class Command(BaseCommand):
                 instance.run()
             else:
                 return cases
-
-        if django_command == "find_and_delete_old_cases":  # If command is run in terminal
-            if len(args) > 1 and args[1] == "no-input":
-                instance.run()
-            elif args and args[0] == "delete":
-                answer = raw_input(
-                    "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
-                        cases.count()
-                    )
-                )
-                if answer == "Yes":
+        else:  # If command is run in terminal
+            if args and args[0] == "delete":
+                if len(args) > 1 and args[1] == "no-input":
                     instance.run()
+                else:
+                    answer = raw_input(
+                        "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
+                            cases.count()
+                        )
+                    )
+                    if answer == "Yes":
+                        instance.run()
             else:
                 print("Number of cases to be deleted: " + str(cases.count()))

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             else:
                 answer = raw_input(
                     "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
-                        str(cases.count())
+                        cases.count()
                     )
                 )
                 if answer == "Yes":

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -22,12 +22,17 @@ class Command(BaseCommand):
         instance = FindAndDeleteCasesUsingCreationTime()
         cases = instance.get_eligible_cases()
         django_command = sys.argv[1]
-        if args and args[0] == "delete":
-            if len(args) > 1 and args[1] == "no-input":
-                instance.run()
-            elif django_command == "test":
+
+        if django_command == "test":  # If command is run in test
+            if args and args[0] == "delete":
                 instance.run()
             else:
+                return cases
+
+        if django_command == "find_and_delete_old_cases":  # If command is run in terminal
+            if len(args) > 1 and args[1] == "no-input":
+                instance.run()
+            elif args and args[0] == "delete":
                 answer = raw_input(
                     "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
                         cases.count()
@@ -35,7 +40,5 @@ class Command(BaseCommand):
                 )
                 if answer == "Yes":
                     instance.run()
-        elif sys.argv[1] == "test":
-            return cases
-        else:
-            print("Number of cases to be deleted: " + str(cases.count()))
+            else:
+                print("Number of cases to be deleted: " + str(cases.count()))

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -21,16 +21,17 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         instance = FindAndDeleteCasesUsingCreationTime()
         cases = instance.get_eligible_cases()
-        if len(args) and args[0] == "delete":
+        django_command = sys.argv[1]
+        if args and args[0] == "delete":
             if len(args) > 1 and args[1] == "no-input":
                 instance.run()
-            elif sys.argv[1] == "test":
+            elif django_command == "test":
                 instance.run()
             else:
                 answer = raw_input(
-                    "Number of cases that will be deleted: "
-                    + str(cases.count())
-                    + "\nAre you sure about this? (Yes/No) "
+                    "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
+                        str(cases.count())
+                    )
                 )
                 if answer == "Yes":
                     instance.run()

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         instance = FindAndDeleteCasesUsingCreationTime()
         cases = instance.get_eligible_cases()
         if len(args) == 0:
-            print(cases.count())
+            print("Number of cases to be deleted: " + str(cases.count()))
         elif args[0] == "test_find":
             return cases
         elif args[0] == "delete":

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -14,7 +14,15 @@ class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
 
 
 class Command(BaseCommand):
-    help = "Find and delete cases that are 2 years old or over that were not deleted prior to the task command being fixed"
+    help = (
+        "Find or delete cases that are 2 years old or over that were not deleted prior to the task command being fixed"
+    )
 
     def handle(self, *args, **kwargs):
-        FindAndDeleteCasesUsingCreationTime().run()
+        if args[0] == "find":
+            cases = FindAndDeleteCasesUsingCreationTime().get_eligible_cases()
+            print(cases)
+            print(cases.count())
+
+        if args[0] == "delete":
+            FindAndDeleteCasesUsingCreationTime().run()

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -22,7 +22,18 @@ class Command(BaseCommand):
         instance = FindAndDeleteCasesUsingCreationTime()
         cases = instance.get_eligible_cases()
         if len(args) and args[0] == "delete":
-            instance.run()
+            if len(args) > 1 and args[1] == "no-input":
+                instance.run()
+            elif sys.argv[1] == "test":
+                instance.run()
+            else:
+                answer = raw_input(
+                    "Number of cases that will be deleted: "
+                    + str(cases.count())
+                    + "\nAre you sure about this? (Yes/No) "
+                )
+                if answer == "Yes":
+                    instance.run()
         elif sys.argv[1] == "test":
             return cases
         else:

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -7,7 +7,7 @@ from cla_butler.tasks import DeleteOldData
 
 class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
     def get_eligible_cases(self):
-        super(FindAndDeleteCasesUsingCreationTime, self)._setup()
+        self._setup()
         two_years = self.now - relativedelta(years=2)
 
         return Case.objects.filter(created__lte=two_years).exclude(log__created__gte=two_years)
@@ -19,10 +19,9 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **kwargs):
-        if args[0] == "find":
-            cases = FindAndDeleteCasesUsingCreationTime().get_eligible_cases()
-            print(cases)
+        instance = FindAndDeleteCasesUsingCreationTime()
+        if len(args) == 0:
+            cases = instance.get_eligible_cases()
             print(cases.count())
-
-        if args[0] == "delete":
-            FindAndDeleteCasesUsingCreationTime().run()
+        elif args[0] == "delete":
+            instance.run()

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -20,8 +20,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         instance = FindAndDeleteCasesUsingCreationTime()
+        cases = instance.get_eligible_cases()
         if len(args) == 0:
-            cases = instance.get_eligible_cases()
             print(cases.count())
+        elif args[0] == "test_find":
+            return cases
         elif args[0] == "delete":
             instance.run()

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -1,3 +1,4 @@
+import sys
 from django.core.management.base import BaseCommand
 from dateutil.relativedelta import relativedelta
 
@@ -7,7 +8,6 @@ from cla_butler.tasks import DeleteOldData
 
 class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
     def get_eligible_cases(self):
-        self._setup()
         two_years = self.now - relativedelta(years=2)
 
         return Case.objects.filter(created__lte=two_years).exclude(log__created__gte=two_years)
@@ -21,9 +21,9 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         instance = FindAndDeleteCasesUsingCreationTime()
         cases = instance.get_eligible_cases()
-        if len(args) == 0:
-            print("Number of cases to be deleted: " + str(cases.count()))
-        elif args[0] == "test_find":
-            return cases
-        elif args[0] == "delete":
+        if len(args) and args[0] == "delete":
             instance.run()
+        elif sys.argv[1] == "test":
+            return cases
+        else:
+            print("Number of cases to be deleted: " + str(cases.count()))

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -7,6 +7,7 @@ from cla_butler.tasks import DeleteOldData
 
 class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
     def get_eligible_cases(self):
+        super(FindAndDeleteCasesUsingCreationTime, self)._setup()
         two_years = self.now - relativedelta(years=2)
 
         return Case.objects.filter(created__lte=two_years).exclude(log__created__gte=two_years)

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -1,0 +1,31 @@
+from django.core.management.base import BaseCommand
+from dateutil.relativedelta import relativedelta
+
+from legalaid.models import Case
+from cla_butler.tasks import DeleteOldData
+from cla_eventlog.models import Log
+
+
+class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
+    def get_eligible_cases(self):
+        two_years = self.now - relativedelta(years=2)
+        old_cases = []
+
+        filtered_cases = Case.objects.filter(created__lte=two_years)
+        for case in filtered_cases:
+            try:
+                latest_log = Log.objects.filter(case__id=case.id).latest("created")
+                if latest_log.created <= two_years:
+                    old_cases.append(case.id)
+            except Log.DoesNotExist:
+                # Old case without any event logs
+                old_cases.append(case.id)
+
+        return Case.objects.filter(id__in=old_cases)
+
+
+class Command(BaseCommand):
+    help = "Find and delete cases that are 2 years old or over that were not deleted prior to the task command being fixed"
+
+    def handle(self, *args, **kwargs):
+        FindAndDeleteCasesUsingCreationTime().run()

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -48,7 +48,7 @@ class FindAndDeleteOldCases(TestCase):
         freezer = freeze_time(current_time)
         freezer.start()
         # Using handle method because command execute method can only return a string i.e it can't return a queryset
-        cases = self.command.handle("test_find")
+        cases = self.command.handle()
         freezer.stop()
         return cases
 

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -203,6 +203,7 @@ class FindAndDeleteOldCases(TestCase):
         case_1 = self.create_case(date, "legalaid.eligible_case")
         case_2 = self.create_case(date, "legalaid.eligible_case")
         self.create_event_log_for_case(case_0, "MT_CHANGED", _make_datetime(year=2014, month=5, day=30, hour=9))
+        self.create_event_log_for_case(case_0, "MT_CHANGED", _make_datetime(year=2018, month=5, day=30, hour=9))
         self.create_event_log_for_case(case_1, "MT_CHANGED", _make_datetime(year=2014, month=5, day=30, hour=9))
         self.create_event_log_for_case(case_2, "MT_CHANGED", _make_datetime(year=2020, month=4, day=27, hour=9))
 
@@ -221,7 +222,8 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(oldCasesFound.count(), 2)
 
         self.delete_old_cases(dt)
-        self.assertEqual(Case.objects.count(), 1)
+        valid_case = Case.objects.filter(id=case_2.id)
+        self.assertEqual(valid_case.count(), 1)
         self.assertEqual(Log.objects.count(), 1)
         self.assertEqual(AuditLog.objects.count(), 1)
         self.assertEqual(Complaint.objects.count(), 1)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -222,8 +222,9 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(oldCasesFound.count(), 2)
 
         self.delete_old_cases(dt)
-        valid_case = Case.objects.filter(id=case_2.id)
-        self.assertEqual(valid_case.count(), 1)
+        case_ids = Case.objects.values_list("id", flat=True)
+        # Check there is only 1 case and that case is the relatively new case
+        self.assertEqual(list(case_ids), [case_2.id])
         self.assertEqual(Log.objects.count(), 1)
         self.assertEqual(AuditLog.objects.count(), 1)
         self.assertEqual(Complaint.objects.count(), 1)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -17,6 +17,12 @@ class FindAndDeleteOldCases(TestCase):
         freezer.stop()
         return case
 
+    def create_event_log_for_case(self, case, code, created=None):
+        if created:
+            make_recipe("cla_eventlog.log", case=case, code=code, created=created)
+        else:
+            make_recipe("cla_eventlog.log", case=case, code=code)
+
     def test_find_cases_viewed_two_years_ago(self):
         new_case = make_recipe("legalaid.case")
         old_case_1 = self.create_three_year_old_case()
@@ -24,18 +30,30 @@ class FindAndDeleteOldCases(TestCase):
 
         self.assertEqual(len(Case.objects.all()), 3)
 
-        make_recipe("cla_eventlog.log", case=new_case, code="CASE_VIEWED")
-        make_recipe("cla_eventlog.log", case=old_case_1, code="CASE_VIEWED")
-        make_recipe(
-            "cla_eventlog.log", case=old_case_2, code="CASE_VIEWED", created=timezone.now() + relativedelta(years=-3)
+        self.create_event_log_for_case(new_case, "CASE_VIEWED")
+        self.create_event_log_for_case(new_case, "CASE_CREATED")
+        self.create_event_log_for_case(new_case, "CASE_VIEWED", created=timezone.now() + relativedelta(years=-3))
+
+        self.create_event_log_for_case(old_case_1, "CASE_VIEWED")
+        self.create_event_log_for_case(old_case_1, "MT_CHANGED")
+        self.create_event_log_for_case(old_case_1, "CASE_VIEWED", created=timezone.now() + relativedelta(years=-1))
+
+        self.create_event_log_for_case(old_case_2, "CASE_VIEWED", created=timezone.now() + relativedelta(years=-3))
+        self.create_event_log_for_case(old_case_2, "CASE_CREATED", created=timezone.now() + relativedelta(years=-3))
+        self.create_event_log_for_case(old_case_2, "CASE_VIEWED", created=timezone.now() + relativedelta(years=-2))
+
+        logs = Log.objects.all()
+
+        self.assertEqual(len(logs), 9)
+
+        event_logs_created_two_years_ago = Log.objects.filter(
+            # Cases created two years ago or over
+            case__created__lte=timezone.now() + relativedelta(years=-2),
+            # That have logs created two years ago or over
+            created__lte=timezone.now() + relativedelta(years=-2),
+            # Where the code field on the log = "CASE_VIEWED"
+            code__contains="CASE_VIEWED",
         )
-
-        self.assertEqual(len(Log.objects.all()), 3)
-
-        logs_for_cases_created_two_years_old = Log.objects.filter(
-            case__created__lte=timezone.now() + relativedelta(years=-2)
-        )
-        case_viewed_logs = logs_for_cases_created_two_years_old.filter(code__contains="CASE_VIEWED")
-        cases_viewed_two_years_ago = case_viewed_logs.filter(created__lte=timezone.now() + relativedelta(years=-2))
-
-        self.assertEqual(len(cases_viewed_two_years_ago), 1)
+        self.assertEqual(len(event_logs_created_two_years_ago), 2)
+        for log in event_logs_created_two_years_ago:
+            self.assertIn(log.case.id, [old_case_2.id])

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -50,7 +50,7 @@ class FindAndDeleteOldCases(TestCase):
         freezer.stop()
         return cases
 
-    def test_old_case_with_recent_event_logs(self):
+    def test_old_case_with_recent_event_logs_is_not_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date)
 
@@ -66,7 +66,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Case.objects.count(), 1)
         self.assertEqual(Log.objects.count(), 3)
 
-    def test_old_case_with_recent_complaint(self):
+    def test_old_case_with_recent_complaint_is_not_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date)
 
@@ -89,7 +89,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Log.objects.count(), 3)
         self.assertEqual(EODDetails.objects.count(), 1)
 
-    def test_old_case_with_recent_means_test_change(self):
+    def test_old_case_with_recent_means_test_change_is_not_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date, "legalaid.eligible_case")
 
@@ -105,7 +105,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Log.objects.count(), 2)
         self.assertEqual(EligibilityCheck.objects.count(), 1)
 
-    def test_old_case_with_two_logs_with_same_date_of_creation(self):
+    def test_old_case_with_two_logs_with_same_date_of_creation_is_not_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date, "legalaid.eligible_case")
 
@@ -121,7 +121,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Log.objects.count(), 2)
         self.assertEqual(EligibilityCheck.objects.count(), 1)
 
-    def test_relatively_new_case_with_no_event_logs(self):
+    def test_relatively_new_case_with_no_event_logs_is_not_deleted(self):
         date = _make_datetime(year=2020, month=4, day=27, hour=9)
         self.create_case(date)
 
@@ -133,7 +133,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Case.objects.count(), 1)
         self.assertEqual(Log.objects.count(), 0)
 
-    def test_old_case_with_no_event_logs(self):
+    def test_old_case_with_no_event_logs_is_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         self.create_case(date)
         self.create_case(date)
@@ -158,7 +158,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(DiagnosisTraversal.objects.count(), 0)
         self.assertEqual(PersonalDetails.objects.count(), 0)
 
-    def test_old_case_with_old_event_logs(self):
+    def test_old_case_with_old_event_logs_is_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date)
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2014, month=5, day=30, hour=9))
@@ -196,3 +196,36 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(EligibilityCheck.objects.count(), 0)
         self.assertEqual(DiagnosisTraversal.objects.count(), 0)
         self.assertEqual(PersonalDetails.objects.count(), 0)
+
+    def test_old_and_new_cases_are_deleted_correctly(self):
+        date = _make_datetime(year=2014, month=4, day=27, hour=9)
+        case_0 = self.create_case(date, "legalaid.eligible_case")
+        case_1 = self.create_case(date, "legalaid.eligible_case")
+        case_2 = self.create_case(date, "legalaid.eligible_case")
+        self.create_event_log_for_case(case_0, "MT_CHANGED", _make_datetime(year=2014, month=5, day=30, hour=9))
+        self.create_event_log_for_case(case_1, "MT_CHANGED", _make_datetime(year=2014, month=5, day=30, hour=9))
+        self.create_event_log_for_case(case_2, "MT_CHANGED", _make_datetime(year=2020, month=4, day=27, hour=9))
+
+        audit_log_1 = make_recipe("cla_auditlog.audit_log")
+        audit_log_2 = make_recipe("cla_auditlog.audit_log")
+        audit_log_3 = make_recipe("cla_auditlog.audit_log")
+        eod_0 = make_recipe("legalaid.eod_details", case=case_0)
+        eod_1 = make_recipe("legalaid.eod_details", case=case_1)
+        eod_2 = make_recipe("legalaid.eod_details", case=case_2)
+        make_recipe("complaints.complaint", eod=eod_0, audit_log=[audit_log_1])
+        make_recipe("complaints.complaint", eod=eod_1, audit_log=[audit_log_2])
+        make_recipe("complaints.complaint", eod=eod_2, audit_log=[audit_log_3])
+
+        dt = _make_datetime(year=2021, month=1, day=1, hour=9)
+        oldCasesFound = self.find_old_cases(dt)
+        self.assertEqual(oldCasesFound.count(), 2)
+
+        self.delete_old_cases(dt)
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 1)
+        self.assertEqual(AuditLog.objects.count(), 1)
+        self.assertEqual(Complaint.objects.count(), 1)
+        self.assertEqual(EODDetails.objects.count(), 1)
+        self.assertEqual(EligibilityCheck.objects.count(), 1)
+        self.assertEqual(DiagnosisTraversal.objects.count(), 1)
+        self.assertEqual(PersonalDetails.objects.count(), 1)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -136,17 +136,10 @@ class FindAndDeleteOldCases(TestCase):
     def test_old_case_with_no_event_logs_is_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         self.create_case(date)
-        self.create_case(date)
-        self.create_case(date)
 
         dt = _make_datetime(year=2021, month=1, day=1, hour=9)
-
-        # Only need to check for this once as every test case uses this method via calling self.find_old_cases
-        with self.assertNumQueries(1):
-            oldCasesFound = self.find_old_cases(dt)
-            oldCasesFound.count()
-
-        self.assertEqual(oldCasesFound.count(), 3)
+        oldCasesFound = self.find_old_cases(dt)
+        self.assertEqual(oldCasesFound.count(), 1)
 
         self.delete_old_cases(dt)
         self.assertEqual(Case.objects.count(), 0)
@@ -218,7 +211,10 @@ class FindAndDeleteOldCases(TestCase):
         make_recipe("complaints.complaint", eod=eod_2, audit_log=[audit_log_3])
 
         dt = _make_datetime(year=2021, month=1, day=1, hour=9)
-        oldCasesFound = self.find_old_cases(dt)
+        with self.assertNumQueries(1):
+            oldCasesFound = self.find_old_cases(dt)
+            oldCasesFound.count()
+
         self.assertEqual(oldCasesFound.count(), 2)
 
         self.delete_old_cases(dt)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from core.tests.mommy_utils import make_recipe
+from cla_eventlog.models import Log
+from legalaid.models import Case
+
+
+class FindAndDeleteOldCases(TestCase):
+    def create_three_year_old_case(self):
+        case = None
+        freezer = freeze_time(timezone.now() + relativedelta(years=-3))
+        freezer.start()
+        case = make_recipe("legalaid.case")
+        freezer.stop()
+        return case
+
+    def test_find_cases_viewed_two_years_ago(self):
+        new_case = make_recipe("legalaid.case")
+        old_case_1 = self.create_three_year_old_case()
+        old_case_2 = self.create_three_year_old_case()
+
+        self.assertEqual(len(Case.objects.all()), 3)
+
+        make_recipe("cla_eventlog.log", case=new_case, code="CASE_VIEWED")
+        make_recipe("cla_eventlog.log", case=old_case_1, code="CASE_VIEWED")
+        make_recipe(
+            "cla_eventlog.log", case=old_case_2, code="CASE_VIEWED", created=timezone.now() + relativedelta(years=-3)
+        )
+
+        self.assertEqual(len(Log.objects.all()), 3)
+
+        logs_for_cases_created_two_years_old = Log.objects.filter(
+            case__created__lte=timezone.now() + relativedelta(years=-2)
+        )
+        case_viewed_logs = logs_for_cases_created_two_years_old.filter(code__contains="CASE_VIEWED")
+        cases_viewed_two_years_ago = case_viewed_logs.filter(created__lte=timezone.now() + relativedelta(years=-2))
+
+        self.assertEqual(len(cases_viewed_two_years_ago), 1)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -42,15 +42,18 @@ class FindAndDeleteOldCases(TestCase):
     def test_old_case_with_recent_event_logs(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date)
+        self.create_case(date)
+        self.create_case(date)
 
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2014, month=5, day=30, hour=9))
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2018, month=4, day=27, hour=9))
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2020, month=4, day=27, hour=9))
 
-        self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
+        with self.assertNumQueries(3):
+            self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
 
-        self.assertEqual(Case.objects.all().count(), 1)
-        self.assertEqual(Log.objects.all().count(), 3)
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 3)
 
     def test_old_case_with_recent_complaint(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
@@ -67,10 +70,10 @@ class FindAndDeleteOldCases(TestCase):
         self.create_event_log_for_case(case, "COMPLAINT_CREATED", complaint_date)
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 1)
-        self.assertEqual(Complaint.objects.all().count(), 1)
-        self.assertEqual(Log.objects.all().count(), 3)
-        self.assertEqual(EODDetails.objects.all().count(), 1)
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Complaint.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 3)
+        self.assertEqual(EODDetails.objects.count(), 1)
 
     def test_old_case_with_recent_means_test_change(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
@@ -80,9 +83,10 @@ class FindAndDeleteOldCases(TestCase):
         self.create_event_log_for_case(case, "MT_CHANGED", _make_datetime(year=2020, month=4, day=27, hour=9))
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 1)
-        self.assertEqual(Log.objects.all().count(), 2)
-        self.assertEqual(EligibilityCheck.objects.all().count(), 1)
+
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 2)
+        self.assertEqual(EligibilityCheck.objects.count(), 1)
 
     def test_old_case_with_two_logs_with_same_date_of_creation(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
@@ -92,31 +96,31 @@ class FindAndDeleteOldCases(TestCase):
         self.create_event_log_for_case(case, "MT_CHANGED", _make_datetime(year=2020, month=4, day=27, hour=9))
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 1)
-        self.assertEqual(Log.objects.all().count(), 2)
-        self.assertEqual(EligibilityCheck.objects.all().count(), 1)
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 2)
+        self.assertEqual(EligibilityCheck.objects.count(), 1)
 
     def test_relatively_new_case_with_no_event_logs(self):
         date = _make_datetime(year=2020, month=4, day=27, hour=9)
         self.create_case(date)
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 1)
-        self.assertEqual(Log.objects.all().count(), 0)
+        self.assertEqual(Case.objects.count(), 1)
+        self.assertEqual(Log.objects.count(), 0)
 
     def test_old_case_with_no_event_logs(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         self.create_case(date)
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 0)
-        self.assertEqual(Log.objects.all().count(), 0)
-        self.assertEqual(AuditLog.objects.all().count(), 0)
-        self.assertEqual(Complaint.objects.all().count(), 0)
-        self.assertEqual(EODDetails.objects.all().count(), 0)
-        self.assertEqual(EligibilityCheck.objects.all().count(), 0)
-        self.assertEqual(DiagnosisTraversal.objects.all().count(), 0)
-        self.assertEqual(PersonalDetails.objects.all().count(), 0)
+        self.assertEqual(Case.objects.count(), 0)
+        self.assertEqual(Log.objects.count(), 0)
+        self.assertEqual(AuditLog.objects.count(), 0)
+        self.assertEqual(Complaint.objects.count(), 0)
+        self.assertEqual(EODDetails.objects.count(), 0)
+        self.assertEqual(EligibilityCheck.objects.count(), 0)
+        self.assertEqual(DiagnosisTraversal.objects.count(), 0)
+        self.assertEqual(PersonalDetails.objects.count(), 0)
 
     def test_old_case_with_old_event_logs(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
@@ -126,27 +130,27 @@ class FindAndDeleteOldCases(TestCase):
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2018, month=4, day=27, hour=9))
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 0)
-        self.assertEqual(Log.objects.all().count(), 0)
-        self.assertEqual(AuditLog.objects.all().count(), 0)
-        self.assertEqual(Complaint.objects.all().count(), 0)
-        self.assertEqual(EODDetails.objects.all().count(), 0)
-        self.assertEqual(EligibilityCheck.objects.all().count(), 0)
-        self.assertEqual(DiagnosisTraversal.objects.all().count(), 0)
-        self.assertEqual(PersonalDetails.objects.all().count(), 0)
+        self.assertEqual(Case.objects.count(), 0)
+        self.assertEqual(Log.objects.count(), 0)
+        self.assertEqual(AuditLog.objects.count(), 0)
+        self.assertEqual(Complaint.objects.count(), 0)
+        self.assertEqual(EODDetails.objects.count(), 0)
+        self.assertEqual(EligibilityCheck.objects.count(), 0)
+        self.assertEqual(DiagnosisTraversal.objects.count(), 0)
+        self.assertEqual(PersonalDetails.objects.count(), 0)
 
-    def test_old_case_with_old_means_test_changed_log(self):
+    def test_old_case_with_old_means_test_changed_is_deleted(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date, "legalaid.eligible_case")
 
         self.create_event_log_for_case(case, "MT_CHANGED", _make_datetime(year=2014, month=5, day=30, hour=9))
 
         self.delete_old_cases(_make_datetime(year=2021, month=1, day=1, hour=9))
-        self.assertEqual(Case.objects.all().count(), 0)
-        self.assertEqual(Log.objects.all().count(), 0)
-        self.assertEqual(AuditLog.objects.all().count(), 0)
-        self.assertEqual(Complaint.objects.all().count(), 0)
-        self.assertEqual(EODDetails.objects.all().count(), 0)
-        self.assertEqual(EligibilityCheck.objects.all().count(), 0)
-        self.assertEqual(DiagnosisTraversal.objects.all().count(), 0)
-        self.assertEqual(PersonalDetails.objects.all().count(), 0)
+        self.assertEqual(Case.objects.count(), 0)
+        self.assertEqual(Log.objects.count(), 0)
+        self.assertEqual(AuditLog.objects.count(), 0)
+        self.assertEqual(Complaint.objects.count(), 0)
+        self.assertEqual(EODDetails.objects.count(), 0)
+        self.assertEqual(EligibilityCheck.objects.count(), 0)
+        self.assertEqual(DiagnosisTraversal.objects.count(), 0)
+        self.assertEqual(PersonalDetails.objects.count(), 0)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -27,7 +27,6 @@ class FindAndDeleteOldCases(TestCase):
         self.command = Command()
 
     def create_case(self, current_time, case_type="legalaid.case"):
-        case = None
         freezer = freeze_time(current_time)
         freezer.start()
         case = make_recipe(case_type)
@@ -44,7 +43,6 @@ class FindAndDeleteOldCases(TestCase):
         freezer.stop()
 
     def find_old_cases(self, current_time):
-        cases = None
         freezer = freeze_time(current_time)
         freezer.start()
         # Using handle method because command execute method can only return a string i.e it can't return a queryset
@@ -142,12 +140,13 @@ class FindAndDeleteOldCases(TestCase):
         self.create_case(date)
 
         dt = _make_datetime(year=2021, month=1, day=1, hour=9)
-        oldCasesFound = self.find_old_cases(dt)
-        self.assertEqual(oldCasesFound.count(), 3)
 
         # Only need to check for this once as every test case uses this method via calling self.find_old_cases
         with self.assertNumQueries(1):
+            oldCasesFound = self.find_old_cases(dt)
             oldCasesFound.count()
+
+        self.assertEqual(oldCasesFound.count(), 3)
 
         self.delete_old_cases(dt)
         self.assertEqual(Case.objects.count(), 0)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -24,7 +24,7 @@ def _make_datetime(year=None, month=None, day=None, hour=0, minute=0, second=0):
 class FindAndDeleteOldCases(TestCase):
     def setUp(self):
         super(FindAndDeleteOldCases, self).setUp()
-        self.instance = Command()
+        self.command = Command()
 
     def create_case(self, current_time, case_type="legalaid.case"):
         case = None
@@ -38,14 +38,17 @@ class FindAndDeleteOldCases(TestCase):
         make_recipe("cla_eventlog.log", case=case, code=code, created=created)
 
     def delete_old_cases(self, current_time):
-        self.instance.execute("delete")
+        freezer = freeze_time(current_time)
+        freezer.start()
+        self.command.execute("delete")
+        freezer.stop()
 
     def find_old_cases(self, current_time):
         cases = None
         freezer = freeze_time(current_time)
         freezer.start()
         # Using handle method because command execute method can only return a string i.e it can't return a queryset
-        cases = self.instance.handle("test_find")
+        cases = self.command.handle("test_find")
         freezer.stop()
         return cases
 

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -42,8 +42,6 @@ class FindAndDeleteOldCases(TestCase):
     def test_old_case_with_recent_event_logs(self):
         date = _make_datetime(year=2014, month=4, day=27, hour=9)
         case = self.create_case(date)
-        self.create_case(date)
-        self.create_case(date)
 
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2014, month=5, day=30, hour=9))
         self.create_event_log_for_case(case, "CASE_VIEWED", _make_datetime(year=2018, month=4, day=27, hour=9))
@@ -54,8 +52,10 @@ class FindAndDeleteOldCases(TestCase):
         freezer.start()
         task = FindAndDeleteCasesUsingCreationTime()
         task._setup()
-        with self.assertNumQueries(3):
-            task.get_eligible_cases()
+        # Only need to check for this once as every test case uses this method via calling self.delete_old_cases
+        with self.assertNumQueries(1):
+            query = task.get_eligible_cases()
+            query.count()
         freezer.stop()
 
         self.delete_old_cases(dt)


### PR DESCRIPTION
- Creates a `FindAndDeleteCasesUsingCreationTime` class
- This is used by a `Command` class. The command does 3 things based on the arguments passed in:
1.  Finds old cases - an old case being a case that is 2 years ago or older and it's most recent log is 2 years old or older
    - If this command is run from a **test suite**, it will return all cases found
    - If this command is run from **cmd line**, it will print out the number of cases found 
2. Deletes cases - deletes all old cases that meet the criteria above
- Subclass the `DeleteOldData` class, so we can make use of the delete functionality 
- Override the `get_eligible_cases` method, so we can change what time `now` refers to (using the `freezetime` library)
- Create test cases based on [these test cases](https://docs.google.com/document/d/1qxKx4l4GCH1PvHSTf8AyP-zwBjWBQq8_EoZCFi4A2LE/edit)

## What does this pull request do?

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
