### PR TITLE
LGA-1936 - Create reusable script to authenticate with cluster

### DIFF
--- a/.circleci/authenticate_with_kubernetes_cluster
+++ b/.circleci/authenticate_with_kubernetes_cluster
@@ -1,0 +1,8 @@
+#!/bin/sh -eu
+
+echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
+kubectl config set-credentials circleci --token=${K8S_TOKEN}
+kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
+kubectl config use-context ${K8S_CLUSTER_NAME}
+kubectl --namespace=${K8S_NAMESPACE} get pods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,16 @@ workflows:
       - lint
       - test
       - cleanup_merged:
-          context: laa-cla-backend
+          name: cleanup_merged_live1
+          context:
+            - laa-cla-backend
+            - laa-cla-backend-live1-uat
+      - cleanup_merged:
+          name: cleanup_merged_live
+          context:
+            - laa-cla-backend
+            - laa-cla-backend-live-uat
+
       - build:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,12 +160,7 @@ jobs:
       - run:
           name: Authenticate with cluster
           command: |
-            echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
-            kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
-            kubectl config set-credentials circleci --token=${K8S_TOKEN}
-            kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
-            kubectl config use-context ${K8S_CLUSTER_NAME}
-            kubectl --namespace=${K8S_NAMESPACE} get pods
+            .circleci/authenticate_with_kubernetes_cluster
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |
@@ -193,10 +188,9 @@ jobs:
             tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
-          name: Initialise Kubernetes uat context
+          name: Authenticate with cluster
           command: |
-            setup-kube-auth
-            kubectl config use-context uat
+            .circleci/authenticate_with_kubernetes_cluster
       - run:
           name: Delete uat release
           command: |


### PR DESCRIPTION
Remove missed setup-kube-auth in cleanup_merged job

## What does this pull request do?

Create reusable script to authenticate with cluster.
Remove missed setup-kube-auth in cleanup_merged job

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
