### PR TITLE
LGA-1719 - Timezone-aware assigned_out_of_hours calculation

### DIFF
--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.utils import timezone
+
+from legalaid.models import Case
+
+
+class Command(BaseCommand):
+    help = "Recalculate case.assigned_out_of_hours since a given date"
+
+    def handle(self, *args, **options):
+        try:
+            date_string = args[0]
+        except IndexError:
+            raise CommandError("A start date is required")
+
+        try:
+            dt = timezone.datetime.strptime(date_string, "%Y-%m-%d")
+        except ValueError:
+            raise CommandError("The start date should be a valid datetime in yyyy-mm-dd format")
+
+        cases = Case.objects.filter(provider_assigned_at__gte=dt)
+        count = cases.count()
+
+        self.stdout.write("{count} cases assigned since {dt}.".format(count=count, dt=dt))
+        if not count:
+            return
+
+        unchanged = []
+        changed_to_true = []
+        changed_to_false = []
+
+        for case in cases:
+            current_value = case.assigned_out_of_hours
+            new_value = self.recalculate_field(case)
+            if new_value == current_value:
+                unchanged.append(case.pk)
+            elif new_value:
+                changed_to_true.append(case.pk)
+            else:
+                changed_to_false.append(case.pk)
+
+        self.stdout.write("{count} cases already had the correct value.".format(count=len(unchanged)))
+        self.stdout.write("{count} cases will be changed to `True`.".format(count=len(changed_to_true)))
+        self.stdout.write("{count} cases will be changed to `False`.".format(count=len(changed_to_false)))
+
+    def recalculate_field(self, case):
+        case_category = getattr(case.eligibility_check.category, "code") if case.eligibility_check else None
+        non_rota_hours = settings.NON_ROTA_OPENING_HOURS[case_category]
+        return not non_rota_hours.available(case.provider_assigned_at, tz_aware=True)

--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -8,9 +8,11 @@ from legalaid.models import Case
 class Command(BaseCommand):
     help = "Recalculate case.assigned_out_of_hours since a given date"
 
-    unchanged = []
-    change_to_true = []
-    change_to_false = []
+    def __init__(self, *args, **kwargs):
+        self.unchanged = []
+        self.change_to_true = []
+        self.change_to_false = []
+        super(Command, self).__init__(*args, **kwargs)
 
     def handle(self, *args, **options):
         try:

--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -8,6 +8,10 @@ from legalaid.models import Case
 class Command(BaseCommand):
     help = "Recalculate case.assigned_out_of_hours since a given date"
 
+    unchanged = []
+    change_to_true = []
+    change_to_false = []
+
     def handle(self, *args, **options):
         try:
             date_string = args[0]
@@ -22,27 +26,42 @@ class Command(BaseCommand):
         cases = Case.objects.filter(provider_assigned_at__gte=dt)
         count = cases.count()
 
-        self.stdout.write("{count} cases assigned since {dt}.".format(count=count, dt=dt))
+        self.stdout.write(u"{count} cases assigned since {dt}.".format(count=count, dt=dt))
         if not count:
             return
 
-        unchanged = []
-        changed_to_true = []
-        changed_to_false = []
+        self.group_cases(cases)
 
+        self.stdout.write(u"{count} cases already had the correct value.".format(count=len(self.unchanged)))
+        self.stdout.write(u"{count} cases will be changed to `True`.".format(count=len(self.change_to_true)))
+        self.stdout.write(u"{count} cases will be changed to `False`.".format(count=len(self.change_to_false)))
+
+        try:
+            commit = args[1] == "commit"
+        except IndexError:
+            commit = False
+
+        if commit:
+            number_changed_to_true = Case.objects.filter(pk__in=self.change_to_true).update(assigned_out_of_hours=True)
+            number_changed_to_false = Case.objects.filter(pk__in=self.change_to_false).update(
+                assigned_out_of_hours=False
+            )
+            self.stdout.write(u"Making changes")
+            self.stdout.write(u"  {count} cases changed to `True`.".format(count=number_changed_to_true))
+            self.stdout.write(u"  {count} cases changed to `False`.".format(count=number_changed_to_false))
+        else:
+            self.stdout.write(u"Not making changes (add 'commit' to make changes)")
+
+    def group_cases(self, cases):
         for case in cases:
             current_value = case.assigned_out_of_hours
             new_value = self.recalculate_field(case)
             if new_value == current_value:
-                unchanged.append(case.pk)
+                self.unchanged.append(case.pk)
             elif new_value:
-                changed_to_true.append(case.pk)
+                self.change_to_true.append(case.pk)
             else:
-                changed_to_false.append(case.pk)
-
-        self.stdout.write("{count} cases already had the correct value.".format(count=len(unchanged)))
-        self.stdout.write("{count} cases will be changed to `True`.".format(count=len(changed_to_true)))
-        self.stdout.write("{count} cases will be changed to `False`.".format(count=len(changed_to_false)))
+                self.change_to_false.append(case.pk)
 
     def recalculate_field(self, case):
         case_category = getattr(case.eligibility_check.category, "code") if case.eligibility_check else None

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -870,7 +870,7 @@ class Case(TimeStampedModel, ModelDiffMixin):
         self.provider_closed = None
         case_category = getattr(self.eligibility_check.category, "code") if self.eligibility_check else None
         non_rota_hours = settings.NON_ROTA_OPENING_HOURS[case_category]
-        self.assigned_out_of_hours = self.provider_assigned_at not in non_rota_hours
+        self.assigned_out_of_hours = not non_rota_hours.available(self.provider_assigned_at, tz_aware=True)
         self.is_urgent = is_urgent
 
         self.save(

--- a/cla_backend/apps/legalaid/tests/test_timezones.py
+++ b/cla_backend/apps/legalaid/tests/test_timezones.py
@@ -1,9 +1,12 @@
 import pytz
-from django.test import SimpleTestCase
+from django.core.management import call_command, CommandError
+from django.test import TestCase
 from django.utils import timezone
+from django.utils.six import StringIO
 from freezegun import freeze_time
 
 from core.tests.mommy_utils import make_recipe
+from legalaid.models import Case
 
 
 class BaseAssignedOutOfHours(object):
@@ -24,6 +27,7 @@ class BaseAssignedOutOfHours(object):
     def test_before_hours(self):
         case = self.create_and_assign(self.dt.replace(hour=7, minute=30))
         self.assertTrue(case.assigned_out_of_hours)
+        return case
 
     def test_first_hour_of_business(self):
         case = self.create_and_assign(self.dt.replace(hour=8, minute=30))
@@ -42,9 +46,145 @@ class BaseAssignedOutOfHours(object):
         self.assertTrue(case.assigned_out_of_hours)
 
 
-class TestGMTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, SimpleTestCase):
+class TestGMTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, TestCase):
     dt = timezone.datetime(2021, 2, 2)
 
 
-class TestBSTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, SimpleTestCase):
+class TestBSTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, TestCase):
     dt = timezone.datetime(2021, 5, 5)
+
+
+class TestCommandDateArgument(TestCase):
+    def test_requires_date(self):
+        with self.assertRaisesMessage(CommandError, "A start date is required"):
+            call_command("recalculate_assigned_out_of_hours")
+
+    def test_date_must_be_a_date_string(self):
+        with self.assertRaisesMessage(CommandError, "The start date should be a valid datetime in yyyy-mm-dd format"):
+            call_command("recalculate_assigned_out_of_hours", "last year")
+
+    def test_date_must_be_correctly_formatted(self):
+        with self.assertRaisesMessage(CommandError, "The start date should be a valid datetime in yyyy-mm-dd format"):
+            call_command("recalculate_assigned_out_of_hours", "2021-30-06")
+
+    def test_date_must_be_valid(self):
+        with self.assertRaisesMessage(CommandError, "The start date should be a valid datetime in yyyy-mm-dd format"):
+            call_command("recalculate_assigned_out_of_hours", "2021-02-30")
+
+
+class TestRecalculateAssignedOutOfHours(TestCase):
+    dt = "2020-04-01"
+
+    def setUp(self, *args, **kwargs):
+        self.provider = make_recipe("cla_provider.provider")
+        self.category = make_recipe("legalaid.category", code="education")
+        super(TestRecalculateAssignedOutOfHours, self).setUp()
+
+    def create(self, year, month, day, hour, minute, out_of_hours):
+        assigned_at = timezone.datetime(year, month, day, hour, minute)
+        case = make_recipe(
+            "legalaid.case",
+            provider_assigned_at=assigned_at,
+            assigned_out_of_hours=out_of_hours,
+            eligibility_check__category=self.category,
+        )
+        return case
+
+    def get_new_value(self, case):
+        return Case.objects.filter(pk=case.pk).values_list("assigned_out_of_hours", flat=True)[0]
+
+    def call_command_and_expect_output(self, messages, commit=False):
+        out = StringIO()
+        command_args = ["recalculate_assigned_out_of_hours", self.dt]
+        if commit:
+            command_args.append("commit")
+        call_command(*command_args, stdout=out)
+        output = out.getvalue()
+        for msg in messages:
+            self.assertIn(msg, output)
+
+    def test_incorrect_first_hour_of_business_bst(self):
+        case = self.create(2021, 5, 5, 9, 30, True)
+        self.call_command_and_expect_output(
+            ["1 cases assigned since", "Not making changes", "1 cases will be changed to `False`"]
+        )
+        self.assertTrue(self.get_new_value(case))
+
+        self.call_command_and_expect_output(
+            ["Making changes", "1 cases will be changed to `False`", "1 cases changed to `False`"], commit=True
+        )
+        self.assertFalse(self.get_new_value(case))
+
+    def test_correct_first_hour_of_business_bst(self):
+        case = self.create(2021, 5, 5, 9, 30, False)
+        self.call_command_and_expect_output(
+            ["1 cases assigned since", "Not making changes", "1 cases already had the correct value"]
+        )
+        self.assertFalse(self.get_new_value(case))
+
+        self.call_command_and_expect_output(
+            ["Making changes", "0 cases changed to `True`", "0 cases changed to `False`"], commit=True
+        )
+        self.assertFalse(self.get_new_value(case))
+
+    def test_correct_before_business_hours_bst(self):
+        case = self.create(2021, 5, 5, 8, 30, True)
+        self.call_command_and_expect_output(
+            ["1 cases assigned since", "Not making changes", "1 cases already had the correct value"]
+        )
+        self.assertTrue(self.get_new_value(case))
+
+        self.call_command_and_expect_output(
+            ["Making changes", "0 cases changed to `True`", "0 cases changed to `False`"], commit=True
+        )
+        self.assertTrue(self.get_new_value(case))
+
+    def test_correct_before_business_hours_gmt(self):
+        case = self.create(2021, 2, 2, 8, 30, True)
+        self.call_command_and_expect_output(
+            ["1 cases assigned since", "Not making changes", "1 cases already had the correct value"]
+        )
+        self.assertTrue(self.get_new_value(case))
+
+        self.call_command_and_expect_output(
+            ["Making changes", "1 cases already had the correct value", "0 cases changed to `False`"], commit=True
+        )
+        self.assertTrue(self.get_new_value(case))
+
+    def test_case_before_cutoff(self):
+        case = self.create(2018, 5, 5, 8, 30, True)
+        self.call_command_and_expect_output(["0 cases assigned since"])
+        self.assertTrue(self.get_new_value(case))
+
+    def test_multiple_cases(self):
+        old_incorrect_bst = self.create(2018, 5, 9, 9, 30, True)
+        correct_gmt = self.create(2021, 2, 2, 9, 30, False)
+        incorrect_bst = self.create(2021, 5, 5, 9, 30, True)
+        incorrect_bst_2 = self.create(2021, 5, 12, 9, 30, True)
+        incorrect_bst_evening = self.create(2021, 5, 12, 17, 30, False)
+        correct_bst = self.create(2021, 5, 19, 9, 30, False)
+        self.call_command_and_expect_output(
+            [
+                "5 cases assigned since",
+                "Not making changes",
+                "2 cases already had the correct value",
+                "2 cases will be changed to `False`",
+                "1 cases will be changed to `True`",
+            ]
+        )
+
+        self.call_command_and_expect_output(
+            [
+                "Making changes",
+                "2 cases already had the correct value",
+                "2 cases changed to `False`",
+                "1 cases changed to `True`",
+            ],
+            commit=True,
+        )
+        self.assertTrue(self.get_new_value(old_incorrect_bst))
+        self.assertFalse(self.get_new_value(correct_gmt))
+        self.assertFalse(self.get_new_value(incorrect_bst))
+        self.assertFalse(self.get_new_value(incorrect_bst_2))
+        self.assertTrue(self.get_new_value(incorrect_bst_evening))
+        self.assertFalse(self.get_new_value(correct_bst))

--- a/cla_backend/apps/legalaid/tests/test_timezones.py
+++ b/cla_backend/apps/legalaid/tests/test_timezones.py
@@ -1,0 +1,50 @@
+import pytz
+from django.test import SimpleTestCase
+from django.utils import timezone
+from freezegun import freeze_time
+
+from core.tests.mommy_utils import make_recipe
+
+
+class BaseAssignedOutOfHours(object):
+    def tearDown(self):
+        self.freezer.stop()
+        super(BaseAssignedOutOfHours, self).tearDown()
+
+    def create_and_assign(self, dt):
+        timezone_aware_dt = timezone.make_aware(dt, timezone.get_current_timezone())
+        utc_dt = timezone_aware_dt.astimezone(pytz.utc)
+        self.freezer = freeze_time(utc_dt)
+        self.freezer.start()
+        provider = make_recipe("cla_provider.provider")
+        case = make_recipe("legalaid.case")
+        case.assign_to_provider(provider)
+        return case
+
+    def test_before_hours(self):
+        case = self.create_and_assign(self.dt.replace(hour=7, minute=30))
+        self.assertTrue(case.assigned_out_of_hours)
+
+    def test_first_hour_of_business(self):
+        case = self.create_and_assign(self.dt.replace(hour=8, minute=30))
+        self.assertFalse(case.assigned_out_of_hours)
+
+    def test_second_hour_of_business(self):
+        case = self.create_and_assign(self.dt.replace(hour=9, minute=30))
+        self.assertFalse(case.assigned_out_of_hours)
+
+    def test_last_hour_of_business(self):
+        case = self.create_and_assign(self.dt.replace(hour=16, minute=30))
+        self.assertFalse(case.assigned_out_of_hours)
+
+    def test_after_hours(self):
+        case = self.create_and_assign(self.dt.replace(hour=17, minute=30))
+        self.assertTrue(case.assigned_out_of_hours)
+
+
+class TestGMTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, SimpleTestCase):
+    dt = timezone.datetime(2021, 2, 2)
+
+
+class TestBSTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, SimpleTestCase):
+    dt = timezone.datetime(2021, 5, 5)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@0.3.13#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@2da49ee8d3e15031f84146339fe3d18e4581ebfa#egg=cla_common
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ django-ipware==0.1.0
 csvkit==0.9.0
 python-dateutil==2.2 # lock for csvkit
 requests==2.6.0
-pytz==2014.10
+pytz==2021.1
 dj-database-url==0.3.0
 django-docopt-command==0.2.0
 transifex-client==0.11b3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Markdown==2.5.2
 bleach==2.0.0
 git+https://github.com/ministryofjustice/django-oauth2-provider.git@b75571be3e19647fe8e726c5fcf8ce8bf9fd7540#egg=django-oauth2-provider==0.2.6.1-dev
 
-git+https://github.com/ministryofjustice/cla_common.git@2da49ee8d3e15031f84146339fe3d18e4581ebfa#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@0.3.15#egg=cla_common
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?
Uses the new `tz_aware` argument to `OpeningHours.available()` to calculate the value of `assigned_out_of_hours` in a timezone-aware, and therefore correct, way.
eg during Daylight Saving Time, 08:30 UTC represents 09:30 BST and therefore the comparison of this datetime to opening hours of 9-5 should be done treating the latter as 08:00 UTC - 16:00 UTC to get accurate results.

The `__contains__` method on `OpeningHours`, that is used by Python for `if dt in object`, continues to use the old behaviour (calling `.available()` with no arguments) for backwards compatibility, so we have switched from that syntax to explicitly calling the `.available()` method with the argument.

This PR also adds a management command to correct records (by simply recalculating the value now) back as far as a given date.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
