### PR TITLE
LGA-2122: Set session timeout for fox admin.

### DIFF
--- a/cla_backend/apps/cla_auth/tests/test_views.py
+++ b/cla_backend/apps/cla_auth/tests/test_views.py
@@ -1,12 +1,15 @@
 import datetime
 
 from django.contrib.auth.models import User
+from django.contrib.sessions.models import Session
 from django.core.urlresolvers import reverse
 from django.core.cache import cache
 from django.test import TestCase
 from django.conf import settings
 from django.utils import timezone
+
 import mock
+import pytz
 
 from oauth2_provider.models import Application
 from core.tests.mommy_utils import make_recipe
@@ -203,6 +206,29 @@ class LoginTestCase(TestCase):
         data = self.get_provider_data(username="user-does-not-exist")
 
         self.assert_unauthorised_response(data, self.INVALID_CLIENT_ERROR)
+
+    def test_session_expiry_date_is_set(self):
+        # Clear all active sessions.
+        Session.objects.all().delete()
+
+        # Login and check a session is created.
+        self.client.login(username=self.op_user, password=self.op_password)
+        login_time = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        sessions = Session.objects.all()
+        login_session = sessions[0]
+        self.assertEqual(sessions.count(), 1)
+
+        # Calculate time until session expiry and compare to settings value.
+        time_to_session_expiry = login_session.expire_date - login_time
+        self.assertGreaterEqual(settings.SESSION_COOKIE_AGE, time_to_session_expiry.seconds)
+
+        # Trigger a session update by performing a request.
+        self.client.get("/admin/auth/user")
+        updated_session = Session.objects.get(pk=login_session.pk)
+        self.assertGreaterEqual(updated_session.expire_date, login_session.expire_date)
+       
+
+
 
     def assert_unauthorised_response(self, data, expected_error):
         response = self.client.post(self.url, data=data)

--- a/cla_backend/apps/cla_auth/tests/test_views.py
+++ b/cla_backend/apps/cla_auth/tests/test_views.py
@@ -226,9 +226,6 @@ class LoginTestCase(TestCase):
         self.client.get("/admin/auth/user")
         updated_session = Session.objects.get(pk=login_session.pk)
         self.assertGreaterEqual(updated_session.expire_date, login_session.expire_date)
-       
-
-
 
     def assert_unauthorised_response(self, data, expected_error):
         response = self.client.post(self.url, data=data)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -441,8 +441,7 @@ CacheAdapter.set_adapter_factory(bank_holidays_cache_adapter_factory)
 MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False") == "True"
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-# Session timeout in s (30mins).
-SESSION_COOKIE_AGE = 1800
+SESSION_COOKIE_AGE = 5
 
 # .local.py overrides all the common settings.
 try:

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -441,7 +441,8 @@ CacheAdapter.set_adapter_factory(bank_holidays_cache_adapter_factory)
 MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False") == "True"
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-SESSION_COOKIE_AGE = 5
+# Set the session cookie timeout to 30mins.
+SESSION_COOKIE_AGE = 1800
 # Extends the session timeout with each request.
 SESSION_SAVE_EVERY_REQUEST = True
 

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -442,6 +442,8 @@ MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False") == "True"
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 5
+# Extends the session timeout with each request.
+SESSION_SAVE_EVERY_REQUEST = True
 
 # .local.py overrides all the common settings.
 try:

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -440,6 +440,10 @@ CacheAdapter.set_adapter_factory(bank_holidays_cache_adapter_factory)
 
 MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False") == "True"
 
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+# Session timeout in s (30mins).
+SESSION_COOKIE_AGE = 1800
+
 # .local.py overrides all the common settings.
 try:
     from .local import *


### PR DESCRIPTION
## What does this pull request do?

- [x] Added a session timeout of 30mins to fox admin 
- [x] Session timeout is request with every request so the timeout only applies during inactivity.
- [x] Set the fox admin session to reset when the browser is closed.

## Additional Notes:

There was concern from users about how this would effect report generation which is sometimes longer than 30mins. I have checked the code and it looks like the report generation is run asynchronously by Celery so the session timeout will not effect the generation itself however the users will stilled be logged out if idle for 30mins. The reports will appear in the list to download when users log back in.






