### PR TITLE
LGA 1604 Split cases

### DIFF
--- a/cla_backend/apps/call_centre/forms.py
+++ b/cla_backend/apps/call_centre/forms.py
@@ -61,9 +61,6 @@ class ProviderAllocationForm(BaseCaseLogForm):
             nfe.append(_(u"There is no provider specified in " u"the system to handle cases of this law category."))
             del self._errors["provider"]
 
-        if not (self.case.matter_type1 and self.case.matter_type2):
-            nfe.append(_(u"Can't assign to specialist provider without setting " u"matter_type1 and matter_type2"))
-
         if (self.case.matter_type1 and self.case.matter_type2) and (
             not self.case.matter_type1.category == self.case.matter_type2.category
         ):

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -55,6 +55,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
+        self.assertContains(Log.objects.first().notes, "Assigned to ")
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -134,6 +135,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
+        self.assertContains(Log.objects.first().notes, "Assigned to ")
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -182,6 +184,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
             self.assertEqual(case.provider, provider)
             self.assertEqual(Log.objects.count(), 1)
+            self.assertContains(Log.objects.first().notes, "Assigned to ")
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -253,6 +256,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
+        self.assertContains(Log.objects.first().notes, "Assigned to ")
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")

--- a/cla_backend/apps/call_centre/tests/test_forms.py
+++ b/cla_backend/apps/call_centre/tests/test_forms.py
@@ -55,7 +55,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
-        self.assertContains(Log.objects.first().notes, "Assigned to ")
+        self.assertIn("Assigned to ", Log.objects.first().notes)
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -135,7 +135,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
-        self.assertContains(Log.objects.first().notes, "Assigned to ")
+        self.assertIn("Assigned to ", Log.objects.first().notes)
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -184,7 +184,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
             self.assertEqual(case.provider, provider)
             self.assertEqual(Log.objects.count(), 1)
-            self.assertContains(Log.objects.first().notes, "Assigned to ")
+            self.assertIn("Assigned to ", Log.objects.first().notes)
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")
@@ -256,7 +256,7 @@ class ProviderAllocationFormTestCase(TestCase):
 
         self.assertEqual(case.provider, provider)
         self.assertEqual(Log.objects.count(), 1)
-        self.assertContains(Log.objects.first().notes, "Assigned to ")
+        self.assertIn("Assigned to ", Log.objects.first().notes)
 
     @mock.patch("cla_provider.models.timezone.now")
     @mock.patch("cla_provider.helpers.timezone.now")

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -128,10 +128,11 @@ class SplitCaseForm(BaseCaseLogForm):
         super(SplitCaseForm, self).__init__(*args, **kwargs)
 
     def is_matter_type_valid(self, category, level, choosen_matter_type):
-        try:
-            MatterType.objects.get(level=level, category=category, code=choosen_matter_type.code)
-        except MatterType.DoesNotExist:
-            return False
+        if choosen_matter_type:
+            try:
+                MatterType.objects.get(level=level, category=category, code=choosen_matter_type.code)
+            except MatterType.DoesNotExist:
+                return False
 
         return True
 

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -116,10 +116,10 @@ class SplitCaseForm(BaseCaseLogForm):
 
     category = forms.ModelChoiceField(queryset=Category.objects.all(), to_field_name="code", required=True)
     matter_type1 = forms.ModelChoiceField(
-        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.ONE), to_field_name="code"
+        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.ONE), to_field_name="code", required=False
     )
     matter_type2 = forms.ModelChoiceField(
-        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.TWO), to_field_name="code"
+        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.TWO), to_field_name="code", required=False
     )
     internal = forms.BooleanField(required=False)
 

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -116,10 +116,10 @@ class SplitCaseForm(BaseCaseLogForm):
 
     category = forms.ModelChoiceField(queryset=Category.objects.all(), to_field_name="code", required=True)
     matter_type1 = forms.ModelChoiceField(
-        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.ONE), to_field_name="code", required=True
+        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.ONE), to_field_name="code"
     )
     matter_type2 = forms.ModelChoiceField(
-        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.TWO), to_field_name="code", required=True
+        queryset=MatterType.objects.filter(level=MATTER_TYPE_LEVELS.TWO), to_field_name="code"
     )
     internal = forms.BooleanField(required=False)
 

--- a/cla_backend/apps/cla_provider/tests/test_forms.py
+++ b/cla_backend/apps/cla_provider/tests/test_forms.py
@@ -171,14 +171,7 @@ class SplitCaseFormTestCase(TestCase):
         # 1. EMPTY DATA
         form = SplitCaseForm(case=self.case, request=self.request, data={})
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(
-            form.errors,
-            {
-                "category": ["This field is required."],
-                "matter_type1": ["This field is required."],
-                "matter_type2": ["This field is required."],
-            },
-        )
+        self.assertDictEqual(form.errors, {"category": ["This field is required."]})
 
         # 2. INVALID DATA
         form = SplitCaseForm(


### PR DESCRIPTION
## What does this pull request do?

Matter type selection was being enforced,  which in turn meant that cases with categories that dont have matter types can be assigned or split.  The validation for enforcing matter types has been removed and the code checked to make sure that it doesnt require them anywhere else.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
