### PR TITLE
LGA-2123 v1.22 Update ingress for Kubernetes 

### DIFF
--- a/helm_deploy/cla-backend/templates/ingress_v122.yaml
+++ b/helm_deploy/cla-backend/templates/ingress_v122.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cla-backend.fullname" . -}}
+{{- $ingressName := printf "%s-%s" $fullName "v122" -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $ingressName }}
+  labels:
+    {{- include "cla-backend.labels" . | nindent 4 }}
+  annotations:
+# Add annotation to exclude 503 error pages from the list the cloud-platform error pages
+# and use our error pages for 503 errors
+    nginx.ingress.kubernetes.io/custom-http-errors: "413,502,504"
+    {{- if .Values.ingress.cluster.name }}
+    external-dns.alpha.kubernetes.io/set-identifier: "{{ $ingressName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
+    external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
+    {{- end }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "cla-backend.whitelist" . }}"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 200001
+spec:
+  ingressClassName: "modsec"
+  tls:
+    - hosts:
+       - "{{ .Values.host }}"
+      {{- if .Values.secretName }}
+      secretName: {{ .Values.secretName }}
+      {{- end }}
+  rules:
+    - host: "{{ .Values.host }}"
+      http:
+        paths:
+          - path: "/"
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-app
+                port:
+                  number: {{ $svcPort }}
+{{- end }}


### PR DESCRIPTION
## What does this pull request do?

Creates new ingress file to do upgrade prior to move to Kubernete 1.22.  Helm will assume you want to delete the existing ingress if you only change the current file to create a new ingress.

Helm adds  it’s own annotations: `app.kubernetes.io/managed-by: Helm` and `helm.sh/chart: cla-backend-0.1.3`; because of this if you make changes directly to  <old-ingress-name> and recommit, helm considers the ingress to be a new version of the same resource and deletes the old one. This leads to downtime.

## Any other changes that would benefit highlighting?
This is a multistep process - first weighting is set to zero for existing 1.21 ingresses, then once this new file has been added and it is verified that traffic is passing through the new v1.22 ingress, the old ingress can be deleted in kubectl and then a further two separate commits will be required to 1) delete the old 1.21 ingress file and then 2)rename this new file as `ingress.yaml`.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
