### PR TITLE
LGA-1777 django upgrade 1 8 19

### DIFF
--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -296,8 +296,7 @@ class SuggestProviderTestCase(BaseCaseTestCase):
     #     #  ...]}
 
     @classmethod
-    def setUpClass(cls):
-        super(SuggestProviderTestCase, cls).setUpClass()
+    def setUpTestData(cls):
         cls.suggested_cat_providers = None
         cls.suggested_category = None
         cls.cat_eligibility_check = None

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -297,6 +297,7 @@ class SuggestProviderTestCase(BaseCaseTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(SuggestProviderTestCase, cls).setUpClass()
         cls.suggested_cat_providers = None
         cls.suggested_category = None
         cls.cat_eligibility_check = None

--- a/cla_backend/apps/cla_provider/helpers.py
+++ b/cla_backend/apps/cla_provider/helpers.py
@@ -6,7 +6,6 @@ from itertools import groupby
 from operator import itemgetter
 
 from django.http import HttpResponse
-from django.template import Context
 from django.template.loader import get_template
 from django.utils import timezone
 from django.conf import settings
@@ -261,6 +260,6 @@ class ProviderExtractFormatter(object):
     def format(self):
         ctx = {"case": self.case}
         template = get_template("provider/case.xml")
-        resp = HttpResponse(template.render(Context(ctx)), content_type="text/xml")
+        resp = HttpResponse(template.render(ctx), content_type="text/xml")
         resp["Access-Control-Allow-Origin"] = "*"
         return resp

--- a/cla_backend/apps/complaints/models.py
+++ b/cla_backend/apps/complaints/models.py
@@ -24,7 +24,6 @@ class ComplaintManager(models.Manager):
                 "eod__case__eligibility_check",
                 "eod__case__eligibility_check__category",
                 "category",
-                "logs",
             )
             .prefetch_related("eod__categories")
         )

--- a/cla_backend/apps/diagnosis/graph.py
+++ b/cla_backend/apps/diagnosis/graph.py
@@ -4,7 +4,7 @@ from os.path import join, abspath, dirname
 import re
 
 from django.conf import settings
-from django.template.loader import get_template_from_string, Context
+from django.template import engines
 from django.utils import translation
 from django.utils.encoding import force_text
 from django.utils.functional import lazy, SimpleLazyObject
@@ -140,11 +140,11 @@ class GraphImporter(object):
     @staticmethod
     def _get_text(a_node, is_templated, translate=True):
         if is_templated and a_node.text and "{%" in a_node.text:
-            tpl = get_template_from_string(u"{%% load i18n %%}%s" % a_node.text)
+            tpl = engines["django"].from_string(u"{%% load i18n %%}%s" % a_node.text)
             if translate:
-                return lazy(lambda: tpl.render(Context()), text_type)()
+                return lazy(lambda: tpl.render({}), text_type)()
             with translation.override("en"):
-                return tpl.render(Context())
+                return tpl.render({})
         return a_node.text
 
     @staticmethod

--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -1,22 +1,25 @@
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.utils import timezone
-
+from argparse import SUPPRESS
 from legalaid.models import Case
 
 
 class Command(BaseCommand):
     help = "Recalculate case.assigned_out_of_hours since a given date"
-    unchanged = []
-    change_to_true = []
-    change_to_false = []
+
+    def __init__(self, *args, **kwargs):
+        self.unchanged = []
+        self.change_to_true = []
+        self.change_to_false = []
+        super(Command, self).__init__(*args, **kwargs)
 
     def add_arguments(self, parser):
-        parser.add_argument("date_string", nargs="?")
-        parser.add_argument("commit", nargs="?")
+        parser.add_argument("date_string", nargs="?", default=SUPPRESS)
+        parser.add_argument("commit", nargs="?", default=SUPPRESS)
 
     def handle(self, *args, **options):
-        if options["date_string"] is None:
+        if "date_string" not in options:
             raise CommandError("A start date is required")
         try:
             date_string = options["date_string"]
@@ -38,8 +41,8 @@ class Command(BaseCommand):
         self.stdout.write(u"{count} cases will be changed to `False`.".format(count=len(self.change_to_false)))
 
         try:
-            commit = args[1] == "commit"
-        except IndexError:
+            commit = options["commit"] == "commit"
+        except KeyError:
             commit = False
 
         if commit:

--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -7,20 +7,20 @@ from legalaid.models import Case
 
 class Command(BaseCommand):
     help = "Recalculate case.assigned_out_of_hours since a given date"
+    unchanged = []
+    change_to_true = []
+    change_to_false = []
 
-    def __init__(self, *args, **kwargs):
-        self.unchanged = []
-        self.change_to_true = []
-        self.change_to_false = []
-        super(Command, self).__init__(*args, **kwargs)
+    def add_arguments(self, parser):
+        parser.add_argument("args")
 
     def handle(self, *args, **options):
         try:
-            date_string = args[0]
+            args[0]
         except IndexError:
             raise CommandError("A start date is required")
-
         try:
+            date_string = "".join(args)
             dt = timezone.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             raise CommandError("The start date should be a valid datetime in yyyy-mm-dd format")

--- a/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
+++ b/cla_backend/apps/legalaid/management/commands/recalculate_assigned_out_of_hours.py
@@ -12,15 +12,14 @@ class Command(BaseCommand):
     change_to_false = []
 
     def add_arguments(self, parser):
-        parser.add_argument("args")
+        parser.add_argument("date_string", nargs="?")
+        parser.add_argument("commit", nargs="?")
 
     def handle(self, *args, **options):
-        try:
-            args[0]
-        except IndexError:
+        if options["date_string"] is None:
             raise CommandError("A start date is required")
         try:
-            date_string = "".join(args)
+            date_string = options["date_string"]
             dt = timezone.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             raise CommandError("The start date should be a valid datetime in yyyy-mm-dd format")

--- a/cla_backend/apps/legalaid/tests/test_timezones.py
+++ b/cla_backend/apps/legalaid/tests/test_timezones.py
@@ -57,7 +57,7 @@ class TestBSTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, TestCase):
 class TestCommandDateArgument(TestCase):
     def test_requires_date(self):
         with self.assertRaisesMessage(CommandError, "A start date is required"):
-            call_command("recalculate_assigned_out_of_hours")
+            call_command("recalculate_assigned_out_of_hours", "")
 
     def test_date_must_be_a_date_string(self):
         with self.assertRaisesMessage(CommandError, "The start date should be a valid datetime in yyyy-mm-dd format"):
@@ -78,7 +78,7 @@ class TestRecalculateAssignedOutOfHours(TestCase):
     def setUp(self, *args, **kwargs):
         self.provider = make_recipe("cla_provider.provider")
         self.category = make_recipe("legalaid.category", code="education")
-        super(TestRecalculateAssignedOutOfHours, self).setUp()
+        # super(TestRecalculateAssignedOutOfHours, self).setUp()
 
     def create(self, year, month, day, hour, minute, out_of_hours):
         assigned_at = timezone.datetime(year, month, day, hour, minute)

--- a/cla_backend/apps/legalaid/tests/test_timezones.py
+++ b/cla_backend/apps/legalaid/tests/test_timezones.py
@@ -57,7 +57,7 @@ class TestBSTAssignedOutOfHoursTestCase(BaseAssignedOutOfHours, TestCase):
 class TestCommandDateArgument(TestCase):
     def test_requires_date(self):
         with self.assertRaisesMessage(CommandError, "A start date is required"):
-            call_command("recalculate_assigned_out_of_hours", "")
+            call_command("recalculate_assigned_out_of_hours")
 
     def test_date_must_be_a_date_string(self):
         with self.assertRaisesMessage(CommandError, "The start date should be a valid datetime in yyyy-mm-dd format"):
@@ -78,7 +78,7 @@ class TestRecalculateAssignedOutOfHours(TestCase):
     def setUp(self, *args, **kwargs):
         self.provider = make_recipe("cla_provider.provider")
         self.category = make_recipe("legalaid.category", code="education")
-        # super(TestRecalculateAssignedOutOfHours, self).setUp()
+        super(TestRecalculateAssignedOutOfHours, self).setUp()
 
     def create(self, year, month, day, hour, minute, out_of_hours):
         assigned_at = timezone.datetime(year, month, day, hour, minute)

--- a/cla_backend/apps/legalaid/tests/views/mixins/case_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/case_api.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import reverse
-from django.conf import settings
 from django.db import connection
+from django.test import override_settings
 
 from rest_framework import status
 
@@ -272,113 +272,107 @@ class BaseSearchCaseAPIMixin(BaseFullCaseAPIMixin):
 
 
 class BaseUpdateCaseTestCase(BaseFullCaseAPIMixin):
+    @override_settings(DEBUG=True)
     def test_update_doesnt_set_readonly_values(self):
-        _old_settings = settings.DEBUG
-        try:
-            settings.DEBUG = True
+        pd = make_recipe("legalaid.personal_details")
+        eligibility_check = make_recipe("legalaid.eligibility_check")
+        thirdparty_details = make_recipe("legalaid.thirdparty_details")
+        adaptation_details = make_recipe("legalaid.adaptation_details")
+        diagnosis = make_recipe("diagnosis.diagnosis")
+        provider = make_recipe("cla_provider.provider")
 
-            pd = make_recipe("legalaid.personal_details")
-            eligibility_check = make_recipe("legalaid.eligibility_check")
-            thirdparty_details = make_recipe("legalaid.thirdparty_details")
-            adaptation_details = make_recipe("legalaid.adaptation_details")
-            diagnosis = make_recipe("diagnosis.diagnosis")
-            provider = make_recipe("cla_provider.provider")
+        case = make_recipe(
+            "legalaid.case",
+            eligibility_check=eligibility_check,
+            personal_details=pd,
+            thirdparty_details=thirdparty_details,
+            adaptation_details=adaptation_details,
+            diagnosis=diagnosis,
+            media_code=None,
+            matter_type1=None,
+            matter_type2=None,
+            source=CASE_SOURCE.PHONE,
+            **self.get_extra_search_make_recipe_kwargs()
+        )
 
-            case = make_recipe(
-                "legalaid.case",
-                eligibility_check=eligibility_check,
+        media_code = make_recipe("legalaid.media_code")
+
+        matter_type1 = make_recipe("legalaid.matter_type1")
+        matter_type2 = make_recipe("legalaid.matter_type2")
+
+        data = {
+            "personal_details": None,
+            "eligibility_check": None,
+            "thirdparty_details": None,
+            "adaptation_details": None,
+            "diagnosis": None,
+            "provider": None,
+            "billable_time": 234,
+            "created": "2014-08-05T10:41:55.979Z",
+            "modified": "2014-08-05T10:41:55.985Z",
+            "created_by": "test_user",
+            "matter_type1": matter_type1.code,
+            "matter_type2": matter_type2.code,
+            "media_code": media_code.code,
+            "laa_reference": 232323,
+            "source": CASE_SOURCE.VOICEMAIL,
+            "requires_action_by": REQUIRES_ACTION_BY.PROVIDER_REVIEW,
+        }
+        response = self.client.patch(
+            self.get_detail_url(case.reference),
+            data=data,
+            format="json",
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertResponseKeys(response)
+
+        self.assertCaseEqual(
+            response.data,
+            Case(
+                reference=response.data["reference"],
                 personal_details=pd,
+                eligibility_check=eligibility_check,
                 thirdparty_details=thirdparty_details,
                 adaptation_details=adaptation_details,
                 diagnosis=diagnosis,
-                media_code=None,
-                matter_type1=None,
-                matter_type2=None,
-                source=CASE_SOURCE.PHONE,
-                **self.get_extra_search_make_recipe_kwargs()
+                provider=provider,
+                billable_time=0,
+                laa_reference=response.data["laa_reference"],
+                matter_type1=matter_type1,
+                matter_type2=matter_type2,
+                media_code=media_code,
+                source=CASE_SOURCE.VOICEMAIL,
+                requires_action_by=case.requires_action_by,
+            ),
+        )
+
+        self.assertNotEqual(response.data["requires_action_by"], data["requires_action_by"])
+        self.assertNotEqual(response.data["created"], data["created"])
+        self.assertNotEqual(response.data["created_by"], data["created_by"])
+        self.assertNotEqual(response.data["modified"], data["modified"])
+        self.assertNotEqual(response.data["laa_reference"], data["laa_reference"])
+
+        self.assertNoLogInDB()
+
+        # looking for the update case query
+        update_query = [query for query in connection.queries if query["sql"].startswith("UPDATE")]
+        self.assertEqual(len(update_query), 1)
+        update_sql = update_query[0]["sql"]
+
+        for readonly_field in [
+            "personal_details",
+            "eligibility_check",
+            "thirdparty_details",
+            "adaptation_details",
+            "provider",
+            "billable_time",
+            "laa_reference",
+            "requires_action_by",
+        ]:
+            self.assertFalse(
+                readonly_field in update_sql, "%s is in the UPDATE query when it shouldn't be!" % readonly_field
             )
-
-            media_code = make_recipe("legalaid.media_code")
-
-            matter_type1 = make_recipe("legalaid.matter_type1")
-            matter_type2 = make_recipe("legalaid.matter_type2")
-
-            data = {
-                "personal_details": None,
-                "eligibility_check": None,
-                "thirdparty_details": None,
-                "adaptation_details": None,
-                "diagnosis": None,
-                "provider": None,
-                "billable_time": 234,
-                "created": "2014-08-05T10:41:55.979Z",
-                "modified": "2014-08-05T10:41:55.985Z",
-                "created_by": "test_user",
-                "matter_type1": matter_type1.code,
-                "matter_type2": matter_type2.code,
-                "media_code": media_code.code,
-                "laa_reference": 232323,
-                "source": CASE_SOURCE.VOICEMAIL,
-                "requires_action_by": REQUIRES_ACTION_BY.PROVIDER_REVIEW,
-            }
-            response = self.client.patch(
-                self.get_detail_url(case.reference),
-                data=data,
-                format="json",
-                HTTP_AUTHORIZATION=self.get_http_authorization(),
-            )
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertResponseKeys(response)
-
-            self.assertCaseEqual(
-                response.data,
-                Case(
-                    reference=response.data["reference"],
-                    personal_details=pd,
-                    eligibility_check=eligibility_check,
-                    thirdparty_details=thirdparty_details,
-                    adaptation_details=adaptation_details,
-                    diagnosis=diagnosis,
-                    provider=provider,
-                    billable_time=0,
-                    laa_reference=response.data["laa_reference"],
-                    matter_type1=matter_type1,
-                    matter_type2=matter_type2,
-                    media_code=media_code,
-                    source=CASE_SOURCE.VOICEMAIL,
-                    requires_action_by=case.requires_action_by,
-                ),
-            )
-
-            self.assertNotEqual(response.data["requires_action_by"], data["requires_action_by"])
-            self.assertNotEqual(response.data["created"], data["created"])
-            self.assertNotEqual(response.data["created_by"], data["created_by"])
-            self.assertNotEqual(response.data["modified"], data["modified"])
-            self.assertNotEqual(response.data["laa_reference"], data["laa_reference"])
-
-            self.assertNoLogInDB()
-
-            # looking for the update case query
-            update_query = [query for query in connection.queries if query["sql"].startswith("UPDATE")]
-            self.assertEqual(len(update_query), 1)
-            update_sql = update_query[0]["sql"]
-
-            for readonly_field in [
-                "personal_details",
-                "eligibility_check",
-                "thirdparty_details",
-                "adaptation_details",
-                "provider",
-                "billable_time",
-                "laa_reference",
-                "requires_action_by",
-            ]:
-                self.assertFalse(
-                    readonly_field in update_sql, "%s is in the UPDATE query when it shouldn't be!" % readonly_field
-                )
-        finally:
-            settings.DEBUG = _old_settings
-            connection.queries = []
 
     def test_update_with_data(self):
         media_code = make_recipe("legalaid.media_code")

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -277,7 +277,6 @@ class OBIEEExportOutputsZipTestCase(TestCase):
 
 
 class TestKnowledgeBaseArticlesExport(TestCase):
-    @classmethod
     def setUp(self):
         article_1, article_2, article_3, article4 = make_recipe("knowledgebase.article", _quantity=4)
         make_recipe("knowledgebase.telephone_number", article=article_1, number=123)

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -278,8 +278,7 @@ class OBIEEExportOutputsZipTestCase(TestCase):
 
 class TestKnowledgeBaseArticlesExport(TestCase):
     @classmethod
-    def setUpClass(cls):
-        super(TestKnowledgeBaseArticlesExport, cls).setUpClass()
+    def setUp(self):
         article_1, article_2, article_3, article4 = make_recipe("knowledgebase.article", _quantity=4)
         make_recipe("knowledgebase.telephone_number", article=article_1, number=123)
         make_recipe("knowledgebase.telephone_number", article=article_1, number=456, name="special")

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -279,6 +279,7 @@ class OBIEEExportOutputsZipTestCase(TestCase):
 class TestKnowledgeBaseArticlesExport(TestCase):
     @classmethod
     def setUpClass(cls):
+        super(TestKnowledgeBaseArticlesExport, cls).setUpClass()
         article_1, article_2, article_3, article4 = make_recipe("knowledgebase.article", _quantity=4)
         make_recipe("knowledgebase.telephone_number", article=article_1, number=123)
         make_recipe("knowledgebase.telephone_number", article=article_1, number=456, name="special")

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -43,19 +43,19 @@ def report_view(request, form_class, title, template="case_report", success_task
     else:
         filename = file_name
     tmpl = "admin/reports/{0}.html".format(template)
-
+    has_permission = request.user.is_active and request.user.is_staff
     form = form_class()
     if valid_submit(request, form):
         success_task().delay(request.user.pk, filename, form_class.__name__, json.dumps(request.POST))
         messages.info(request, u"Your export is being processed. It will show up in the downloads tab shortly.")
 
-    return render(request, tmpl, {"title": title, "form": form})
+    return render(request, tmpl, {'has_permission': has_permission, "title": title, "form": form})
 
 
 def scheduled_report_view(request, form_class, title):
     tmpl = "admin/reports/case_report.html"
-
-    return render(request, tmpl, {"title": title})
+    has_permission = request.user.is_active and request.user.is_staff
+    return render(request, tmpl, {"title": title, 'has_permission': has_permission})
 
 
 def valid_submit(request, form):

--- a/cla_backend/apps/reports/views.py
+++ b/cla_backend/apps/reports/views.py
@@ -2,6 +2,7 @@ import json
 import re
 import os
 from django.contrib import messages
+from django.contrib.admin import AdminSite
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, Http404
@@ -37,25 +38,26 @@ from reports.utils import get_s3_connection
 
 
 def report_view(request, form_class, title, template="case_report", success_task=ExportTask, file_name=None):
+
+    admin_site_instance = AdminSite()
     slug = re.sub("[^0-9a-zA-Z]+", "_", title.lower()).strip("_")
     if not file_name:
         filename = "{0}.csv".format(slug)
     else:
         filename = file_name
     tmpl = "admin/reports/{0}.html".format(template)
-    has_permission = request.user.is_active and request.user.is_staff
     form = form_class()
     if valid_submit(request, form):
         success_task().delay(request.user.pk, filename, form_class.__name__, json.dumps(request.POST))
         messages.info(request, u"Your export is being processed. It will show up in the downloads tab shortly.")
 
-    return render(request, tmpl, {'has_permission': has_permission, "title": title, "form": form})
+    return render(request, tmpl, {'has_permission': admin_site_instance.has_permission(request), "title": title, "form": form})
 
 
-def scheduled_report_view(request, form_class, title):
+def scheduled_report_view(request, title):
     tmpl = "admin/reports/case_report.html"
-    has_permission = request.user.is_active and request.user.is_staff
-    return render(request, tmpl, {"title": title, 'has_permission': has_permission})
+    admin_site_instance = AdminSite()
+    return render(request, tmpl, {"title": title, 'has_permission': admin_site_instance.has_permission(request)})
 
 
 def valid_submit(request, form):
@@ -112,7 +114,7 @@ def mi_survey_extract(request):
 @permission_required("legalaid.run_reports")
 def mi_cb1_extract(request):
     if settings.SHOW_NEW_CB1:
-        return scheduled_report_view(request, MICB1Extract, "MI CB1 Extract")
+        return scheduled_report_view(request, "MI CB1 Extract")
     else:
         return report_view(request, MICB1Extract, "MI CB1 Extract")
 

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -461,7 +461,6 @@ SESSION_SECURITY_EXPIRE_AFTER = 60 * 30
 PASSIVE_URL_REGEX_LIST = [r"^(?!\/admin\/).*", r"^(\/admin\/).*\/exports/$"]
 
 SESSION_SECURITY_PASSIVE_URLS = []
-TEMPLATE_CONTEXT_PROCESSORS += ("django.core.context_processors.request",)
 
 # .local.py overrides all the common settings.
 try:

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -129,8 +129,6 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STATIC_FILES_STORAGE_BUCKET_NAME")
 
 AWS_DELETED_OBJECTS_BUCKET_NAME = os.environ.get("AWS_DELETED_OBJECTS_BUCKET_NAME")
 
-SITE_HOSTNAME = os.environ.get("SITE_HOSTNAME", "cla.local:8000")
-
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split()

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -42,7 +42,7 @@ PING_JSON_KEYS = {
 }
 
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
-TEMPLATE_DEBUG = DEBUG
+
 
 ADMINS = ()
 
@@ -129,6 +129,8 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STATIC_FILES_STORAGE_BUCKET_NAME")
 
 AWS_DELETED_OBJECTS_BUCKET_NAME = os.environ.get("AWS_DELETED_OBJECTS_BUCKET_NAME")
 
+SITE_HOSTNAME = os.environ.get("SITE_HOSTNAME", "cla.local:8000")
+
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split()
@@ -188,11 +190,6 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = os.environ.get("SECRET_KEY", "iia425u_J_pwntnEyqBuI1xBDqOX8nZ4uC73epGce_w")
 
-# List of callables that know how to import templates from various sources.
-# TEMPLATE_LOADERS = (
-#     'django.template.loaders.filesystem.Loader',
-#     'django.template.loaders.app_directories.Loader',
-# )
 
 MIDDLEWARE_CLASSES = (
     "django.middleware.locale.LocaleMiddleware",
@@ -211,7 +208,25 @@ ROOT_URLCONF = "cla_backend.urls"
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = "cla_backend.wsgi.application"
 
-TEMPLATE_DIRS = (root("templates"),)
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [root("templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.template.context_processors.request",
+                "django.contrib.messages.context_processors.messages",
+            ]
+        },
+    }
+]
 
 BACKEND_ENABLED = os.environ.get("BACKEND_ENABLED", "True") == "True"
 ADMIN_ENABLED = os.environ.get("ADMIN_ENABLED", "True") == "True"

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -130,7 +130,7 @@ docopt==0.6.2
     #   coveralls
     #   django-docopt-command
     #   notifications-python-client
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in
@@ -195,7 +195,7 @@ monotonic==1.6
     # via notifications-python-client
 networkx==1.9.1
     # via -r requirements/source/requirements-base.in
-nodeenv==1.8.0
+nodeenv==1.7.0
     # via pre-commit
 notifications-python-client==6.0.0
     # via -r requirements/source/requirements-base.in
@@ -285,7 +285,7 @@ six==1.16.0
     #   virtualenv
 speaklater==1.3
     # via cla-common
-sqlalchemy==1.4.48
+sqlalchemy==1.4.46
     # via csvkit
 sqlparse==0.3.1
     # via django-debug-toolbar
@@ -301,7 +301,7 @@ unittest-xml-reporting==2.5.1
     # via -r requirements/source/requirements-testing.in
 urllib3-secure-extra==0.1.0
     # via urllib3
-urllib3[secure]==1.26.16
+urllib3[secure]==1.26.14
     # via
     #   botocore
     #   coveralls

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -106,7 +106,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.11
+django==1.8.19
     # via
     #   -r requirements/source/requirements-base.in
     #   django-debug-toolbar
@@ -189,7 +189,7 @@ markdown==2.5.2
     # via -r requirements/source/requirements-base.in
 mock==1.0.1
     # via -r requirements/source/requirements-testing.in
-model-mommy==1.2.3
+model-mommy==1.2.4
     # via -r requirements/source/requirements-testing.in
 monotonic==1.6
     # via notifications-python-client

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -78,7 +78,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.11
+django==1.8.19
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -103,7 +103,7 @@ docopt==0.6.2
     #   notifications-python-client
 docutils==0.17.1
     # via sphinx
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -72,7 +72,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.11
+django==1.8.19
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -93,7 +93,7 @@ docopt==0.6.2
     # via
     #   django-docopt-command
     #   notifications-python-client
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -116,7 +116,7 @@ docopt==0.6.2
     #   coveralls
     #   django-docopt-command
     #   notifications-python-client
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -93,7 +93,7 @@ django-storages==1.5.2
     # via -r requirements/source/requirements-base.in
 django-uuidfield==0.5.0
     # via -r requirements/source/requirements-base.in
-django==1.7.11
+django==1.8.19
     # via
     #   -r requirements/source/requirements-base.in
     #   django-model-utils
@@ -162,7 +162,7 @@ markdown==2.5.2
     # via -r requirements/source/requirements-base.in
 mock==1.0.1
     # via -r requirements/source/requirements-testing.in
-model-mommy==1.2.3
+model-mommy==1.2.4
     # via -r requirements/source/requirements-testing.in
 monotonic==1.6
     # via notifications-python-client

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -2,7 +2,7 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-Django==1.7.11
+Django==1.8.19
 
 django-model-utils==2.2
 

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -26,7 +26,7 @@ django-filter==0.9.2
 jsonpatch==1.9
 networkx==1.9.1
 lxml==4.9.1
-drf-extensions==0.2.8
+drf-extensions==0.3.1
 logstash-formatter==0.5.9
 django-ipware==0.1.0
 csvkit==0.9.0

--- a/requirements/source/requirements-testing.in
+++ b/requirements/source/requirements-testing.in
@@ -4,7 +4,7 @@ coverage==4.5.4
 coveralls==1.8.2
 freezegun==0.3.14
 mock==1.0.1
-model-mommy==1.2.3
+model-mommy==1.2.4
 unittest-xml-reporting==2.5.1
 https://github.com/HassenPy/django-pdb/archive/refs/tags/0.3.2.tar.gz
 selenium==3.141.0


### PR DESCRIPTION
## What does this pull request do?
Upgrade Django to 1.8.19
https://docs.djangoproject.com/en/1.8/releases/1.8/

Major changes seen in this version of Django:
- Changes to the way templates are managed, have updated the settings as described in the announcement.
- Changes to the permissions for the usertools block - see miscellaneous changes in the release notes: https://docs.djangoproject.com/en/4.1/releases/1.8/#miscellaneous
- Changes to management commands, now use argparse instead of optparse as standard so needed to change the way parameters are passed in for custom commands.
- Changes to TestCase data setup. Removed setUpClass from test_case_api and replaced with setUpTestData that calls cls, resolving the cls atomics issue.  All test setup is now included in `setUpTestData` instead of `setUpClass`. Link to stackoverflow - https://stackoverflow.com/a/29655301
- `select_related` now checks all inputs to see if they are valid. Logs was not a valid input for ComplaintManager so was removed after checking versus master and seeing no change after it's removal.

## Any other changes that would benefit highlighting?

When running the database diff script from the end to end repository we compared these results with those after the previous dsrf ticket. We found changes to three tables:

- diagnosis_diagnosistraversal - same information across both tables but populated on different rows

- django_content_type - The name column has been removed as part of the Django upgrade. “The name field of django.contrib.contenttypes.models.ContentType has been removed by a migration and replaced by a property. That means it’s not possible to query or filter a ContentType by this field any longer.” - [Django](https://docs.djangoproject.com/en/4.1/releases/1.8/#miscellaneous) 

- Django-migrations table - 6 new migrations. All of these were linked to changes listed in the migrations

    - 2 were related to the removal of the name field in content type.

    - 1 was related to the default email field max_length being increased to 254 characters

    - 1 was related to the max name for Permission.name being increased to 255 characters

    - 1 was related to allowing the user’s last login field to be nullable

    - 1 was related to changing username “opts” - which there is some debate which change in the release notes it relates to

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
