### PR TITLE
LGA-1721 Delete old cases and complaints

### DIFF
--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from dateutil.relativedelta import relativedelta
 
 from legalaid.models import Case
+from cla_eventlog.models import Log
 from cla_butler.tasks import DeleteOldData
 
 
@@ -12,33 +13,58 @@ class FindAndDeleteCasesUsingCreationTime(DeleteOldData):
 
         return Case.objects.filter(created__lte=two_years).exclude(log__created__gte=two_years)
 
+    def get_digital_justice_user_logs(self):
+        return Log.objects.filter(created_by__email__endswith="digital.justice.gov.uk")
+
 
 class Command(BaseCommand):
-    help = (
-        "Find or delete cases that are 2 years old or over that were not deleted prior to the task command being fixed"
-    )
+    help = """
+        Use cases:
+        1. Find or delete cases that are 2 years old or over that were not deleted prior to the task command being fixed
+        2. Delete logs created by users with a @digital.justice.gov.uk email
+        """
+
+    def handle_test_command(self, args, cases):
+        digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
+        if args[0] == "delete":
+            self.instance.run()
+        elif args[0] == "delete-logs":
+            self.instance._delete_objects(digital_justice_user_logs)
+
+    def handle_terminal_command(self, args, cases):
+        digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
+        if args[0] == "delete":
+            if len(args) > 1 and args[1] == "no-input":
+                self.instance.run()
+            else:
+                answer = raw_input(
+                    "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
+                        cases.count()
+                    )
+                )
+                if answer == "Yes":
+                    self.instance.run()
+        elif args[0] == "delete-logs":
+            answer = raw_input(
+                "Number of digital justice user logs that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
+                    digital_justice_user_logs.count()
+                )
+            )
+            if answer == "Yes":
+                self.instance._delete_objects(digital_justice_user_logs)
 
     def handle(self, *args, **kwargs):
-        instance = FindAndDeleteCasesUsingCreationTime()
-        cases = instance.get_eligible_cases()
+        self.instance = FindAndDeleteCasesUsingCreationTime()
+        cases = self.instance.get_eligible_cases()
         django_command = sys.argv[1]
 
         if django_command == "test":  # If command is run in test
-            if args and args[0] == "delete":
-                instance.run()
+            if args:
+                self.handle_test_command(args, cases)
             else:
                 return cases
         else:  # If command is run in terminal
-            if args and args[0] == "delete":
-                if len(args) > 1 and args[1] == "no-input":
-                    instance.run()
-                else:
-                    answer = raw_input(
-                        "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
-                            cases.count()
-                        )
-                    )
-                    if answer == "Yes":
-                        instance.run()
+            if args:
+                self.handle_terminal_command(args, cases)
             else:
                 print("Number of cases to be deleted: " + str(cases.count()))

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -45,12 +45,11 @@ class Command(BaseCommand):
                 if answer == "Yes":
                     self.instance.run()
         elif args[0] == "delete-logs":
+            digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
             if len(args) > 1 and args[1] == "no-input":
-                self.instance.run()
+                self.instance._delete_objects(digital_justice_user_logs)
             else:
-                digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
                 answer = self.get_user_input("digital justice user logs", digital_justice_user_logs)
-
                 if answer == "Yes":
                     self.instance._delete_objects(digital_justice_user_logs)
 

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -43,12 +43,12 @@ class Command(BaseCommand):
             if len(args) > 1 and args[1] == "no-input":
                 self.instance.run()
             else:
-                answer = get_user_input("cases", cases)
+                answer = self.get_user_input("cases", cases)
                 if answer == "Yes":
                     self.instance.run()
         elif args[0] == "delete-logs":
             digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
-            answer = get_user_input("digital justice user logs", digital_justice_user_logs)
+            answer = self.get_user_input("digital justice user logs", digital_justice_user_logs)
             if answer == "Yes":
                 self.instance._delete_objects(digital_justice_user_logs)
 

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -24,32 +24,31 @@ class Command(BaseCommand):
         2. Delete logs created by users with a @digital.justice.gov.uk email
         """
 
+    def get_user_input(self, qs_type, qs):
+        return raw_input(
+            "Number of {0} that will be deleted: {1}\nAre you sure about this? (Yes/No) ".format(
+                qs_type, qs.count()
+            )
+        )
+
     def handle_test_command(self, args, cases):
-        digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
         if args[0] == "delete":
             self.instance.run()
         elif args[0] == "delete-logs":
+            digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
             self.instance._delete_objects(digital_justice_user_logs)
 
     def handle_terminal_command(self, args, cases):
-        digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
         if args[0] == "delete":
             if len(args) > 1 and args[1] == "no-input":
                 self.instance.run()
             else:
-                answer = raw_input(
-                    "Number of cases that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
-                        cases.count()
-                    )
-                )
+                answer = get_user_input("cases", cases)
                 if answer == "Yes":
                     self.instance.run()
         elif args[0] == "delete-logs":
-            answer = raw_input(
-                "Number of digital justice user logs that will be deleted: {0}\nAre you sure about this? (Yes/No) ".format(
-                    digital_justice_user_logs.count()
-                )
-            )
+            digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
+            answer = get_user_input("digital justice user logs", digital_justice_user_logs)
             if answer == "Yes":
                 self.instance._delete_objects(digital_justice_user_logs)
 

--- a/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/management/commands/find_and_delete_old_cases.py
@@ -26,9 +26,7 @@ class Command(BaseCommand):
 
     def get_user_input(self, qs_type, qs):
         return raw_input(
-            "Number of {0} that will be deleted: {1}\nAre you sure about this? (Yes/No) ".format(
-                qs_type, qs.count()
-            )
+            "Number of {0} that will be deleted: {1}\nAre you sure about this? (Yes/No) ".format(qs_type, qs.count())
         )
 
     def handle_test_command(self, args, cases):
@@ -47,10 +45,14 @@ class Command(BaseCommand):
                 if answer == "Yes":
                     self.instance.run()
         elif args[0] == "delete-logs":
-            digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
-            answer = self.get_user_input("digital justice user logs", digital_justice_user_logs)
-            if answer == "Yes":
-                self.instance._delete_objects(digital_justice_user_logs)
+            if len(args) > 1 and args[1] == "no-input":
+                self.instance.run()
+            else:
+                digital_justice_user_logs = self.instance.get_digital_justice_user_logs()
+                answer = self.get_user_input("digital justice user logs", digital_justice_user_logs)
+
+                if answer == "Yes":
+                    self.instance._delete_objects(digital_justice_user_logs)
 
     def handle(self, *args, **kwargs):
         self.instance = FindAndDeleteCasesUsingCreationTime()

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -46,6 +46,12 @@ class FindAndDeleteOldCases(TestCase):
         self.command.execute("delete")
         freezer.stop()
 
+    def delete_logs(self, current_time):
+        freezer = freeze_time(current_time)
+        freezer.start()
+        self.command.execute("delete-logs")
+        freezer.stop()
+
     def find_old_cases(self, current_time):
         freezer = freeze_time(current_time)
         freezer.start()

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -35,10 +35,10 @@ class FindAndDeleteOldCases(TestCase):
         return case
 
     def create_event_log_for_case(self, case, code, created, created_by=None):
+        kwargs = {"case": case, "code": code, "created": created}
         if created_by:
-            make_recipe("cla_eventlog.log", case=case, code=code, created=created, created_by=created_by)
-        else:
-            make_recipe("cla_eventlog.log", case=case, code=code, created=created)
+            kwargs.update(created_by=created_by)
+        make_recipe("cla_eventlog.log", **kwargs)
 
     def delete_old_cases(self, current_time):
         freezer = freeze_time(current_time)
@@ -239,7 +239,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(DiagnosisTraversal.objects.count(), 1)
         self.assertEqual(PersonalDetails.objects.count(), 1)
 
-    def test_log_is_deleted_when_case_is_viewed_by_digital_justice_user(self):
+    def test_case_viewed_by_digital_justice_user(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -260,7 +260,7 @@ class FindAndDeleteOldCases(TestCase):
         cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=digital_justice_user)
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
 
-    def test_log_is_not_deleted_when_case_is_viewed_by_non_digital_justice_user(self):
+    def test_case_viewed_by_non_digital_justice_user(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -281,7 +281,7 @@ class FindAndDeleteOldCases(TestCase):
         cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=non_digital_justice_user)
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 1)
 
-    def test_log_deletion_when_case_is_viewed_by_digital_and_non_digital_users(self):
+    def test_case_viewed_by_digital_and_non_digital_users(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -309,7 +309,7 @@ class FindAndDeleteOldCases(TestCase):
         # Implies implicitly that the non digital justice user log did not get deleted
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
 
-    def test_log_deletion_when_case_viewed_on_the_same_day_by_digital_and_non_digital_users(self):
+    def test_case_viewed_same_day_by_digital_and_non_digital_users(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -337,7 +337,7 @@ class FindAndDeleteOldCases(TestCase):
         # Implies implicitly that the non digital justice user log did not get deleted
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
 
-    def test_log_deletion_when_case_is_viewed_multiple_times_by_digital_and_non_digital_users(self):
+    def test_case_viewed_multiple_times_by_digital_and_non_digital_users(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -377,7 +377,7 @@ class FindAndDeleteOldCases(TestCase):
         # Implies implicitly that the non digital justice user logs did not get deleted
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
 
-    def test_log_deletion_across_multiple_cases(self):
+    def test_multiple_cases_viewed_by_multiple_users(self):
         case_1_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case_1 = self.create_case(case_1_date, "legalaid.eligible_case")
 

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -262,7 +262,7 @@ class FindAndDeleteOldCases(TestCase):
         eod = make_recipe("legalaid.eod_details", case=case)
         make_recipe("complaints.complaint", eod=eod, created=complaint_date)
 
-        non_digital_justice_user = User.objects.create_user("non_digital_justice_user", "email@chs.email.com")
+        non_digital_justice_user = User.objects.create_user("non_digital_justice_user", "chs.user@email.com")
         self.create_event_log_for_case(
             case, "CASE_VIEWED", _make_datetime(year=2020, month=6, day=27, hour=9), non_digital_justice_user
         )
@@ -272,5 +272,5 @@ class FindAndDeleteOldCases(TestCase):
 
         self.assertEqual(Log.objects.count(), 1)
         self.assertEqual(Case.objects.count(), 1)
-        cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=digital_justice_user)
-        self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
+        cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=non_digital_justice_user)
+        self.assertEqual(cases_with_digital_justice_user_logs.count(), 1)

--- a/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
+++ b/cla_backend/apps/cla_eventlog/tests/test_find_and_delete_old_cases.py
@@ -233,7 +233,7 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(DiagnosisTraversal.objects.count(), 1)
         self.assertEqual(PersonalDetails.objects.count(), 1)
 
-    def test_log_is_deleted_when_viewed_by_digital_justice_user(self):
+    def test_log_is_deleted_when_case_is_viewed_by_digital_justice_user(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -254,7 +254,7 @@ class FindAndDeleteOldCases(TestCase):
         cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=digital_justice_user)
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
 
-    def test_log_is_deleted_when_viewed_by_non_digital_justice_user(self):
+    def test_log_is_not_deleted_when_case_is_viewed_by_non_digital_justice_user(self):
         case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
         case = self.create_case(case_date, "legalaid.eligible_case")
 
@@ -274,3 +274,71 @@ class FindAndDeleteOldCases(TestCase):
         self.assertEqual(Case.objects.count(), 1)
         cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=non_digital_justice_user)
         self.assertEqual(cases_with_digital_justice_user_logs.count(), 1)
+
+    def test_single_log_deletion_when_case_is_viewed_by_digital_and_non_digital_users(self):
+        case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
+        case = self.create_case(case_date, "legalaid.eligible_case")
+
+        complaint_date = _make_datetime(year=2014, month=5, day=27, hour=9)
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod, created=complaint_date)
+
+        digital_justice_user = User.objects.create_user("digital_justice_user", "email@digital.justice.gov.uk")
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=5, day=27, hour=9), digital_justice_user
+        )
+
+        non_digital_justice_user = User.objects.create_user("non_digital_justice_user", "chs.user@email.com")
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=6, day=27, hour=9), non_digital_justice_user
+        )
+
+        dt = _make_datetime(year=2021, month=1, day=1, hour=9)
+        self.delete_logs(dt)
+
+        self.assertEqual(Log.objects.count(), 1)
+        self.assertEqual(Case.objects.count(), 1)
+
+        cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=digital_justice_user)
+        # Implies implicitly that the non digital justice user log did not get deleted
+        self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)
+
+    def test_multiple_log_deletion_when_case_is_viewed_by_digital_and_non_digital_users(self):
+        case_date = _make_datetime(year=2014, month=5, day=24, hour=9)
+        case = self.create_case(case_date, "legalaid.eligible_case")
+
+        complaint_date = _make_datetime(year=2014, month=5, day=27, hour=9)
+        eod = make_recipe("legalaid.eod_details", case=case)
+        make_recipe("complaints.complaint", eod=eod, created=complaint_date)
+
+        digital_justice_user = User.objects.create_user("digital_justice_user", "email@digital.justice.gov.uk")
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=5, day=27, hour=9), digital_justice_user
+        )
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=6, day=27, hour=9), digital_justice_user
+        )
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=8, day=27, hour=9), digital_justice_user
+        )
+
+        non_digital_justice_user = User.objects.create_user("non_digital_justice_user", "chs.user@email.com")
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=3, day=22, hour=9), non_digital_justice_user
+        )
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=6, day=22, hour=9), non_digital_justice_user
+        )
+        self.create_event_log_for_case(
+            case, "CASE_VIEWED", _make_datetime(year=2020, month=9, day=21, hour=9), non_digital_justice_user
+        )
+
+        dt = _make_datetime(year=2021, month=1, day=1, hour=9)
+        self.delete_logs(dt)
+
+        self.assertEqual(Log.objects.count(), 3)
+        self.assertEqual(Case.objects.count(), 1)
+
+        cases_with_digital_justice_user_logs = Case.objects.filter(log__created_by=digital_justice_user)
+        # Implies implicitly that the non digital justice user log did not get deleted
+        self.assertEqual(cases_with_digital_justice_user_logs.count(), 0)


### PR DESCRIPTION
## What does this pull request do?

- Creates test cases for deleting logs created by users with a **digital.justice.gov.uk** email
- Logs created by users with a non digital.justice.gov.uk email **will not be deleted**
- Let us potentially filter more old cases/complaints to be queued for deletion
- Delete logs by passing a `delete-logs` parameter to the command
- Create conditionals depending on whether the command is called in the terminal/test suite
- Refactor command handling due to linting errors complaining code was too complex

## Any other changes that would benefit highlighting?

Coveralls failing due to some of the code only accessible/used in the terminal and not in the test suite

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
