### PR TITLE
LGA-2216 - Use forked version of django-moj-irat that supports django1.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,10 @@ PyYAML==3.11
 pyminizip==0.2.3
 
 #Irat healthcheck and ping package
-git+https://github.com/ministryofjustice/django-moj-irat.git@0.3#egg=django-moj-irat==0.3
+# Temporarily forked until we move to django1.8
+# use git+https://github.com/ministryofjustice/django-moj-irat.git@0.3#egg=django-moj-irat==0.3 when we have upgraded to
+# django 1.8
+git+https://github.com/said-moj/django-moj-irat.git@0.3.1#egg=django-moj-irat==0.3.1
 
 # stack interrogation
 boto3>=1.5,<2


### PR DESCRIPTION
## What does this pull request do?

Use forked version of django-moj-irat that supports django1.7

## Any other changes that would benefit highlighting?

The current main repo for django-moj-irat requires django>=1.8,<1.9
We are looking to switch to pip-tools and the version that is compatible with our python version does not yet support resolving version mismatch

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
