### PR TITLE
LGA-2158: Training references to database-11 secret removed.

### DIFF
--- a/helm_deploy/cla-backend/values-training.yaml
+++ b/helm_deploy/cla-backend/values-training.yaml
@@ -1,4 +1,3 @@
-
 # Default values for cla-backend in a dev environment.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -20,27 +19,6 @@ ingress:
 envVars:
   DEBUG:
     value: "False"
-  DB_HOST:
-    secret:
-      name: database-11
-      key: host
-  DB_PORT:
-    secret:
-      name: database-11
-      key: port
-      optional: true
-  DB_NAME:
-    secret:
-      name: database-11
-      key: name
-  DB_USER:
-    secret:
-      name: database-11
-      key: user
-  DB_PASSWORD:
-    secret:
-      name: database-11
-      key: password
   LOAD_SEED_DATA:
     value: "True"
   LOAD_END_TO_END_FIXTURES:


### PR DESCRIPTION
## What does this pull request do?

- [x] References to the database-11 secrets removed from the training values file so that they are picked up from the base values file instead.

## Any other changes that would benefit highlighting?



## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
