### PR TITLE
LGA-1797 upgrade drf-extension to 0.3.1

### DIFF
--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -129,7 +129,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   django-docopt-command
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -101,7 +101,7 @@ docopt==0.6.2
     # via django-docopt-command
 docutils==0.17.1
     # via sphinx
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -91,7 +91,7 @@ https://github.com/ministryofjustice/djorm-ext-pgfulltext/archive/refs/tags/0.1.
     # via -r requirements/source/requirements-base.in
 docopt==0.6.2
     # via django-docopt-command
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -115,7 +115,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   django-docopt-command
-drf-extensions==0.2.8
+drf-extensions==0.3.1
     # via -r requirements/source/requirements-base.in
 drf-nested-routers==0.9.0
     # via -r requirements/source/requirements-base.in

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -26,7 +26,7 @@ django-filter==0.9.2
 jsonpatch==1.9
 networkx==1.9.1
 lxml==4.9.1
-drf-extensions==0.2.8
+drf-extensions==0.3.1
 logstash-formatter==0.5.9
 django-ipware==0.1.0
 csvkit==0.9.0


### PR DESCRIPTION
## What does this pull request do?

Upgrades the drf-extension to 0.3.1

## Any other changes that would benefit highlighting?

This needs to be merged into the django upgrade branch after the django upgrade to 1.8.19 has been merged first.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
