### PR TITLE
Read SECRET_KEY from environment variable

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -170,7 +170,7 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = "o=>4$)9?38N@^}d&pj,VL9^{r][xM9L.9cfE:xZZNk(N?v27+i"
+SECRET_KEY = os.environ.get("SECRET_KEY", "iia425u_J_pwntnEyqBuI1xBDqOX8nZ4uC73epGce_w")
 
 # List of callables that know how to import templates from various sources.
 # TEMPLATE_LOADERS = (


### PR DESCRIPTION
## What does this pull request do?

Read SECRET_KEY from environment variable

## Any other changes that would benefit highlighting?

Ideally I wanted this to be `os.environ["SECRET_KEY"]` but circleci is not detecting the environment variable that determines which setting file to use. This can be done separately as it probably requires more time to investigate why this is happening and this work is required to go out as soon as possible.

Possible impact after merging this PR:
Users being logged out

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
