### PR TITLE
Feature/lga 2236 Update Opening hours to use env variables

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -51,14 +51,6 @@ MANAGERS = ADMINS
 EMAIL_FROM_ADDRESS = "no-reply@civillegaladvice.service.gov.uk"
 DEFAULT_EMAIL_TO = "cla-alerts@digital.justice.gov.uk"
 
-# Want to alter start and end times via environment variables.
-# In case these are not set, default values are set here
-DEFAULT_NON_ROTA_START_TIME_HR = 8
-DEFAULT_NON_ROTA_END_TIME_HR = 17
-DEFAULT_ED_START_TIME_HR = 9
-DEFAULT_ED_END_TIME_HR = 17
-DEFAULT_DISCRIM_START_TIME_HR = 8
-DEFAULT_DISCRIM_END_TIME_HR = 18
 
 OPERATOR_USER_ALERT_EMAILS = []
 SPECIALIST_USER_ALERT_EMAILS = []
@@ -339,6 +331,15 @@ else:
 CALL_CENTRE_NOTIFY_EMAIL_ADDRESS = os.environ.get("CALL_CENTRE_NOTIFY_EMAIL_ADDRESS", DEFAULT_EMAIL_TO)
 
 # LGA-2236 Set rota hours start and end times using environment variables so can change without updating the code.
+# Want to alter start and end times via environment variables.
+# In case these are not set, default values are set here
+DEFAULT_NON_ROTA_START_TIME_HR = 8
+DEFAULT_NON_ROTA_END_TIME_HR = 17
+DEFAULT_ED_START_TIME_HR = 9
+DEFAULT_ED_END_TIME_HR = 17
+DEFAULT_DISCRIM_START_TIME_HR = 8
+DEFAULT_DISCRIM_END_TIME_HR = 18
+
 NON_ROTA_START_TIME_HR = int(os.environ.get("NON_ROTA_START_TIME_HR", DEFAULT_NON_ROTA_START_TIME_HR))
 NON_ROTA_END_TIME_HR = int(os.environ.get("NON_ROTA_END_TIME_HR", DEFAULT_NON_ROTA_END_TIME_HR))
 

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -352,17 +352,12 @@ NON_ROTA_HOURS = {"weekday": (datetime.time(NON_ROTA_START_TIME_HR, 0), datetime
 EDUCATION_DAILY_HOURS = (datetime.time(EDUCATION_START_TIME_HR, 0), datetime.time(EDUCATION_END_TIME_HR, 0))
 DISCRIMINATION_NON_ROTA_HOURS = {"weekday": (datetime.time(DISCRIMINATION_START_TIME_HR, 0), datetime.time(DISCRIMINATION_END_TIME_HR, 0))}
 
-JULY_EDUCATION_FEATURE_FLAG = os.environ.get("JULY_EDUCATION", "False").lower() == "true"
-
-if JULY_EDUCATION_FEATURE_FLAG is True:
-    EDUCATION_NON_ROTA_HOURS = {
+EDUCATION_NON_ROTA_HOURS = {
         "monday": EDUCATION_DAILY_HOURS,
         "tuesday": EDUCATION_DAILY_HOURS,
         "wednesday": EDUCATION_DAILY_HOURS,
         "thursday": EDUCATION_DAILY_HOURS,
-    }
-else:
-    EDUCATION_NON_ROTA_HOURS = {"monday": EDUCATION_DAILY_HOURS, "tuesday": EDUCATION_DAILY_HOURS, "wednesday": EDUCATION_DAILY_HOURS}
+}
 
 # If an unknown or empty is used to get from NON_ROTA_OPENING_HOURS then it will default to a basic NON_ROTA_HOURS
 NON_ROTA_OPENING_HOURS = defaultdict(lambda: OpeningHours(**NON_ROTA_HOURS))


### PR DESCRIPTION
## What does this pull request do?

Updated all of the rota opening hours to use environment variables. This means they can be set without changing the code.
There are defaults set in case these are not set.
This change is primarily so we can run out of hours end to end tests.

## Any other changes that would benefit highlighting?

Have also removed the code creating a  JULY_EDUCATION_FEATURE_FLAG, this will need to be removed from the configMap as well.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
