### PR TITLE
Reduce Sentry traces sample rate

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -278,7 +278,7 @@ if "SENTRY_DSN" in os.environ:
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.5,
         environment=os.environ.get("CLA_ENV", "unknown"),
     )
 


### PR DESCRIPTION
This reduces the Sentry traces sample rate by a half to avoid transactions across MoJ being rate limited. This month [we've hit our rate limit](https://sentry.io/organizations/ministryofjustice/stats/?dataCategory=transactions&pageStatsPeriod=14d&transform=periodic) only half way through the month so I'm looking to reduce the sample rate across our apps which send the most to Sentry. https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1529 is an example for `hmpps-book-secure-move-api`.

I hope reducing the sample rate by a half doesn't affect your application too much.