### PR TITLE
LGA-2063 - Use the newly migrated postgres10 database credentials for training environment

### DIFF
--- a/helm_deploy/cla-backend/values-training.yaml
+++ b/helm_deploy/cla-backend/values-training.yaml
@@ -20,6 +20,26 @@ envVars:
     value: "False"
   LOAD_TEST_DATA:
     value: "True"
+  DB_HOST:
+    secret:
+      name: database-10
+      key: host
+  DB_PORT:
+    secret:
+      name: database-10
+      key: port
+  DB_NAME:
+    secret:
+      name: database-10
+      key: name
+  DB_USER:
+    secret:
+      name: database-10
+      key: user
+  DB_PASSWORD:
+    secret:
+      name: database-10
+      key: password
   REPLICA_DB_HOST:
     value: ~
     secret: ~


### PR DESCRIPTION
## What does this pull request do?

Use the newly migrated postgres10 database credentials for training environment

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
