### PR TITLE
Update to using slack orb to version 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  slack: circleci/slack@4.12.1
+  slack: circleci/slack@4.11.0
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
 jobs:
   build:
@@ -204,18 +204,7 @@ jobs:
             echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
       - slack/notify:
           event: pass
-          custom: |
-            {
-              "blocks": [
-                  {
-                      "type": "section",
-                      "text": {
-                          "type": "mrkdwn",
-                          "text": "This is a test"
-                      }
-                  }
-              ]
-            }
+          template: basic_success_1
 
   cleanup_merged:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.12.1
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
 jobs:
   build:
@@ -203,9 +203,22 @@ jobs:
             ./bin/<< parameters.namespace >>_deploy.sh << parameters.dynamic_hostname >>
             echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
       - slack/notify:
-          message: ':tada: (<< parameters.namespace >>) Deployed branch $CIRCLE_BRANCH'
-          title: '$RELEASE_HOST'
-          title_link: 'https://$RELEASE_HOST/admin/'
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "DEPLOYED https://$RELEASE_HOST/admin/ HERE\n:tada: (<< parameters.namespace >>) Deployed branch $CIRCLE_BRANCH\n[Visit Job]($CIRCLE_BUILD_URL)"
+                      }
+                  }
+              ]
+            }
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
 
   cleanup_merged:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  slack: circleci/slack@4.11.0
+  slack: circleci/slack@4.5.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,8 @@ jobs:
       dynamic_hostname:
         type: boolean
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      # - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:2.1
     shell: /bin/sh -leo pipefail
     environment:
       BASH_ENV: /etc/profile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,14 +211,11 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "DEPLOYED https://$RELEASE_HOST/admin/ HERE\n:tada: (<< parameters.namespace >>) Deployed branch $CIRCLE_BRANCH\n[Visit Job]($CIRCLE_BUILD_URL)"
+                          "text": "This is a test"
                       }
                   }
               ]
             }
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   cleanup_merged:
     docker:
@@ -244,21 +241,21 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - lint
-      - pip-compile
-      - test:
-          requires:
-            - lint
-            - pip-compile
-      - cleanup_merged:
-          name: cleanup_merged_live
-          context:
-            - laa-cla-backend
-            - laa-cla-backend-live-uat
+#      - lint
+#      - pip-compile
+#      - test:
+#          requires:
+#            - lint
+#            - pip-compile
+#      - cleanup_merged:
+#          name: cleanup_merged_live
+#          context:
+#            - laa-cla-backend
+#            - laa-cla-backend-live-uat
 
       - build:
-          requires:
-            - test
+#          requires:
+#            - test
           context: laa-cla-backend
 
       - cla-end-to-end-tests/behave:


### PR DESCRIPTION
## What does this pull request do?

Update to using slack orb to version 4 as version 3 webhooks are no longer used

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
