### PR TITLE
LGA-1967 - Pull down the latest version of the end-to-end-tests orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@dev:first
+  cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
 jobs:
   build:
     docker:


### PR DESCRIPTION
## What does this pull request do?

Pull down the latest version of the end-to-end-tests orb

## Any other changes that would benefit highlighting?

Requires https://github.com/ministryofjustice/cla-end-to-end-tests/pull/63

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
