### PR TITLE
LGA-2291: Update migration validation script

### DIFF
--- a/bin/database-migration/Dockerfile
+++ b/bin/database-migration/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add \
 RUN adduser -D app && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime
 
-RUN pip install psycopg2==2.7.5 --no-cache-dir
+RUN pip install psycopg2==2.7.5 pgdatadiff==0.2.1 --no-cache-dir
 
 USER 1000
 WORKDIR /home/app

--- a/bin/database-migration/migration_validation.py
+++ b/bin/database-migration/migration_validation.py
@@ -3,6 +3,8 @@ import sys
 import os
 import psycopg2
 
+from pgdatadiff.pgdatadiff import DBDiff
+
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -91,6 +93,29 @@ def get_last_row(cursor, table_name):
     return cursor.fetchone()
 
 
+def check_table_data(error_list):
+    connection_string_template = "postgres://{}:{}@{}/{}"
+
+    source_db = connection_string_template.format(
+        os.environ["SOURCE_DB_USER"],
+        os.environ["SOURCE_DB_PASSWORD"],
+        os.environ["SOURCE_DB_HOST"],
+        os.environ["SOURCE_DB_NAME"]
+    )
+    target_db = connection_string_template.format(
+        os.environ["TARGET_DB_USER"],
+        os.environ["TARGET_DB_PASSWORD"],
+        os.environ["TARGET_DB_HOST"],
+        os.environ["TARGET_DB_NAME"]
+    )
+
+    pg_diff_tool = DBDiff(source_db, target_db, chunk_size=100000)
+    if pg_diff_tool.diff_all_table_data():
+        error_list.append("Differences found in the migrated data by the pgDataDiff tool.")
+
+    return error_list
+
+
 if __name__ == "__main__":
     target_cursor = get_target_db_cursor()
     source_cursor = get_source_db_cursor()
@@ -131,6 +156,8 @@ if __name__ == "__main__":
                         sequence[0], source_sequence_value, target_sequence_value
                     )
                 )
+
+    errors = check_table_data(errors)
 
     if errors:
         eprint("\n".join(errors))

--- a/bin/database-migration/migration_validation.py
+++ b/bin/database-migration/migration_validation.py
@@ -93,7 +93,8 @@ def get_last_row(cursor, table_name):
     return cursor.fetchone()
 
 
-def check_table_data(error_list):
+def check_table_data():
+    errors = []
     connection_string_template = "postgres://{}:{}@{}/{}"
 
     source_db = connection_string_template.format(
@@ -111,9 +112,9 @@ def check_table_data(error_list):
 
     pg_diff_tool = DBDiff(source_db, target_db, chunk_size=100000)
     if pg_diff_tool.diff_all_table_data():
-        error_list.append("Differences found in the migrated data by the pgDataDiff tool.")
+        errors.append("Differences found in the migrated data by the pgDataDiff tool.")
 
-    return error_list
+    return errors
 
 
 if __name__ == "__main__":
@@ -157,7 +158,7 @@ if __name__ == "__main__":
                     )
                 )
 
-    errors = check_table_data(errors)
+    errors += check_table_data()
 
     if errors:
         eprint("\n".join(errors))


### PR DESCRIPTION
## What does this pull request do?

- [x] `pgDataDiff` installation added to the database migration dockerfile.
- [x]  Migration validation script updated to compare the database contents using the `pgDataDiff` tool.

## Any other changes that would benefit highlighting?

- `pgDataDiff` requests `md5` hashes for "chunks" of data and using this to do a fast comparison. At the moment the `chunk_size` has been set to 100k. This means that the comparison is fast but we won't be able to pinpoint the exact row where the difference exists.

