### PR TITLE
LGA-1933 - Remove deprecated extensions/v1beta1 ingress api version and use networking.k8s.io/v1

### DIFF
--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,7 +28,10 @@ spec:
       http:
         paths:
           - path: "/"
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}-app
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}-app
+                port:
+                  number: {{ $svcPort }}
 {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Remove deprecated extensions/v1beta1 ingress api version and use networking.k8s.io/v1

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
