### PR TITLE
LGA-1933 - Remove usage of deprecated extensions/v1beta1 ingress api version

### DIFF
--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
## What does this pull request do?

Remove usage of deprecated extensions/v1beta1 ingress api version
Use networking.k8s.io/v1 ingress api version

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
