### PR TITLE
LGA-2157: Staging references to database-11 secret removed.

### DIFF
--- a/helm_deploy/cla-backend/values-staging.yaml
+++ b/helm_deploy/cla-backend/values-staging.yaml
@@ -19,31 +19,6 @@ ingress:
 envVars:
   DEBUG:
     value: "False"
-  DB_HOST:
-    secret:
-      name: database-11
-      key: host
-  DB_PORT:
-    secret:
-      name: database-11
-      key: port
-      optional: true
-  DB_NAME:
-    secret:
-      name: database-11
-      key: name
-  DB_USER:
-    secret:
-      name: database-11
-      key: user
-  DB_PASSWORD:
-    secret:
-      name: database-11
-      key: password
-  REPLICA_DB_HOST:
-    secret:
-      name: database-11
-      key: replica_host
   LOAD_SEED_DATA:
     value: "True"
   LOAD_TEST_DATA:


### PR DESCRIPTION
## What does this pull request do?

- [x] Database-11 secrets removed from the staging values file so the base values file will be used instead.

## Any other changes that would benefit highlighting?

N/A

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
