### PR TITLE
LGA 1707 cb1 report scheduling

### DIFF
--- a/cla_backend/apps/reports/api.py
+++ b/cla_backend/apps/reports/api.py
@@ -3,6 +3,8 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework import generics
 from rest_framework.permissions import IsAdminUser
 
+from core.models import get_web_user
+
 from .serializers import ExportSerializer
 from .models import Export
 
@@ -13,6 +15,10 @@ class ExportListView(generics.ListAPIView, generics.DestroyAPIView):
     permission_classes = (IsAdminUser,)
     authentication_classes = (SessionAuthentication,)
     page_size = 1000
+    scheduled = False
 
     def get_queryset(self):
-        return super(ExportListView, self).get_queryset().filter(user=self.request.user)
+        if self.scheduled:
+            return super(ExportListView, self).get_queryset().filter(user=get_web_user())
+        else:
+            return super(ExportListView, self).get_queryset().filter(user=self.request.user)

--- a/cla_backend/apps/reports/api.py
+++ b/cla_backend/apps/reports/api.py
@@ -19,6 +19,8 @@ class ExportListView(generics.ListAPIView, generics.DestroyAPIView):
 
     def get_queryset(self):
         if self.scheduled:
-            return super(ExportListView, self).get_queryset().filter(user=get_web_user())
+            user = get_web_user()
         else:
-            return super(ExportListView, self).get_queryset().filter(user=self.request.user)
+            user = self.request.user
+
+        return super(ExportListView, self).get_queryset().filter(user=user)

--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -359,7 +359,8 @@ class MISurveyExtract(SQLFileDateRangeReport):
 class MICB1Extract(SQLFileDateRangeReport):
     QUERY_FILE = "MICB1sSLA.sql"
 
-    max_date_range = 7
+    # currently sunday to sunday
+    max_date_range = 8
 
     def get_now(self):
         return timezone.now()

--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -359,7 +359,7 @@ class MISurveyExtract(SQLFileDateRangeReport):
 class MICB1Extract(SQLFileDateRangeReport):
     QUERY_FILE = "MICB1sSLA.sql"
 
-    max_date_range = 3
+    max_date_range = 7
 
     def get_now(self):
         return timezone.now()
@@ -595,7 +595,7 @@ class MIExtractComplaintViewAuditLog(SQLFileDateRangeReport):
 
 class AllKnowledgeBaseArticles(ReportForm):
     def get_queryset(self):
-        return Article.objects.prefetch_related('articlecategorymatrix_set__article_category', 'telephonenumber_set')
+        return Article.objects.prefetch_related("articlecategorymatrix_set__article_category", "telephonenumber_set")
 
     def get_rows(self):
         for article in self.get_queryset():
@@ -691,15 +691,15 @@ def get_from_nth(items, n, attribute):
     try:
         item = items[n - 1]
     except IndexError:
-        return ''
+        return ""
     else:
         return get_recursively(item, attribute)
 
 
 def get_recursively(item, attribute):
-    attribute_parts = attribute.split('.')
+    attribute_parts = attribute.split(".")
     value = getattr(item, attribute_parts[0])
-    remaining = '.'.join(attribute_parts[1:])
+    remaining = ".".join(attribute_parts[1:])
     if remaining:
         return get_recursively(value, remaining)
-    return value if value is not None else ''
+    return value if value is not None else ""

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 import logging
 from django.core.management.base import BaseCommand
-
+from reports.tasks import ExportTask
+from core.models import get_web_user
+from django.views.decorators.csrf import csrf_exempt
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +14,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.create_report()
 
-    def create_report():
-        print("stuff goes here")
-
-        # '{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "08/05/2021", "date_to": "10/05/2021"}'
+    @csrf_exempt
+    def create_report(self):
+        report_data = '{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "2021-05-08", "date_to": "2021-05-10"}'
 
         # report_data = json_stuff_goes_here
-        #         ExportTask().delay(user_person.pk, filename_of_report, mi_cb1_extract_agilisys, report_data)
+        web_user = get_web_user()
+        filename_of_report = "WEEKLY-REPORT-TEST.csv"
+        ExportTask().delay(web_user.pk, filename_of_report, "MICB1Extract", report_data)

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -18,7 +18,6 @@ class Command(BaseCommand):
     def create_report(self):
         report_data = '{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "2021-05-08", "date_to": "2021-05-10"}'
 
-        # report_data = json_stuff_goes_here
         web_user = get_web_user()
         filename_of_report = "WEEKLY-REPORT-TEST.csv"
         ExportTask().delay(web_user.pk, filename_of_report, "MICB1Extract", report_data)

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         date_from = (date.today() - timedelta(days=7)).strftime("%Y-%m-%d")
         date_to = date.today().strftime("%Y-%m-%d")
 
-        report_data = '{{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": {0}, "date_to": {1}}}'.format(
+        report_data = '{{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "{0}", "date_to": "{1}"}}'.format(
             date_from, date_to
         )
 

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -20,9 +20,7 @@ class Command(BaseCommand):
         date_from = (date.today() - timedelta(days=7)).strftime("%Y-%m-%d")
         date_to = date.today().strftime("%Y-%m-%d")
 
-        report_data = '{{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "{0}", "date_to": "{1}"}}'.format(
-            date_from, date_to
-        )
+        report_data = '{{"action": "Export", "date_from": "{0}", "date_to": "{1}"}}'.format(date_from, date_to)
 
         web_user = get_web_user()
         filename_of_report = "scheduled-mi-cb1-extract.csv"

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import logging
+from datetime import date, timedelta
 from django.core.management.base import BaseCommand
 from reports.tasks import ExportTask
 from core.models import get_web_user
@@ -16,8 +17,13 @@ class Command(BaseCommand):
 
     @csrf_exempt
     def create_report(self):
-        report_data = '{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "2021-05-08", "date_to": "2021-05-10"}'
+        date_from = (date.today() - timedelta(days=7)).strftime("%Y-%m-%d")
+        date_to = date.today().strftime("%Y-%m-%d")
+
+        report_data = '{{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": {0}, "date_to": {1}}}'.format(
+            date_from, date_to
+        )
 
         web_user = get_web_user()
-        filename_of_report = "WEEKLY-REPORT-TEST.csv"
+        filename_of_report = "scheduled-mi-cb1-extract.csv"
         ExportTask().delay(web_user.pk, filename_of_report, "MICB1Extract", report_data)

--- a/cla_backend/apps/reports/management/commands/mi_cb1_report.py
+++ b/cla_backend/apps/reports/management/commands/mi_cb1_report.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+import logging
+from django.core.management.base import BaseCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "This runs the MCCB1sSLA report"
+
+    def handle(self, *args, **options):
+        self.create_report()
+
+    def create_report():
+        print("stuff goes here")
+
+        # '{"action": "Export", "csrfmiddlewaretoken": "PQk4Pt55CL0NBapx9hSqZTJkSn6tL6TL", "date_from": "08/05/2021", "date_to": "10/05/2021"}'
+
+        # report_data = json_stuff_goes_here
+        #         ExportTask().delay(user_person.pk, filename_of_report, mi_cb1_extract_agilisys, report_data)

--- a/cla_backend/apps/reports/urls.py
+++ b/cla_backend/apps/reports/urls.py
@@ -7,7 +7,7 @@ from . import api
 urlpatterns = patterns(
     "",
     url(r"^api/exports/$", api.ExportListView.as_view(), name="exports"),
-    url(r"^api/exports/scheduled/$", api.ExportListView.as_view(scheduled=True), name="exports"),
+    url(r"^api/exports/scheduled/$", api.ExportListView.as_view(scheduled=True), name="scheduled"),
     url(r"^api/exports/(?P<pk>[0-9]+)/$", api.ExportListView.as_view(), name="exports"),
     url(r"^exports/download/(?P<file_name>[A-Za-z0-9-_\.]+)$", views.download_file, name="exports"),
     url(

--- a/cla_backend/apps/reports/urls.py
+++ b/cla_backend/apps/reports/urls.py
@@ -7,6 +7,7 @@ from . import api
 urlpatterns = patterns(
     "",
     url(r"^api/exports/$", api.ExportListView.as_view(), name="exports"),
+    url(r"^api/exports/scheduled/$", api.ExportListView.as_view(scheduled=True), name="exports"),
     url(r"^api/exports/(?P<pk>[0-9]+)/$", api.ExportListView.as_view(), name="exports"),
     url(r"^exports/download/(?P<file_name>[A-Za-z0-9-_\.]+)$", views.download_file, name="exports"),
     url(

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -46,9 +46,7 @@ def report_view(request, form_class, title, template="case_report", success_task
     if valid_submit(request, form):
         success_task().delay(request.user.pk, filename, form_class.__name__, json.dumps(request.POST))
 
-        messages.info(
-            request, u"Your export is being processed. It " u"will show up in the downloads tab " u"shortly."
-        )
+        messages.info(request, u"Your export is being processed. It will show up in the downloads tab shortly.")
 
     return render(request, tmpl, {"title": title, "form": form})
 

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -34,29 +34,23 @@ from .tasks import ExportTask, OBIEEExportTask
 from reports.utils import get_s3_connection
 
 
-def report_view(form_class, title, template="case_report", success_task=ExportTask, file_name=None):
-    def wrapper(fn):
-        slug = re.sub("[^0-9a-zA-Z]+", "_", title.lower()).strip("_")
-        if not file_name:
-            filename = "{0}.csv".format(slug)
-        else:
-            filename = file_name
-        tmpl = "admin/reports/{0}.html".format(template)
+def report_view(request, form_class, title, template="case_report", success_task=ExportTask, file_name=None):
+    slug = re.sub("[^0-9a-zA-Z]+", "_", title.lower()).strip("_")
+    if not file_name:
+        filename = "{0}.csv".format(slug)
+    else:
+        filename = file_name
+    tmpl = "admin/reports/{0}.html".format(template)
 
-        def view(request):
-            form = form_class()
-            if valid_submit(request, form):
-                success_task().delay(request.user.pk, filename, form_class.__name__, json.dumps(request.POST))
+    form = form_class()
+    if valid_submit(request, form):
+        success_task().delay(request.user.pk, filename, form_class.__name__, json.dumps(request.POST))
 
-                messages.info(
-                    request, u"Your export is being processed. It " u"will show up in the downloads tab " u"shortly."
-                )
+        messages.info(
+            request, u"Your export is being processed. It " u"will show up in the downloads tab " u"shortly."
+        )
 
-            return render(request, tmpl, {"title": title, "form": form})
-
-        return view
-
-    return wrapper
+    return render(request, tmpl, {"title": title, "form": form})
 
 
 def valid_submit(request, form):
@@ -69,109 +63,116 @@ def valid_submit(request, form):
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIProviderAllocationExtract, "MI Provider Allocation")
-def mi_provider_allocation_extract():
-    pass
+def mi_provider_allocation_extract(request):
+    return report_view(request, MIProviderAllocationExtract, "MI Provider Allocation")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MICaseExtract, "MI Case Extract")
-def mi_case_extract():
-    pass
+def mi_case_extract(request):
+    return report_view(request, MICaseExtract, "MI Case Extract")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIFeedbackExtract, "MI Feedback Extract")
-def mi_feedback_extract():
-    pass
+def mi_feedback_extract(request):
+    return report_view(request, MIFeedbackExtract, "MI Feedback Extract")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIDuplicateCaseExtract, "MI Duplicate Case Extract")
-def mi_duplicate_case_extract():
-    pass
+def mi_duplicate_case_extract(request):
+    return report_view(request, MIDuplicateCaseExtract, "MI Duplicate Case Extract")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIContactsPerCaseByCategoryExtract, "MI Contacts Per Case By Category")
-def mi_contacts_extract():
-    pass
+def mi_contacts_extract(request):
+    return report_view(request, MIContactsPerCaseByCategoryExtract, "MI Contacts Per Case By Category")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIAlternativeHelpExtract, "MI Alternative Help Extract")
-def mi_alternative_help_extract():
-    pass
+def mi_alternative_help_extract(request):
+    return report_view(request, MIAlternativeHelpExtract, "MI Alternative Help Extract")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MISurveyExtract, "MI Survey Extract (ONLY RUN ON DOM1)")
-def mi_survey_extract():
-    pass
+def mi_survey_extract(request):
+    return report_view(request, MISurveyExtract, "MI Survey Extract (ONLY RUN ON DOM1)")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MICB1Extract, "MI CB1 Extract")
-def mi_cb1_extract():
-    pass
+def mi_cb1_extract(request):
+    return report_view(request, MICB1Extract, "MI CB1 Extract")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MICB1ExtractAgilisys, "MI CB1 Extract for Agilisys")
-def mi_cb1_extract_agilisys():
-    pass
+def mi_cb1_extract_agilisys(request):
+    return report_view(request, MICB1ExtractAgilisys, "MI CB1 Extract for Agilisys")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIVoiceReport, "MI Voice Report")
-def mi_voice_extract():
-    pass
+def mi_voice_extract(request):
+    return report_view(request, MIVoiceReport, "MI Voice Report")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIDigitalCaseTypesExtract, "MI Digital Case Types Report")
-def mi_digital_case_type_extract():
-    pass
+def mi_digital_case_type_extract(request):
+    return report_view(request, MIDigitalCaseTypesExtract, "MI Digital Case Types Report")
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MIEODReport, "MI EOD Report")
-def mi_eod_extract():
-    pass
+def mi_eod_extract(request):
+    return report_view(request, MIEODReport, "MI EOD Report")
 
 
 @staff_member_required
 @permission_required("legalaid.run_complaints_report")
-@report_view(ComplaintsReport, "Complaints Report")
-def mi_complaints():
-    pass
+def mi_complaints(request):
+    return report_view(request, ComplaintsReport, "Complaints Report")
 
 
 @staff_member_required
 @permission_required("legalaid.run_obiee_reports")
-@report_view(
-    MIOBIEEExportExtract, "MI Export to Email for OBIEE", file_name="cla.database.zip", success_task=OBIEEExportTask
-)
-def mi_obiee_extract():
-    pass
+def mi_obiee_extract(request):
+    return report_view(
+        request,
+        MIOBIEEExportExtract,
+        "MI Export to Email for OBIEE",
+        file_name="cla.database.zip",
+        success_task=OBIEEExportTask,
+    )
 
 
 @staff_member_required
 @permission_required("legalaid.run_reports")
-@report_view(MetricsReport, "Metrics Report")
-def metrics_report():
-    pass
+def metrics_report(request):
+    return report_view(request, MetricsReport, "Metrics Report")
+
+
+@staff_member_required
+@permission_required("legalaid.run_reports")
+def mi_case_view_audit_log_extract(request):
+    report_view(request, MIExtractCaseViewAuditLog, "MI Case Views Audit Log Extract")
+
+
+@staff_member_required
+@permission_required("legalaid.run_reports")
+def mi_complaint_view_audit_log_extract(request):
+    report_view(request, MIExtractComplaintViewAuditLog, "MI Complaints Views Audit Log Extract")
+
+
+@staff_member_required
+@permission_required("legalaid.run_reports")
+def all_knowledgebase_articles(request):
+    report_view(request, AllKnowledgeBaseArticles, "Knowledge Base Articles")
 
 
 @staff_member_required
@@ -200,24 +201,3 @@ def download_file(request, file_name="", *args, **kwargs):
         raise Http404("Export does not exist")
 
     return response
-
-
-@staff_member_required
-@permission_required("legalaid.run_reports")
-@report_view(MIExtractCaseViewAuditLog, "MI Case Views Audit Log Extract")
-def mi_case_view_audit_log_extract():
-    pass
-
-
-@staff_member_required
-@permission_required("legalaid.run_reports")
-@report_view(MIExtractComplaintViewAuditLog, "MI Complaints Views Audit Log Extract")
-def mi_complaint_view_audit_log_extract():
-    pass
-
-
-@staff_member_required
-@permission_required("legalaid.run_reports")
-@report_view(AllKnowledgeBaseArticles, "Knowledge Base Articles")
-def all_knowledgebase_articles():
-    pass

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -201,11 +201,14 @@ def download_file(request, file_name="", *args, **kwargs):
     response["Content-Disposition"] = "attachment; filename=%s" % smart_str(file_name)
     response["X-Sendfile"] = smart_str("%s%s" % (settings.TEMP_DIR, file_name))
 
-    if not file_name.__contains__("scheduled"):
-        try:
-            export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
-            export_record.delete()
-        except Export.DoesNotExist:
-            raise Http404("Export does not exist")
+    def delete_record():
+        if "scheduled" not in file_name:
+            try:
+                export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
+                export_record.delete()
+            except Export.DoesNotExist:
+                raise Http404("Export does not exist")
+
+    delete_record()
 
     return response

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -201,14 +201,15 @@ def download_file(request, file_name="", *args, **kwargs):
     response["Content-Disposition"] = "attachment; filename=%s" % smart_str(file_name)
     response["X-Sendfile"] = smart_str("%s%s" % (settings.TEMP_DIR, file_name))
 
-    def delete_record():
-        if "scheduled" not in file_name:
-            try:
-                export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
-                export_record.delete()
-            except Export.DoesNotExist:
-                raise Http404("Export does not exist")
-
-    delete_record()
+    if "scheduled" not in file_name:
+        delete_record(request.user.pk, file_name)
 
     return response
+
+
+def delete_record(user_id, file_name):
+    try:
+        export_record = Export.objects.get(user_id=user_id, path__endswith=file_name)
+        export_record.delete()
+    except Export.DoesNotExist:
+        raise Http404("Export does not exist")

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -203,10 +203,11 @@ def download_file(request, file_name="", *args, **kwargs):
     response["Content-Disposition"] = "attachment; filename=%s" % smart_str(file_name)
     response["X-Sendfile"] = smart_str("%s%s" % (settings.TEMP_DIR, file_name))
 
-    try:
-        export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
-        export_record.delete()
-    except Export.DoesNotExist:
-        raise Http404("Export does not exist")
+    if not file_name.__contains__("WEEKLY-REPORT"):
+        try:
+            export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
+            export_record.delete()
+        except Export.DoesNotExist:
+            raise Http404("Export does not exist")
 
     return response

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -53,6 +53,12 @@ def report_view(request, form_class, title, template="case_report", success_task
     return render(request, tmpl, {"title": title, "form": form})
 
 
+def scheduled_report_view(request, form_class, title):
+    tmpl = "admin/reports/case_report.html"
+
+    return render(request, tmpl, {"title": title})
+
+
 def valid_submit(request, form):
     if request.method == "POST":
         form.data = request.POST
@@ -106,7 +112,10 @@ def mi_survey_extract(request):
 @staff_member_required
 @permission_required("legalaid.run_reports")
 def mi_cb1_extract(request):
-    return report_view(request, MICB1Extract, "MI CB1 Extract")
+    if settings.SHOW_NEW_CB1:
+        return scheduled_report_view(request, MICB1Extract, "MI CB1 Extract")
+    else:
+        return report_view(request, MICB1Extract, "MI CB1 Extract")
 
 
 @staff_member_required

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -201,7 +201,7 @@ def download_file(request, file_name="", *args, **kwargs):
     response["Content-Disposition"] = "attachment; filename=%s" % smart_str(file_name)
     response["X-Sendfile"] = smart_str("%s%s" % (settings.TEMP_DIR, file_name))
 
-    if not file_name.__contains__("WEEKLY-REPORT"):
+    if not file_name.__contains__("scheduled"):
         try:
             export_record = Export.objects.get(user_id=request.user.pk, path__endswith=file_name)
             export_record.delete()

--- a/cla_backend/assets/admin/js/ReportTask.js
+++ b/cla_backend/assets/admin/js/ReportTask.js
@@ -39,7 +39,7 @@
       var self = this;
       $.ajax({
         method: 'DELETE',
-        url: self.url  + id + '/',
+        url: '/admin/reports/api/exports/' + id + '/',
         headers: {
           'X-CSRFTOKEN': readCookie('csrftoken')
         },

--- a/cla_backend/assets/admin/js/ReportTask.js
+++ b/cla_backend/assets/admin/js/ReportTask.js
@@ -80,9 +80,9 @@
             .data('id', data[i]['id']);
           deleteCol.append($deleteLink);
           $task.append(deleteCol);
-
-          this.table.append($task);
         }
+
+        this.table.append($task);
       }
     },
 

--- a/cla_backend/assets/admin/js/ReportTask.js
+++ b/cla_backend/assets/admin/js/ReportTask.js
@@ -72,14 +72,17 @@
         }
         $task.append(linkcol);
 
-        var deleteCol = $('<td></td>');
-        var $deleteLink = $('<a class="delete-task"></a>')
-          .text('DELETE')
-          .data('id', data[i]['id']);
-        deleteCol.append($deleteLink);
-        $task.append(deleteCol);
+        var index = this.url.indexOf("scheduled")
+        if (index == -1) {
+          var deleteCol = $('<td></td>');
+          var $deleteLink = $('<a class="delete-task"></a>')
+            .text('DELETE')
+            .data('id', data[i]['id']);
+          deleteCol.append($deleteLink);
+          $task.append(deleteCol);
 
-        this.table.append($task);
+          this.table.append($task);
+        }
       }
     },
 

--- a/cla_backend/assets/admin/js/ReportTask.js
+++ b/cla_backend/assets/admin/js/ReportTask.js
@@ -15,7 +15,7 @@
   }
 
   var ReportTask = {
-    url: '/admin/reports/api/exports/',
+    url: window.reportUrl,
     el: null,
 
     init: function () {

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -29,6 +29,8 @@ root = lambda *x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
 sys.path.insert(0, root("apps"))
 sys.path.insert(0, root("libs"))
 
+SHOW_NEW_CB1 = os.environ.get("SHOW_NEW_CB1", "False").lower() == "true"
+
 HEALTHCHECKS = ["moj_irat.healthchecks.database_healthcheck", "status.healthchecks.check_disk"]
 
 AUTODISCOVER_HEALTHCHECKS = True

--- a/cla_backend/templates/admin/reports/base.html
+++ b/cla_backend/templates/admin/reports/base.html
@@ -17,6 +17,12 @@
   <script type="text/javascript" src="{{ jsi18nurl|default:"../../../jsi18n/" }}"></script>
   {{ media }}
 
+  {% if form %}
+    <script>window.reportUrl = '/admin/reports/api/exports/'</script>
+  {% else %}
+    <script>window.reportUrl = '/admin/reports/api/exports/scheduled/'</script>
+  {% endif %}
+
   <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>
   <script type="text/javascript" src="{% static "admin/js/jquery.js" %}"></script>
   <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
@@ -41,16 +47,18 @@
 {% block coltype %}flex{% endblock %}
 
 {% block content %}
-  <div id="content-main">
-    <div id="changelist" class="module">
-      <form id="claimpricing_form" method="post" action="" enctype="multipart/form-data">{% csrf_token %}
-        <div id="toolbar">
-          {% block inner_form %}
-          {% endblock inner_form %}
-        </div>
-        {% block submit_row %}
-        {% endblock submit_row %}
-      </form>
+  {% if form %}
+    <div id="content-main">
+      <div id="changelist" class="module">
+        <form id="claimpricing_form" method="post" action="" enctype="multipart/form-data">{% csrf_token %}
+          <div id="toolbar">
+            {% block inner_form %}
+            {% endblock inner_form %}
+          </div>
+          {% block submit_row %}
+          {% endblock submit_row %}
+        </form>
+      </div>
     </div>
-  </div>
+  {% endif %}
 {% endblock %}

--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -25,7 +25,7 @@ metadata:
   labels:
     {{- include "cla-backend.labels" . | nindent 4 }}
 spec:
-  schedule: "15 2 * * *"
+  schedule: "*/5 16 * 5 2"
   jobTemplate:
     spec:
       template:

--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -25,7 +25,7 @@ metadata:
   labels:
     {{- include "cla-backend.labels" . | nindent 4 }}
 spec:
-  schedule: "*/5 16 * 5 2"
+  schedule: "15 2 * * *"
   jobTemplate:
     spec:
       template:

--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -57,3 +57,23 @@ spec:
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-mi-cb1-report
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "0 5 * * 0" 
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: reporting
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["python", "manage.py", "mi_cb1_report"]
+            env:
+              {{ include "cla-backend.app.vars" . | nindent 12 }}
+          restartPolicy: OnFailure

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -45,3 +45,5 @@ envVars:
     value: "False"
   SQS_SECRET_KEY:
     value: "False"
+  SHOW_NEW_CB1:
+    value: "True"

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -223,6 +223,8 @@ envVars:
     secret:
       name: sqs
       key: sqs_id
+  SHOW_NEW_CB1:
+    value: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -224,7 +224,7 @@ envVars:
       name: sqs
       key: sqs_id
   SHOW_NEW_CB1:
-    value: false
+    value: "False"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## What does this pull request do?

This pull request is a small redesign of the CB1 MI report.

  - A new command has been created which runs the report for the current sunday to sunday.  This is scheduled via the cronjobs to run on 5am sundays.
  - View code around the display of reports has been refactored to be clearer in its objective.
  - As well as get reports for specific user there is now a route which will give you all the scheduled reports that have been produced.
  - JS has been amended, if the report is scheduled we no longer display a delete link for it.
  - The new route for showing the *scheduled* cb1 MI reports is behind the feature flag SHOW_NEW_CB1 which can be set to true or false.  Note:  I have increased the day limit on the report to 8 days and this is not behind the feature flag.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
