### PR TITLE
LGA-2416 Make provider name unique to prevent CLA provider report fail

### DIFF
--- a/cla_backend/apps/cla_provider/migrations/0003_auto_20230405_1449.py
+++ b/cla_backend/apps/cla_provider/migrations/0003_auto_20230405_1449.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("cla_provider", "0002_auto_20150127_1536")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="provider",
+            name="name",
+            field=models.CharField(unique=True, max_length=255),
+            preserve_default=True,
+        )
+    ]

--- a/cla_backend/apps/cla_provider/models.py
+++ b/cla_backend/apps/cla_provider/models.py
@@ -28,7 +28,7 @@ class ProviderManager(models.Manager):
 
 
 class Provider(TimeStampedModel):
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, unique=True)
     opening_hours = models.CharField(max_length=100, blank=True)
     law_category = models.ManyToManyField("legalaid.Category", through="ProviderAllocation")
     active = models.BooleanField(default=False)

--- a/cla_backend/apps/cla_provider/tests/test_models.py
+++ b/cla_backend/apps/cla_provider/tests/test_models.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from django.db import IntegrityError
+from core.tests.mommy_utils import make_recipe
+
+
+class ProviderModelTestCase(TestCase):
+    def test_unique_provider_name(self):
+        make_recipe("cla_provider.provider", name="Stephensons")
+        with self.assertRaises(IntegrityError):
+            make_recipe("cla_provider.provider", name="Stephensons")


### PR DESCRIPTION
## What does this pull request do?

The MI Allocation Provider report fails when there is a duplicate case sensitive provider name. (IE - "Test" and "Test" fails, whereas "Test" and "test" would not fail)

To ensure that provider name is unique (in a case sensitive manner as above), this PR:
- updates the provider model 
- adds a migration file
- adds a unit test 

## Any other changes that would benefit highlighting?

Updating the model pushes an error to the django form as seen in the screenshot below:
![Screenshot 2023-04-03 at 11 36 42 (2)](https://user-images.githubusercontent.com/61416092/229539958-2284d11b-2bcf-4ff2-adfd-f948689f8fb0.png)


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
