### PR TITLE
LGA-2164 Roll back database-11 changes

### DIFF
--- a/helm_deploy/cla-backend/values-staging.yaml
+++ b/helm_deploy/cla-backend/values-staging.yaml
@@ -19,31 +19,6 @@ ingress:
 envVars:
   DEBUG:
     value: "False"
-  DB_HOST:
-    secret:
-      name: database-11
-      key: host
-  DB_PORT:
-    secret:
-      name: database-11
-      key: port
-      optional: true
-  DB_NAME:
-    secret:
-      name: database-11
-      key: name
-  DB_USER:
-    secret:
-      name: database-11
-      key: user
-  DB_PASSWORD:
-    secret:
-      name: database-11
-      key: password
-  REPLICA_DB_HOST:
-    secret:
-      name: database-11
-      key: replica_host
   LOAD_SEED_DATA:
     value: "True"
   LOAD_TEST_DATA:


### PR DESCRIPTION
## What does this pull request do?

When comparing pre and post migration reports, it seems as though not all the files were not the same. This PR makes the application point back at database-10 so can see if there was an issue with the migration.

Trying to rule out the issue being with this or the oauth change.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
