### PR TITLE
LGA 2111 new education provider hours in july

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -334,7 +334,18 @@ NINE_TO_FIVE = (datetime.time(9, 0), datetime.time(17, 0))
 
 NON_ROTA_HOURS = {"weekday": (datetime.time(8, 0), datetime.time(17, 0))}
 DISCRIMINATION_NON_ROTA_HOURS = {"weekday": (datetime.time(8, 0), datetime.time(18, 0))}
-EDUCATION_NON_ROTA_HOURS = {"monday": NINE_TO_FIVE, "tuesday": NINE_TO_FIVE, "wednesday": NINE_TO_FIVE}
+
+JULY_EDUCATION = os.environ.get("JULY_EDUCATION", "False").lower() == "true"
+
+if JULY_EDUCATION is True:
+    EDUCATION_NON_ROTA_HOURS = {
+        "monday": NINE_TO_FIVE,
+        "tuesday": NINE_TO_FIVE,
+        "wednesday": NINE_TO_FIVE,
+        "thursday": NINE_TO_FIVE,
+    }
+else:
+    EDUCATION_NON_ROTA_HOURS = {"monday": NINE_TO_FIVE, "tuesday": NINE_TO_FIVE, "wednesday": NINE_TO_FIVE}
 
 # If an unknown or empty is used to get from NON_ROTA_OPENING_HOURS then it will default to a basic NON_ROTA_HOURS
 NON_ROTA_OPENING_HOURS = defaultdict(lambda: OpeningHours(**NON_ROTA_HOURS))

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -228,6 +228,11 @@ envVars:
       name: maintenance-mode
       key: "value"
       optional: true
+  JULY_EDUCATION:
+    configmap:
+      name: july-education
+      key: "value"
+      optional: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Added a feature flag that when switched on goes to the new education
provider hours to be set in july.

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
