### PR TITLE
LGA-1971 - Update forked django-pagedown

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ jsonfield==0.9.22
 django-uuidfield==0.5.0
 drf-nested-routers==0.1.3
 # Fork of django pagedown to allow extensions in JS
-git+https://github.com/ministryofjustice/django-pagedown.git@v0.2.1#egg=django-pagedown==0.2.1
+git+https://github.com/ministryofjustice/django-pagedown.git@v0.2.2#egg=django-pagedown==0.2.2
 
 Markdown==2.5.2
 bleach==2.0.0


### PR DESCRIPTION
## What does this pull request do?
Update to version 0.2.2, which is the same as 0.2.1 but with submodules
defined using the https:// protocol instead of the git:// protocol, to
allow them to continue to be installed

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
