### PR TITLE
LGA-1772 - Update Django Rest Framework(DRF) to 2.4.8

### DIFF
--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -15,7 +15,7 @@ from historic.models import CaseArchived
 from legalaid.permissions import IsManagerOrMePermission
 
 from rest_framework import viewsets, mixins, status
-from rest_framework.decorators import action, link
+from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response as DRFResponse
 from rest_framework.filters import OrderingFilter, DjangoFilterBackend, SearchFilter, BaseFilterBackend
 
@@ -24,7 +24,6 @@ from cla_eventlog.views import BaseEventViewSet, BaseLogViewSet
 from cla_provider.helpers import ProviderAllocationHelper, notify_case_assigned
 
 from core.drf.pagination import RelativeUrlPaginationSerializer
-from core.drf.decorators import list_route
 from core.drf.mixins import FormActionMixin
 from notifications.views import BaseNotificationViewSet
 
@@ -282,7 +281,7 @@ class CaseViewSet(
 
         return DRFResponse(serializer.data)
 
-    @link()
+    @detail_route()
     def assign_suggest(self, request, reference=None, **kwargs):
         """
         @return: dict - 'suggested_provider' (single item) ;
@@ -320,7 +319,7 @@ class CaseViewSet(
 
         return DRFResponse(suggestions)
 
-    @action()
+    @detail_route(methods=["post"])
     def assign(self, request, reference=None, **kwargs):
         """
         Assigns the case to a provider
@@ -359,7 +358,7 @@ class CaseViewSet(
 
         return DRFResponse(dict(form.errors), status=status.HTTP_400_BAD_REQUEST)
 
-    @action()
+    @detail_route(methods=["post"])
     def defer_assignment(self, request, **kwargs):
         obj = self.get_object()
         form = DeferAssignmentCaseForm(case=obj, data=request.DATA)
@@ -369,19 +368,19 @@ class CaseViewSet(
 
         return DRFResponse(dict(form.errors), status=status.HTTP_400_BAD_REQUEST)
 
-    @action()
+    @detail_route(methods=["post"])
     def decline_help(self, request, reference=None, **kwargs):
         response = self._form_action(request, DeclineHelpCaseForm)
         self.set_case_organisation(self.get_object())
         return response
 
-    @action()
+    @detail_route(methods=["post"])
     def suspend(self, request, reference=None, **kwargs):
         response = self._form_action(request, SuspendCaseForm)
         self.set_case_organisation(self.get_object())
         return response
 
-    @action()
+    @detail_route(methods=["post"])
     def assign_alternative_help(self, request, reference=None, **kwargs):
         response = self._form_action(request, AlternativeHelpForm)
         self.set_case_organisation(self.get_object())
@@ -390,7 +389,7 @@ class CaseViewSet(
     def get_log_notes(self, obj):
         return "Case created"
 
-    @link()
+    @detail_route(methods=["get"])
     def search_for_personal_details(self, request, reference=None, **kwargs):
         """
             You can only call this endpoint if the case doesn't have any
@@ -420,7 +419,7 @@ class CaseViewSet(
 
         return DRFResponse(data)
 
-    @action()
+    @detail_route(methods=["post"])
     def link_personal_details(self, request, reference=None, **kwargs):
         """
         * if not DATA.personal_details => return 400
@@ -457,19 +456,19 @@ class CaseViewSet(
         self.set_case_organisation(self.get_object(), save=True)
         return DRFResponse(status=status.HTTP_204_NO_CONTENT)
 
-    @action()
+    @detail_route(methods=["post"])
     def call_me_back(self, request, reference=None, **kwargs):
         response = self._form_action(request, CallMeBackForm)
         self.set_case_organisation(self.get_object(), save=True)
         return response
 
-    @action()
+    @detail_route(methods=["post"])
     def stop_call_me_back(self, request, reference=None, **kwargs):
         response = self._form_action(request, StopCallMeBackForm)
         self.set_case_organisation(self.get_object(), save=True)
         return response
 
-    @action()
+    @detail_route(methods=["post"])
     def start_call(self, request, reference=None, **kwargs):
         obj = self.get_object()
         event = event_registry.get_event("case")()
@@ -539,7 +538,7 @@ class PersonalDetailsViewSet(
 ):
     serializer_class = PersonalDetailsSerializer
 
-    @action()
+    @detail_route(methods=["post"])
     def set_diversity(self, request, reference=None, **kwargs):
         return self._form_action(request, DiversityForm)
 

--- a/cla_backend/apps/checker/views.py
+++ b/cla_backend/apps/checker/views.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets, mixins
-from rest_framework.decorators import action, link
+from rest_framework.decorators import detail_route
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response as DRFResponse
 
@@ -64,14 +64,14 @@ class EligibilityCheckViewSet(
     def get_request_user(self):
         return get_web_user()
 
-    @action()
+    @detail_route(methods=["post"])
     def is_eligible(self, request, *args, **kwargs):
         obj = self.get_object()
 
         response, ec, reasons = obj.get_eligibility_state()
         return DRFResponse({"is_eligible": response, "reasons": reasons})
 
-    @link()
+    @detail_route()
     def case_ref(self, request, *args, **kwargs):
         try:
             return DRFResponse({"reference": self.get_object().case.reference})

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from legalaid.permissions import IsManagerOrMePermission
 
 from rest_framework import mixins
-from rest_framework.decorators import action, link
+from rest_framework.decorators import detail_route
 from rest_framework.response import Response as DRFResponse
 from rest_framework.filters import SearchFilter
 
@@ -151,35 +151,35 @@ class CaseViewSet(CLAProviderPermissionViewSetMixin, FullCaseViewSet):
 
         return qs
 
-    @action()
+    @detail_route(methods=["post"])
     def reject(self, request, reference=None, **kwargs):
         """
         Rejects a case
         """
         return self._form_action(request, Form=RejectCaseForm)
 
-    @action()
+    @detail_route(methods=["post"])
     def accept(self, request, reference=None, **kwargs):
         """
         Accepts a case
         """
         return self._form_action(request, Form=AcceptCaseForm, no_body=False)
 
-    @action()
+    @detail_route(methods=["post"])
     def close(self, request, reference=None, **kwargs):
         """
         Closes a case
         """
         return self._form_action(request, Form=CloseCaseForm)
 
-    @action()
+    @detail_route(methods=["post"])
     def reopen(self, request, reference=None, **kwargs):
         """
         Reopens a case
         """
         return self._form_action(request, Form=ReopenCaseForm, no_body=False)
 
-    @link()
+    @detail_route()
     def legal_help_form_extract(self, *args, **kwargs):
         case = self.get_object()
         data = {
@@ -189,7 +189,7 @@ class CaseViewSet(CLAProviderPermissionViewSetMixin, FullCaseViewSet):
         }
         return DRFResponse(data)
 
-    @action()
+    @detail_route(methods=["post"])
     def split(self, request, reference=None, **kwargs):
         return self._form_action(request, Form=SplitCaseForm, form_kwargs={"request": request})
 

--- a/cla_backend/apps/complaints/views.py
+++ b/cla_backend/apps/complaints/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.utils.text import capfirst, force_text
 from rest_framework import viewsets, mixins, status, views as rest_views
-from rest_framework.decorators import action
+from rest_framework.decorators import detail_route
 from rest_framework.response import Response as DRFResponse
 
 from cla_eventlog import event_registry
@@ -152,7 +152,7 @@ class BaseComplaintViewSet(
                 code="OWNER_SET",
             )
 
-    @action()
+    @detail_route(methods=["post"])
     def add_event(self, request, pk):
         obj = self.get_object()
         form = ComplaintLogForm(complaint=obj, data=request.DATA)
@@ -162,7 +162,7 @@ class BaseComplaintViewSet(
 
         return DRFResponse(dict(form.errors), status=status.HTTP_400_BAD_REQUEST)
 
-    @action()
+    @detail_route(methods=["post"])
     def reopen(self, request, pk):
         obj = self.get_object()
         closed_logs = obj.logs.filter(code__in=["COMPLAINT_CLOSED", "COMPLAINT_VOID"])  # complaint void

--- a/cla_backend/apps/core/drf/decorators.py
+++ b/cla_backend/apps/core/drf/decorators.py
@@ -10,17 +10,3 @@ def detail_route(methods=["get"], **kwargs):
         return func
 
     return decorator
-
-
-def list_route(methods=["get"], **kwargs):
-    """
-    Used to mark a method on a ViewSet that should be routed for list requests.
-    """
-
-    def decorator(func):
-        func.bind_to_methods = methods
-        func.detail = False
-        func.kwargs = kwargs
-        return func
-
-    return decorator

--- a/cla_backend/apps/core/drf/router.py
+++ b/cla_backend/apps/core/drf/router.py
@@ -41,7 +41,7 @@ class NestedCLARouter(NestedSimpleRouter):
             initkwargs={"suffix": "Instance"},
         ),
         # Dynamically generated routes.
-        # Generated using @action or @link decorators on methods of the viewset.
+        # Generated using @detail_route or @list_route decorators on methods of the viewset.
         DynamicDetailRoute(url=r"^{prefix}/{methodname}/$", name="{basename}-{methodnamehyphen}", initkwargs={}),
     ]
 

--- a/cla_backend/apps/core/drf/router.py
+++ b/cla_backend/apps/core/drf/router.py
@@ -1,12 +1,10 @@
 from collections import namedtuple, OrderedDict
-
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
-
 from rest_framework import views
 from rest_framework.routers import BaseRouter, flatten, replace_methodname
 from rest_framework.urlpatterns import format_suffix_patterns
-from rest_framework.compat import url
+from django.conf.urls import url
 from rest_framework.reverse import reverse
 from rest_framework.response import Response
 

--- a/cla_backend/apps/core/drf/router.py
+++ b/cla_backend/apps/core/drf/router.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
@@ -9,11 +9,7 @@ from rest_framework.reverse import reverse
 from rest_framework.response import Response
 
 from rest_framework_nested.routers import NestedSimpleRouter as OriginalNestedSimpleRouter
-
-
-Route = namedtuple("Route", ["url", "mapping", "name", "initkwargs"])
-DynamicDetailRoute = namedtuple("DynamicDetailRoute", ["url", "name", "initkwargs"])
-DynamicListRoute = namedtuple("DynamicListRoute", ["url", "name", "initkwargs"])
+from rest_framework.routers import Route, DynamicDetailRoute, DynamicListRoute
 
 
 class NestedSimpleRouter(OriginalNestedSimpleRouter):
@@ -46,12 +42,7 @@ class NestedCLARouter(NestedSimpleRouter):
         ),
         # Dynamically generated routes.
         # Generated using @action or @link decorators on methods of the viewset.
-        Route(
-            url=r"^{prefix}/{methodname}/$",
-            mapping={"{httpmethod}": "{methodname}"},
-            name="{basename}-{methodnamehyphen}",
-            initkwargs={},
-        ),
+        DynamicDetailRoute(url=r"^{prefix}/{methodname}/$", name="{basename}-{methodnamehyphen}", initkwargs={}),
     ]
 
 

--- a/cla_backend/apps/core/routers.py
+++ b/cla_backend/apps/core/routers.py
@@ -16,7 +16,7 @@ class SingletonRouter(DefaultRouter):
         DELETE: deletes the object
 
      * prefix/<method>/
-        used for @action and @link methods (NOTE: not tested yet)
+        used for @detail_route and @list_route methods (NOTE: not tested yet)
     """
 
     routes = [
@@ -34,7 +34,7 @@ class SingletonRouter(DefaultRouter):
             initkwargs={"suffix": "Instance"},
         ),
         # Dynamically generated routes.
-        # Generated using @action or @link decorators on methods of the viewset
+        # Generated using @detail_route or @list_route decorators on methods of the viewset
         Route(
             url=r"^{prefix}/{methodname}{trailing_slash}$",
             mapping={"{httpmethod}": "{methodname}"},

--- a/cla_backend/apps/core/serializers.py
+++ b/cla_backend/apps/core/serializers.py
@@ -6,8 +6,17 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework_extensions.serializers import PartialUpdateSerializerMixin
 
 from core import fields
+from legalaid.fields import MoneyField, MoneyFieldDRF
 
 from cla_common.money_interval.serializers import MoneyIntervalModelSerializerMixin
+
+
+class MoneyFieldModelSerializerMixin(object):
+    def __init__(self, *args, **kwargs):
+        # add a model serializer which is used throughout this project
+        self.field_mapping = self.field_mapping.copy()  # ouch
+        self.field_mapping[MoneyField] = MoneyFieldDRF
+        super(MoneyFieldModelSerializerMixin, self).__init__(*args, **kwargs)
 
 
 class UUIDSerializer(serializers.SlugRelatedField):
@@ -28,7 +37,9 @@ class JSONField(serializers.WritableField):
         return obj
 
 
-class ClaModelSerializer(MoneyIntervalModelSerializerMixin, NullBooleanModelSerializerMixin, ModelSerializer):
+class ClaModelSerializer(
+    MoneyIntervalModelSerializerMixin, NullBooleanModelSerializerMixin, MoneyFieldModelSerializerMixin, ModelSerializer
+):
     pass
 
 

--- a/cla_backend/apps/diagnosis/views.py
+++ b/cla_backend/apps/diagnosis/views.py
@@ -1,7 +1,7 @@
 import json
 
 from rest_framework import mixins, viewsets, status
-from rest_framework.decorators import action
+from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
 from core.drf.mixins import NestedGenericModelMixin
@@ -16,11 +16,11 @@ class DiagnosisModelMixin(object):
     model = DiagnosisTraversal
     lookup_field = "reference"
 
-    @action()
+    @detail_route(methods=["post"])
     def move_down(self, request, **kwargs):
         return self.partial_update(request, **kwargs)
 
-    @action()
+    @detail_route(methods=["post"])
     def move_up(self, request, **kwargs):
         self.object = self.get_object()
         serializer = self.get_serializer(self.object)

--- a/cla_backend/apps/legalaid/fields.py
+++ b/cla_backend/apps/legalaid/fields.py
@@ -1,6 +1,17 @@
 # coding=utf-8
 from django.core import validators
 from django.db import models
+from rest_framework.serializers import WritableField
+
+
+class MoneyFieldDRF(WritableField):
+    def __init__(self, max_value=9999999999, min_value=0, *args, **kwargs):
+        kwargs.setdefault("validators", [])
+        if max_value is not None:
+            kwargs["validators"].append(validators.MaxValueValidator(max_value))
+        if min_value is not None:
+            kwargs["validators"].append(validators.MinValueValidator(min_value))
+        super(MoneyFieldDRF, self).__init__(*args, **kwargs)
 
 
 class MoneyField(models.BigIntegerField):

--- a/cla_backend/apps/legalaid/views.py
+++ b/cla_backend/apps/legalaid/views.py
@@ -6,7 +6,7 @@ from django.db import connection, transaction, IntegrityError
 from django.core.paginator import Paginator
 from django.utils.crypto import get_random_string
 from rest_framework import viewsets, mixins, status
-from rest_framework.decorators import action, link
+from rest_framework.decorators import detail_route
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response as DRFResponse
 from rest_framework.filters import OrderingFilter, DjangoFilterBackend
@@ -122,7 +122,7 @@ class BaseUserViewSet(
         self.check_object_permissions(self.request, obj)
         return obj
 
-    @action()
+    @detail_route(methods=["post"])
     def password_reset(self, request, *args, **kwargs):
         user = self.get_object().user
         try:
@@ -132,7 +132,7 @@ class BaseUserViewSet(
         except PermissionDenied as pd:
             return DRFResponse(pd.detail, status=status.HTTP_403_FORBIDDEN)
 
-    @action()
+    @detail_route(methods=["post"])
     def reset_lockout(self, request, *args, **kwargs):
         logged_in_user_model = self.get_logged_in_user_model()
         if not logged_in_user_model.is_manager:
@@ -165,12 +165,12 @@ class BaseEligibilityCheckViewSet(JsonPatchViewSetMixin, viewsets.GenericViewSet
     model = EligibilityCheck
     lookup_field = "reference"
 
-    @link()
+    @detail_route()
     def validate(self, request, **kwargs):
         obj = self.get_object()
         return DRFResponse(obj.validate())
 
-    @action()
+    @detail_route(methods=["post"])
     def is_eligible(self, request, *args, **kwargs):
         obj = self.get_object()
 

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -106,7 +106,7 @@ django==1.7.11
     #   django-uuidfield
     #   jsonfield
     #   model-mommy
-djangorestframework==2.3.14
+djangorestframework==2.4.8
     # via
     #   -r requirements/source/requirements-base.in
     #   drf-extensions

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -119,7 +119,7 @@ docopt==0.6.2
     #   django-docopt-command
 drf-extensions==0.2.5
     # via -r requirements/source/requirements-base.in
-drf-nested-routers==0.1.3
+drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in
 enum34==1.1.10
     # via cryptography

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -82,7 +82,7 @@ django==1.7.11
     #   django-rest-swagger
     #   django-uuidfield
     #   jsonfield
-djangorestframework==2.3.14
+djangorestframework==2.4.8
     # via
     #   -r requirements/source/requirements-base.in
     #   django-rest-swagger

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -96,7 +96,7 @@ docutils==0.17.1
     # via sphinx
 drf-extensions==0.2.5
     # via -r requirements/source/requirements-base.in
-drf-nested-routers==0.1.3
+drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -86,7 +86,7 @@ docopt==0.6.2
     # via django-docopt-command
 drf-extensions==0.2.5
     # via -r requirements/source/requirements-base.in
-drf-nested-routers==0.1.3
+drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -75,7 +75,7 @@ django==1.7.11
     #   django-pagedown
     #   django-uuidfield
     #   jsonfield
-djangorestframework==2.3.14
+djangorestframework==2.4.8
     # via
     #   -r requirements/source/requirements-base.in
     #   drf-extensions

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -105,7 +105,7 @@ docopt==0.6.2
     #   django-docopt-command
 drf-extensions==0.2.5
     # via -r requirements/source/requirements-base.in
-drf-nested-routers==0.1.3
+drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in
 enum34==1.1.10
     # via cryptography

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -92,7 +92,7 @@ django==1.7.11
     #   django-uuidfield
     #   jsonfield
     #   model-mommy
-djangorestframework==2.3.14
+djangorestframework==2.4.8
     # via
     #   -r requirements/source/requirements-base.in
     #   drf-extensions

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -9,7 +9,7 @@ django-model-utils==2.2
 psycopg2==2.7.5
 sentry-sdk==0.19.3
 
-djangorestframework==2.3.14
+djangorestframework==2.4.8
 jsonfield==0.9.22
 django-uuidfield==0.5.0
 drf-nested-routers==0.1.3

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -12,7 +12,7 @@ sentry-sdk==0.19.3
 djangorestframework==2.4.8
 jsonfield==0.9.22
 django-uuidfield==0.5.0
-drf-nested-routers==0.1.3
+drf-nested-routers==0.9.0
 https://github.com/timmyomahony/django-pagedown/archive/refs/tags/v1.1.tar.gz
 
 Markdown==2.5.2


### PR DESCRIPTION
## What does this pull request do?

- Update Django Rest Framework(DRF) to 2.4.8
- Update DRF Nested Routes package to 0.9.0
- Remove usage of deprecated `@action` and `@link` decorators in favour of recommended `@detail_route`

## Any other changes that would benefit highlighting?
[2.4 Announcement ](http://www.tomchristie.com/rest-framework-2-docs/topics/2.4-announcement)
[2.4 release notes](https://github.com/encode/django-rest-framework/blob/version-2.4.x/docs/topics/release-notes.md#240)

The update to DRF Nested Routes was required because the previous version [0.1.3 stopped working with DRF 2.4](https://github.com/alanjds/drf-nested-routers/issues/24)

rest_framework.compat no longer exists in DRF 2.4  - [rest_framework.compat.url was imported from django.conf.urls.url](https://github.com/encode/django-rest-framework/blob/2.3.14/rest_framework/compat.py#L22), so we directly import from there now

Removed core.drf.routers.Route, core.drf.routers. DynamicDetailRoute and core.drf.routers.DynamicListRoute - These are now available as part of the DRF in `from rest_framework.routers import Route, DynamicDetailRoute, DynamicListRoute`

Used DynamicDetailRoute instead of Route for dynamically generated links so that [at]action and [at]link routes are added as routes

There was a [change in the way DRF does field_mapping in 2.4](https://github.com/encode/django-rest-framework/pull/1818) which resulted in the `legalaid.fields.MoneyField` being mapped to a `rest_framework.fields.IntegerField` and the validation for min and max values not working. To work around this issue we introduced a new `legalaid.fields.MoneyFieldDRF` field that is added to the field_mapping so that MoneyField min and max validators run.


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
