### PR TITLE
LGA-1500 Add guidance notes fixture as part of data to be loaded into DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Create an admin user by running the following command and specifying username ==
 
 Load initial data:
 
-    ./manage.py loaddata initial_groups.json kb_from_knowledgebase.json initial_category.json test_provider.json test_provider_allocations.json initial_mattertype.json test_auth_clients.json initial_media_codes.json test_rotas.json
+    ./manage.py loaddata initial_groups.json kb_from_knowledgebase.json initial_category.json test_provider.json test_provider_allocations.json initial_mattertype.json test_auth_clients.json initial_media_codes.json test_rotas.json initial_guidance_notes.json
 
 Start the server:
 

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/ministryofjustice/cla_backend",
   "success_url": "/admin/",
   "scripts": {
-    "postdeploy": "./manage.py migrate --noinput && ./manage.py loaddata initial_groups.json kb_from_knowledgebase.json initial_category.json test_provider.json test_provider_allocations.json initial_mattertype.json test_auth_clients.json initial_media_codes.json test_rotas.json"
+    "postdeploy": "./manage.py migrate --noinput && ./manage.py loaddata initial_groups.json kb_from_knowledgebase.json initial_category.json test_provider.json test_provider_allocations.json initial_mattertype.json test_auth_clients.json initial_media_codes.json test_rotas.json initial_guidance_notes.json"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -9,6 +9,7 @@ migrations() {
     python manage.py loaddata initial_mattertype.json
     python manage.py loaddata initial_media_codes.json
     python manage.py loaddata initial_complaint_categories.json
+    python manage.py loaddata initial_guidance_notes.json
 }
 
 load_test_data() {


### PR DESCRIPTION
## What does this pull request do?

- Adds guidance notes fixture `initial_guidance_notes.json` as part of data to be loaded into DB
- Updated README to reflect this change (will require us to run `./manage loaddata initial_guidance_notes.json` command to apply the change)

## Any other changes that would benefit highlighting?

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
