### PR TITLE
Feature/lga 2376 update disregards questions

### DIFF
--- a/cla_backend/apps/call_centre/tests/api/test_eligibility_check_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_eligibility_check_api.py
@@ -80,3 +80,28 @@ class EligibilityCheckTestCase(CLAOperatorAuthBaseApiTestMixin, NestedEligibilit
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"warnings": {}})
+
+    def test_check_validate_disregards(self):
+        """
+               Make sure that the disregards does not allow fields that have not been created
+               """
+        disregard_defined = {"disregards": {"criminal_injuries": "true"}}
+
+        disregard_not_defined = {"disregards": {"no_disregard_defined": "true"}}
+
+        response = self.client.patch(
+            self.detail_url, data=disregard_defined, format="json", HTTP_AUTHORIZATION=self.get_http_authorization()
+        )
+        # if you pass in  an expected disregards field then it should return the same data
+        expected_good = {"criminal_injuries": True}
+        self.assertEqual(response.data["disregards"], expected_good)
+
+        # if you pass in something other than an expected disregards field then it should fail
+        response = self.client.patch(
+            self.detail_url,
+            data=disregard_not_defined,
+            format="json",
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+        expected_bad = {"disregards": [u"Fields no_disregard_defined not recognised"]}
+        self.assertEqual(response.data, expected_bad)

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -35,7 +35,7 @@ cfgv==2.0.1
     # via pre-commit
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.19.tar.gz
     # via -r requirements/source/requirements-base.in
 click==7.1.2
     # via pip-tools

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -35,7 +35,7 @@ cfgv==2.0.1
     # via pre-commit
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.16.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
     # via -r requirements/source/requirements-base.in
 click==7.1.2
     # via pip-tools

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -32,7 +32,7 @@ certifi==2021.10.8
     #   sentry-sdk
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.19.tar.gz
     # via -r requirements/source/requirements-base.in
 configparser==4.0.2
     # via importlib-metadata

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -32,7 +32,7 @@ certifi==2021.10.8
     #   sentry-sdk
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.16.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
     # via -r requirements/source/requirements-base.in
 configparser==4.0.2
     # via importlib-metadata

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -28,7 +28,7 @@ certifi==2021.10.8
     #   sentry-sdk
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.19.tar.gz
     # via -r requirements/source/requirements-base.in
 configparser==4.0.2
     # via importlib-metadata

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -28,7 +28,7 @@ certifi==2021.10.8
     #   sentry-sdk
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.16.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
     # via -r requirements/source/requirements-base.in
 configparser==4.0.2
     # via importlib-metadata

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -31,7 +31,7 @@ cffi==1.15.1
     # via cryptography
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.16.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
     # via -r requirements/source/requirements-base.in
 colorama==0.4.6
     # via crayons

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -31,7 +31,7 @@ cffi==1.15.1
     # via cryptography
 chardet==4.0.0
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.19.tar.gz
     # via -r requirements/source/requirements-base.in
 colorama==0.4.6
     # via crayons

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -21,7 +21,7 @@ bleach==3.3.0
 django-oauth-toolkit==0.11.0
 django-braces==1.8.1
 
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.16.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -21,7 +21,7 @@ bleach==3.3.0
 django-oauth-toolkit==0.11.0
 django-braces==1.8.1
 
-https://github.com/ministryofjustice/cla_common/archive/refs/heads/feature/LGA-2376-update-disregards.zip
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.19.tar.gz
 django-extended-choices==0.3.0
 django-filter==0.9.2
 jsonpatch==1.9


### PR DESCRIPTION
## What does this pull request do?

When disregards questions where updated in cla_frontend, the new questions also needed to be included in cla_common so that cla_backend would validate the questions correctly and allow the eligibility_check to pass.
https://github.com/ministryofjustice/cla_frontend/pull/891

This meant updating the version of cla_common used by cla_backend.

Have also created a unit test that makes sure the validation works if try and pass in a question that is not allowed.


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
