### PR TITLE
WIP - LGA-2221 - Use original package of django-pagedown

### DIFF
--- a/cla_backend/apps/core/admin/fields.py
+++ b/cla_backend/apps/core/admin/fields.py
@@ -34,7 +34,7 @@ class MarkdownAdminField(forms.CharField):
         self.extensions = kwargs.pop("extensions", [])
 
         if "widget" not in kwargs:
-            kwargs["widget"] = AdminPagedownWidget(extensions=self.extensions)
+            kwargs["widget"] = AdminPagedownWidget()
 
         self.markdown_whitelist = kwargs.pop("markdown_whitelist", DEFAULT_MARKDOWN_WHITELIST)
 

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -83,7 +83,7 @@ https://github.com/said-moj/django-moj-irat/archive/refs/tags/0.3.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/ministryofjustice/django-oauth2-provider/archive/refs/tags/v2.7.0.beta.tar.gz
     # via -r requirements/source/requirements-base.in
-https://github.com/ministryofjustice/django-pagedown/archive/refs/tags/v0.2.2.tar.gz
+https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/HassenPy/django-pdb/archive/refs/tags/0.3.2.tar.gz
     # via -r requirements/source/requirements-testing.in

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -60,7 +60,7 @@ https://github.com/said-moj/django-moj-irat/archive/refs/tags/0.3.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/ministryofjustice/django-oauth2-provider/archive/refs/tags/v2.7.0.beta.tar.gz
     # via -r requirements/source/requirements-base.in
-https://github.com/ministryofjustice/django-pagedown/archive/refs/tags/v0.2.2.tar.gz
+https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
     # via -r requirements/source/requirements-base.in
 django-rest-swagger==0.1.14
     # via -r requirements/source/requirements-docs.in

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -56,7 +56,7 @@ https://github.com/said-moj/django-moj-irat/archive/refs/tags/0.3.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/ministryofjustice/django-oauth2-provider/archive/refs/tags/v2.7.0.beta.tar.gz
     # via -r requirements/source/requirements-base.in
-https://github.com/ministryofjustice/django-pagedown/archive/refs/tags/v0.2.2.tar.gz
+https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
     # via -r requirements/source/requirements-base.in
 django-storages==1.5.2
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -70,7 +70,7 @@ https://github.com/said-moj/django-moj-irat/archive/refs/tags/0.3.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/ministryofjustice/django-oauth2-provider/archive/refs/tags/v2.7.0.beta.tar.gz
     # via -r requirements/source/requirements-base.in
-https://github.com/ministryofjustice/django-pagedown/archive/refs/tags/v0.2.2.tar.gz
+https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
     # via -r requirements/source/requirements-base.in
 https://github.com/HassenPy/django-pdb/archive/refs/tags/0.3.2.tar.gz
     # via -r requirements/source/requirements-testing.in

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -13,8 +13,7 @@ djangorestframework==2.3.14
 jsonfield==0.9.22
 django-uuidfield==0.5.0
 drf-nested-routers==0.1.3
-# Fork of django pagedown to allow extensions in JS
-https://github.com/ministryofjustice/django-pagedown/archive/refs/tags/v0.2.2.tar.gz
+https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
 
 Markdown==2.5.2
 bleach==2.0.0


### PR DESCRIPTION
## What does this pull request do?
Use original package of django-pagedown

## Any other changes that would benefit highlighting?

Version v1.1 of timmyomahony/django-pagedown incorporates the changes from the fork thanks to https://github.com/timmyomahony/django-pagedown/pull/33

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
