### PR TITLE
LGA-2412 - Update build job docker image to use latest cloud-platform image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       dynamic_hostname:
         type: boolean
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:2.1
     shell: /bin/sh -leo pipefail
     environment:
       BASH_ENV: /etc/profile
@@ -209,7 +209,7 @@ jobs:
 
   cleanup_merged:
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:2.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## What does this pull request do?

Update build job docker image to use latest cloud-platform image

## Any other changes that would benefit highlighting?

The previous cloud-platform/tools:circleci image is out of date and is using out of date ubuntu version that is missing latest lets encrypt root certificate which was causing our slack notifications not to go out. 

https://app.circleci.com/pipelines/github/ministryofjustice/cla_backend/2668/workflows/435b3775-cc54-49b7-81ad-540e34d7d650/jobs/13559?invite=true#step-106-64


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
