### PR TITLE
LGA-1771 - update django to version 1.7.11

### DIFF
--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -95,7 +95,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.10
+django==1.7.11
     # via
     #   -r requirements/source/requirements-base.in
     #   django-debug-toolbar

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -72,7 +72,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.10
+django==1.7.11
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -66,7 +66,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.10
+django==1.7.11
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -82,7 +82,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.10
+django==1.7.11
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -2,7 +2,7 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-Django==1.7.10
+Django==1.7.11
 
 django-model-utils==2.2
 


### PR DESCRIPTION
## What does this pull request do?

Upgrade requirements to use django 1.7.11 - this is a minor upgrade and should not need any other changes.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
