### PR TITLE
WIP LGA-2123 Update ingress for changes to Kubernetes 1.22

### DIFF
--- a/helm_deploy/cla-backend/templates/ingress.yaml
+++ b/helm_deploy/cla-backend/templates/ingress.yaml
@@ -1,19 +1,19 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-backend.fullname" . -}}
+{{- $ingressName := printf "%s-%s" $fullName "v122" -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $ingressName }}
   labels:
     {{- include "cla-backend.labels" . | nindent 4 }}
   annotations:
 # Add annotation to exclude 503 error pages from the list the cloud-platform error pages
 # and use our error pages for 503 errors
     nginx.ingress.kubernetes.io/custom-http-errors: "413,502,504"
-    kubernetes.io/ingress.class: "modsec01"
     {{- if .Values.ingress.cluster.name }}
-    external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
+    external-dns.alpha.kubernetes.io/set-identifier: "{{ $ingressName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
     external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
     {{- end }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "cla-backend.whitelist" . }}"
@@ -24,6 +24,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleRemoveById 200001
 spec:
+  ingressClassName: "modsec"
   tls:
     - hosts:
        - "{{ .Values.host }}"


### PR DESCRIPTION
## What does this pull request do?

Update ingress for changes to Kubernetes 1.22

Suffix the new ingress name (metadata.name)with v122. This required creating a new variable called $ingressName which combines $fullName and v122.

Made sure apiVersion has a value of networking.k8s.io/v1

Made sure the format of the ingress is the same as in the cloud platforms example (in particular look at paths under spec) 

Added the annotation ingressClassName: "modsec" under spec.  It was under annotations and has a different format. Remove the line in annotations.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
