### PR TITLE
LGA-2459 Update graphml to reflect change in family scope

### DIFF
--- a/cla_backend/apps/diagnosis/data/graph.graphml
+++ b/cla_backend/apps/diagnosis/data/graph.graphml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:java="http://www.yworks.com/xml/yfiles-common/1.0/java" xmlns:sys="http://www.yworks.com/xml/yfiles-common/markup/primitives/2.0" xmlns:x="http://www.yworks.com/xml/yfiles-common/markup/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:y="http://www.yworks.com/xml/graphml" xmlns:yed="http://www.yworks.com/xml/yed/3" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd">
-  <!--Created by yEd 3.22-->
+  <!--Created by yEd 3.23.1-->
   <key for="port" id="d0" yfiles.type="portgraphics"/>
   <key for="port" id="d1" yfiles.type="portgeometry"/>
   <key for="port" id="d2" yfiles.type="portuserdata"/>
@@ -6370,6 +6370,70 @@ No financial assessment is required.]]></data>
         </y:ShapeNode>
       </data>
     </node>
+    <node id="n351">
+      <data key="d3" xml:space="preserve"><![CDATA[Special Guardianship Order]]></data>
+      <data key="d4" xml:space="preserve"><![CDATA[Special Guardianship Order]]></data>
+      <data key="d10" xml:space="preserve"><![CDATA[n410]]></data>
+      <data key="d13">
+        <y:ShapeNode>
+          <y:Geometry height="30.0" width="150.0" x="1468.7809523809524" y="116.0"/>
+          <y:Fill color="#CCFFCC" transparent="false"/>
+          <y:BorderStyle color="#000000" type="line" width="1.0"/>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.1328125" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="162.724609375" x="-6.3623046875" xml:space="preserve" y="5.93359375">Special Guardianship Order<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
+          <y:Shape type="rectangle"/>
+        </y:ShapeNode>
+      </data>
+    </node>
+    <node id="n352">
+      <data key="d3" xml:space="preserve"><![CDATA[Parent, or person with parental responsibility, opposing or seeking to discharge a Special Guardianship Order]]></data>
+      <data key="d4" xml:space="preserve"><![CDATA[Parent]]></data>
+      <data key="d6">
+        <context xml:space="preserve" xmlns="">   <finance xml:space="preserve">passported</finance> </context>
+      </data>
+      <data key="d10" xml:space="preserve"><![CDATA[n411]]></data>
+      <data key="d13">
+        <y:ShapeNode>
+          <y:Geometry height="30.0" width="150.0" x="1093.7809523809524" y="83.0"/>
+          <y:Fill color="#CCFFCC" transparent="false"/>
+          <y:BorderStyle color="#000000" type="line" width="1.0"/>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.1328125" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="40.791015625" x="54.6044921875" xml:space="preserve" y="5.93359375">Parent<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
+          <y:Shape type="rectangle"/>
+        </y:ShapeNode>
+      </data>
+    </node>
+    <node id="n353">
+      <data key="d3" xml:space="preserve"><![CDATA[Any other person seeking a Special Guardianship Order, or seeking to discharge an order]]></data>
+      <data key="d4" xml:space="preserve"><![CDATA[Other person]]></data>
+      <data key="d10" xml:space="preserve"><![CDATA[n412]]></data>
+      <data key="d13">
+        <y:ShapeNode>
+          <y:Geometry height="30.0" width="150.0" x="1093.7809523809524" y="148.0"/>
+          <y:Fill color="#CCFFCC" transparent="false"/>
+          <y:BorderStyle color="#000000" type="line" width="1.0"/>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.1328125" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="80.734375" x="34.6328125" xml:space="preserve" y="5.93359375">Other person<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
+          <y:Shape type="rectangle"/>
+        </y:ShapeNode>
+      </data>
+    </node>
+    <node id="n354">
+      <data key="d3" xml:space="preserve"><![CDATA[INSCOPE]]></data>
+      <data key="d4" xml:space="preserve"><![CDATA[INSCOPE]]></data>
+      <data key="d6" xml:space="preserve">
+        <context xmlns="" xml:space="preserve">
+	<category xml:space="preserve">family</category>
+</context>
+      </data>
+      <data key="d10" xml:space="preserve"><![CDATA[n413]]></data>
+      <data key="d13">
+        <y:ShapeNode>
+          <y:Geometry height="30.0" width="150.0" x="773.8206349206348" y="116.0"/>
+          <y:Fill color="#CCFFCC" transparent="false"/>
+          <y:BorderStyle color="#000000" type="line" width="1.0"/>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.1328125" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="53.546875" x="48.2265625" xml:space="preserve" y="5.93359375">INSCOPE<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
+          <y:Shape type="rectangle"/>
+        </y:ShapeNode>
+      </data>
+    </node>
     <edge id="e0" source="n1" target="n2">
       <data key="d17">
         <y:PolyLineEdge>
@@ -12043,6 +12107,73 @@ No financial assessment is required.]]></data>
       <data key="d17">
         <y:PolyLineEdge>
           <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e475" source="n89" target="n351">
+      <data key="d16"/>
+      <data key="d17">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0">
+            <y:Point x="1689.0" y="188.0"/>
+            <y:Point x="1689.0" y="131.0"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e476" source="n351" target="n353">
+      <data key="d16"/>
+      <data key="d17">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0">
+            <y:Point x="1543.7809523809524" y="163.0"/>
+            <y:Point x="1374.0" y="163.0"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e477" source="n351" target="n352">
+      <data key="d16"/>
+      <data key="d17">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0">
+            <y:Point x="1543.7809523809524" y="98.0"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e478" source="n352" target="n354">
+      <data key="d16"/>
+      <data key="d17">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0">
+            <y:Point x="848.8206349206348" y="98.0"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e479" source="n353" target="n354">
+      <data key="d16"/>
+      <data key="d17">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0">
+            <y:Point x="848.8206349206348" y="163.0"/>
+          </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
           <y:BendStyle smoothed="false"/>

--- a/cla_backend/apps/diagnosis/data/graph.graphml.tpl
+++ b/cla_backend/apps/diagnosis/data/graph.graphml.tpl
@@ -1,6 +1,6 @@
 {% load i18n %}<?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:java="http://www.yworks.com/xml/yfiles-common/1.0/java" xmlns:sys="http://www.yworks.com/xml/yfiles-common/markup/primitives/2.0" xmlns:x="http://www.yworks.com/xml/yfiles-common/markup/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:y="http://www.yworks.com/xml/graphml" xmlns:yed="http://www.yworks.com/xml/yed/3" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd">
-  <!--Created by yEd 3.22-->
+  <!--Created by yEd 3.23.1-->
   <key for="port" id="d0" yfiles.type="portgraphics"/>
   <key for="port" id="d1" yfiles.type="portgeometry"/>
   <key for="port" id="d2" yfiles.type="portuserdata"/>
@@ -3186,6 +3186,34 @@ No financial assessment is required.</data>
       </data>
       <data key="d10" xml:space="preserve">n350</data>
       </node>
+    <node id="n351">
+      <data key="d3" xml:space="preserve">{% trans "Special Guardianship Order" %}</data>
+      <data key="d4" xml:space="preserve">Special Guardianship Order</data>
+      <data key="d10" xml:space="preserve">n410</data>
+      </node>
+    <node id="n352">
+      <data key="d3" xml:space="preserve">{% trans "Parent, or person with parental responsibility, opposing or seeking to discharge a Special Guardianship Order" %}</data>
+      <data key="d4" xml:space="preserve">Parent</data>
+      <data key="d6">
+        <context xmlns="" xml:space="preserve">   <finance xml:space="preserve">passported</finance> </context>
+      </data>
+      <data key="d10" xml:space="preserve">n411</data>
+      </node>
+    <node id="n353">
+      <data key="d3" xml:space="preserve">{% trans "Any other person seeking a Special Guardianship Order, or seeking to discharge an order" %}</data>
+      <data key="d4" xml:space="preserve">Other person</data>
+      <data key="d10" xml:space="preserve">n412</data>
+      </node>
+    <node id="n354">
+      <data key="d3" xml:space="preserve">INSCOPE</data>
+      <data key="d4" xml:space="preserve">INSCOPE</data>
+      <data key="d6" xml:space="preserve">
+        <context xmlns="" xml:space="preserve">
+	<category xml:space="preserve">family</category>
+</context>
+      </data>
+      <data key="d10" xml:space="preserve">n413</data>
+      </node>
     <edge id="e0" source="n1" target="n2">
       </edge>
     <edge id="e1" source="n2" target="n3">
@@ -4135,6 +4163,21 @@ No financial assessment is required.</data>
     <edge id="e473" source="n0" target="n349">
       </edge>
     <edge id="e474" source="n349" target="n350">
+      </edge>
+    <edge id="e475" source="n89" target="n351">
+      <data key="d16"/>
+      </edge>
+    <edge id="e476" source="n351" target="n353">
+      <data key="d16"/>
+      </edge>
+    <edge id="e477" source="n351" target="n352">
+      <data key="d16"/>
+      </edge>
+    <edge id="e478" source="n352" target="n354">
+      <data key="d16"/>
+      </edge>
+    <edge id="e479" source="n353" target="n354">
+      <data key="d16"/>
       </edge>
   </graph>
   <data key="d14">

--- a/cla_backend/translations/cy/LC_MESSAGES/django.po
+++ b/cla_backend/translations/cy/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CLA Backend\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 10:34+0000\n"
+"POT-Creation-Date: 2023-06-08 10:57+0100\n"
 "PO-Revision-Date: 2016-04-12 15:07+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi.gov.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/ministry-of-justice/cla-backend/language/cy/)\n"
@@ -2286,6 +2286,18 @@ msgstr ""
 
 #: apps/diagnosis/data/graph.graphml.tpl:3166
 msgid "Parent is a foster carer or an approved prospective adoptive parent  or for a former foster parent of a young person who continues to reside with their former foster carer making an application to the first tier tribunal in a SEND case"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3190
+msgid "Special Guardianship Order"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3195
+msgid "Parent, or person with parental responsibility, opposing or seeking to discharge a Special Guardianship Order"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3203
+msgid "Any other person seeking a Special Guardianship Order, or seeking to discharge an order"
 msgstr ""
 
 #: apps/timer/models.py:54

--- a/cla_backend/translations/en_GB/LC_MESSAGES/django.po
+++ b/cla_backend/translations/en_GB/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CLA Backend\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 10:34+0000\n"
+"POT-Creation-Date: 2023-06-08 10:57+0100\n"
 "PO-Revision-Date: 2015-05-20 12:59+0000\n"
 "Last-Translator: Igor U\n"
 "Language-Team: English (http://www.transifex.com/projects/p/cla-backend/language/en/)\n"
@@ -2022,6 +2022,18 @@ msgstr ""
 
 #: apps/diagnosis/data/graph.graphml.tpl:3166
 msgid "Parent is a foster carer or an approved prospective adoptive parent  or for a former foster parent of a young person who continues to reside with their former foster carer making an application to the first tier tribunal in a SEND case"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3190
+msgid "Special Guardianship Order"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3195
+msgid "Parent, or person with parental responsibility, opposing or seeking to discharge a Special Guardianship Order"
+msgstr ""
+
+#: apps/diagnosis/data/graph.graphml.tpl:3203
+msgid "Any other person seeking a Special Guardianship Order, or seeking to discharge an order"
 msgstr ""
 
 #: apps/timer/models.py:54


### PR DESCRIPTION
## What does this pull request do?

- Updates the GraphML to include a Special Guardianship Order
- If Special Guardianship order is selected, offers 2 new (radio button) options:
> - Parental figure chosen. If this is chosen, skips means assessment
> - Other person chosen. If this is chosen, continue to create means assessment

## Any other changes that would benefit highlighting?

Created end-to-end tests that passed when run locally [link to branch](https://github.com/ministryofjustice/cla-end-to-end-tests/pull/101)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
