### PR TITLE
LGA-1806 - Add disregards in the eligibility report

### DIFF
--- a/cla_backend/apps/reports/sql/obiee/export_legal_aid_eligibility_check.sql
+++ b/cla_backend/apps/reports/sql/obiee/export_legal_aid_eligibility_check.sql
@@ -15,6 +15,7 @@ dependants_old,
 on_passported_benefits,
 on_nass_benefits,
 specific_benefits,
+CASE WHEN lower(disregards::text) LIKE '%%:true%%' THEN 'Yes' ELSE 'No' end as "Disregarded Payment",
 is_you_or_your_partner_over_60,
 has_partner,
 calculations


### PR DESCRIPTION
## What does this pull request do?

Add disregards in the eligibility report

## Any other changes that would benefit highlighting?

If Yes is given as answer to any disregards then use a value of "Yes" or  a value of "No" in the eligibility report

Due to the disregards column being an json object and not an array, I couldn't find a way to check if the object contained any True value within the same main query.

If the column was a json array or a postgres then I could have used a function like the ANY function to check if it contained a True value.

The other option was to introduce a new has_any_disregards column to contain True if any disregards were selected but I think the chosen approach does this without the additional column.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
