### PR TITLE
Patch/lga 1777 upgrade celery

### DIFF
--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -22,7 +22,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-celery==3.1.17
+celery==3.1.18
     # via -r requirements/source/requirements-base.in
 certifi==2021.10.8
     # via

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -24,7 +24,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-celery==3.1.17
+celery==3.1.18
     # via -r requirements/source/requirements-base.in
 certifi==2021.10.8
     # via

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -20,7 +20,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-celery==3.1.17
+celery==3.1.18
     # via -r requirements/source/requirements-base.in
 certifi==2021.10.8
     # via

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -20,7 +20,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-celery==3.1.17
+celery==3.1.18
     # via -r requirements/source/requirements-base.in
 certifi==2021.10.8
     # via

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -40,7 +40,7 @@ polib==1.0.6
 
 # Fork PgFulltext - PR added
 https://github.com/ministryofjustice/djorm-ext-pgfulltext/archive/refs/tags/0.1.0.tar.gz
-celery==3.1.17
+celery==3.1.18
 boto==2.39.0
 PyYAML==5.4
 pyminizip==0.2.3


### PR DESCRIPTION
## What does this pull request do?

According to https://github.com/celery/celery/issues/2536 we need to upgrade our celery version to be compatible with Django 1.8

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist
Deployment instructions:

1. Merge changes to staging and training

2. Put dependant applications into maintenance mode 

(https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/4417486849/Putting+applications+into+maintenance+mode) 

or 

`./bin/maintenance_mode.sh <environment(uat,staging,training,production)> True`
 

4. [Take a snapshot of the production database before deployment](https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/4328980606/Create+database+snapshot)

5. Merge the changes to production

6. Take the site out of maintenance mode
`./bin/maintenance_mode.sh <environment(uat,staging,training,production)> False`



- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
