### PR TITLE
Increase timeoutSeconds for worker pods probes

### DIFF
--- a/helm_deploy/cla-backend/templates/deployment-worker.yaml
+++ b/helm_deploy/cla-backend/templates/deployment-worker.yaml
@@ -24,12 +24,12 @@ spec:
             exec:
               command: ["python", "manage.py", "worker_probes"]
             initialDelaySeconds: 10
-            timeoutSeconds: 2
+            timeoutSeconds: 10
             periodSeconds: 10
           livenessProbe:
             exec:
               command: ["python", "manage.py", "worker_probes"]
             initialDelaySeconds: 10
-            timeoutSeconds: 2
+            timeoutSeconds: 10
             periodSeconds: 10
 {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Increase timeoutSeconds for worker pods probes

## Any other changes that would benefit highlighting?
It seems that on the new cluster the worker pod probes were taking longer than 2 seconds and was causing the pod to crash loop.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
