### PR TITLE
LGA-2313 Enabling Modsecurity in detection mode for cla_backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,10 +295,6 @@ workflows:
           type: approval
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
 
       - deploy:
           name: staging_deploy_live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,10 @@ workflows:
           type: approval
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
 
       - deploy:
           name: staging_deploy_live

--- a/helm_deploy/cla-backend/templates/ingress_v122.yaml
+++ b/helm_deploy/cla-backend/templates/ingress_v122.yaml
@@ -21,8 +21,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleRemoveById 200001
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
Removing snippet and putting ModSecurity into dection mode only.

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

[Kibana](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/goto/ae8948f736fbcbf6346bd118dccbf8a3)

## Checklist

[LGA-2313](https://dsdmoj.atlassian.net/browse/LGA-2313)


[LGA-2313]: https://dsdmoj.atlassian.net/browse/LGA-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ