### PR TITLE
LGA-2313 Enabling Modsecurity for cla_backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,10 +295,6 @@ workflows:
           type: approval
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
 
       - deploy:
           name: staging_deploy_live

--- a/helm_deploy/cla-backend/templates/ingress_v122.yaml
+++ b/helm_deploy/cla-backend/templates/ingress_v122.yaml
@@ -21,8 +21,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
 spec:
   ingressClassName: "modsec"
   tls:

--- a/helm_deploy/cla-backend/templates/ingress_v122.yaml
+++ b/helm_deploy/cla-backend/templates/ingress_v122.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleRemoveById 200001
+      SecRuleEngine On
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
## What does this pull request do?

Enabling ModSecurity and taking it out of detection mode. 

## Any other changes that would benefit highlighting?

Process is to push to staging and monitor activity there. If happy we can push into production and again monitor via Kibana logs. 

## Checklist

[LGA-2313](https://dsdmoj.atlassian.net/browse/LGA-2313)


[LGA-2313]: https://dsdmoj.atlassian.net/browse/LGA-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ