### PR TITLE
LGA-2156: Clean up postgres 10 usage in UAT

### DIFF
--- a/helm_deploy/cla-backend/values-uat-static.yaml
+++ b/helm_deploy/cla-backend/values-uat-static.yaml
@@ -19,27 +19,6 @@ ingress:
 envVars:
   DEBUG:
     value: "False"
-  DB_HOST:
-    secret:
-      name: database-11
-      key: host
-  DB_PORT:
-    secret:
-      name: database-11
-      key: port
-      optional: true
-  DB_NAME:
-    secret:
-      name: database-11
-      key: name
-  DB_USER:
-    secret:
-      name: database-11
-      key: user
-  DB_PASSWORD:
-    secret:
-      name: database-11
-      key: password
   REPLICA_DB_HOST:
     secret:
       optional: true


### PR DESCRIPTION
## What does this pull request do?

- [x] Removed unneeded references to database secrets from the static UAT values files so they are no inherited from the base values file after the database upgrade to postgres 11.

## Any other changes that would benefit highlighting?


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
