### PR TITLE
LGA-2081 - Add maintenance mode page

### DIFF
--- a/cla_backend/apps/status/middleware.py
+++ b/cla_backend/apps/status/middleware.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.shortcuts import redirect
+
+
+class MaintenanceModeMiddleware(object):
+    MAINTENANCE_PATH = "/maintenance"
+    EXEMPT_PATHS = [
+        "/status",
+        "/status/ping.json",
+        "/status/status.json",
+        "/status/healthcheck.json",
+        MAINTENANCE_PATH,
+    ]
+
+    def process_request(self, request):
+        maintenance_mode = getattr(settings, "MAINTENANCE_MODE", False)
+        if maintenance_mode and request.path not in self.EXEMPT_PATHS:
+            return redirect(self.MAINTENANCE_PATH)
+        if not maintenance_mode and request.path == self.MAINTENANCE_PATH:
+            return redirect("/admin")

--- a/cla_backend/apps/status/views.py
+++ b/cla_backend/apps/status/views.py
@@ -2,6 +2,7 @@ from django.db import connection, DatabaseError
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.renderers import JSONRenderer
+from django.views.generic import TemplateView
 
 from cla_common.smoketest import smoketest
 from moj_irat.views import PingJsonView as BasePingJsonView
@@ -44,3 +45,11 @@ def smoketests(request):
 
 class PingJsonView(BasePingJsonView):
     CONTRACT_2018_ENABLED_key = None
+
+
+class MaintenanceModeView(TemplateView):
+    template_name = "maintenance.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        return self.render_to_response(context, status=503)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -186,6 +186,7 @@ MIDDLEWARE_CLASSES = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "status.middleware.MaintenanceModeMiddleware",
 )
 
 ROOT_URLCONF = "cla_backend.urls"
@@ -408,6 +409,8 @@ def bank_holidays_cache_adapter_factory():
 
 
 CacheAdapter.set_adapter_factory(bank_holidays_cache_adapter_factory)
+
+MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False") == "True"
 
 # .local.py overrides all the common settings.
 try:

--- a/cla_backend/templates/maintenance.html
+++ b/cla_backend/templates/maintenance.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block title %}This service is down for maintenance{% endblock %}
+
+{% block content %}
+	<h1>This service is down for maintenance</h1>
+{% endblock content %}

--- a/cla_backend/urls.py
+++ b/cla_backend/urls.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.conf.urls.static import static
+from status.views import MaintenanceModeView
 
 
 urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
@@ -21,6 +22,7 @@ if settings.ADMIN_ENABLED:
 
     urlpatterns += patterns(
         "",
+        url(r"^maintenance$", view=MaintenanceModeView.as_view(), name="maintenance_page"),
         url(r"^status/", include("status.urls", namespace="status")),
         url(r"^admin/", include(admin.site.urls)),
         url(r"^admin/reports/", include("reports.urls", namespace="reports")),

--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "cla-backend.labels" . | nindent 4 }}
   annotations:
+# Add annotation to exclude 503 error pages from the list the cloud-platform error pages
+# and use our error pages for 503 errors
+    nginx.ingress.kubernetes.io/custom-http-errors: "413,502,504"
     kubernetes.io/ingress.class: "modsec01"
     {{- if .Values.ingress.cluster.name }}
     external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -223,6 +223,11 @@ envVars:
       name: show-new-cb1
       key: showing
       optional: true
+  MAINTENANCE_MODE:
+    configmap:
+      name: maintenance-mode
+      key: "value"
+      optional: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## What does this pull request do?

Add maintenance mode page
Add `MAINTENANCE_MODE` environment variable that is set from a K8 `maintenance-mode` configmap
Add annotation to exclude 503 error pages from the list the cloud-platform error pages and use our error pages for 503 errors
## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
