### PR TITLE
Feature/lga 2228 addition outcome codes

### DIFF
--- a/cla_backend/apps/legalaid/events.py
+++ b/cla_backend/apps/legalaid/events.py
@@ -223,6 +223,42 @@ class SuspendCaseEvent(BaseEvent):
             "order": 110,
             "set_requires_action_by": None_if_owned_by_op_or_op_manager,
         },
+        "REFDPA": {
+            "type": LOG_TYPES.OUTCOME,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [LOG_ROLES.OPERATOR],
+            "description": "Refused DPA",
+            "stops_timer": True,
+            "order": 120,
+            "set_requires_action_by": None_if_owned_by_op_or_op_manager,
+        },
+        "RELBD": {
+            "type": LOG_TYPES.OUTCOME,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [LOG_ROLES.OPERATOR],
+            "description": u"Don't transfer / COI identifier",
+            "stops_timer": True,
+            "order": 130,
+            "set_requires_action_by": None_if_owned_by_op_or_op_manager,
+        },
+        "RSTR": {
+            "type": LOG_TYPES.OUTCOME,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [LOG_ROLES.OPERATOR],
+            "description": "Restricted from service",
+            "stops_timer": True,
+            "order": 140,
+            "set_requires_action_by": None_if_owned_by_op_or_op_manager,
+        },
+        "NOLA": {
+            "type": LOG_TYPES.OUTCOME,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [LOG_ROLES.OPERATOR],
+            "description": "No Legal Aid",
+            "stops_timer": True,
+            "order": 150,
+            "set_requires_action_by": None_if_owned_by_op_or_op_manager,
+        },
     }
 
 

--- a/cla_backend/apps/legalaid/tests/test_events.py
+++ b/cla_backend/apps/legalaid/tests/test_events.py
@@ -111,7 +111,23 @@ class CaseEventAvoidDuplicatesTestCase(EventTestCaseMixin, TestCase):
 class SuspendCaseEventTestCase(EventTestCaseMixin, TestCase):
     EVENT_KEY = "suspend_case"
 
-    CODES = ["INSUF", "ABND", "TERM", "IRCB", "COPE", "DUPL", "RDSP", "SAME", "WROF", "MRNB", "MRCC"]
+    CODES = [
+        "INSUF",
+        "ABND",
+        "TERM",
+        "IRCB",
+        "COPE",
+        "DUPL",
+        "RDSP",
+        "SAME",
+        "WROF",
+        "MRNB",
+        "MRCC",
+        "REFDPA",
+        "RELBD",
+        "RSTR",
+        "NOLA",
+    ]
 
     def test_INSUF(self):
         self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
@@ -164,4 +180,24 @@ class SuspendCaseEventTestCase(EventTestCaseMixin, TestCase):
     def test_MRCC(self):
         self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
             self.CODES, code="MRCC", expected_level=LOG_LEVELS.HIGH
+        )
+
+    def test_REFDPA(self):
+        self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
+            self.CODES, code="REFDPA", expected_level=LOG_LEVELS.HIGH
+        )
+
+    def test_RELBD(self):
+        self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
+            self.CODES, code="RELBD", expected_level=LOG_LEVELS.HIGH
+        )
+
+    def test_RSTR(self):
+        self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
+            self.CODES, code="RSTR", expected_level=LOG_LEVELS.HIGH
+        )
+
+    def test_NOLA(self):
+        self._test_process_with_expicit_code_and_requires_action_None_if_op_or_op_manager(
+            self.CODES, code="NOLA", expected_level=LOG_LEVELS.HIGH
         )


### PR DESCRIPTION
## What does this pull request do?

Added new outcome codes REFDPA, RELBD, RSTR, NOLA for Operator on Suspend Case modal options.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- New outcome codes added
- Unit test updated with new outcome codes to check.
