### PR TITLE
LGA 2506 Shelter Media Code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,6 @@ workflows:
               only:
                 - master
                 - django-upgrade
-                - /^feature/LGA-2506.*/
 
       - deploy:
           name: staging_deploy_live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,7 @@ workflows:
               only:
                 - master
                 - django-upgrade
+                - /^feature/LGA-2506.*/
 
       - deploy:
           name: staging_deploy_live

--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -8,6 +8,7 @@ migrations() {
     python manage.py loaddata initial_category.json
     python manage.py loaddata initial_mattertype.json
     python manage.py loaddata initial_media_codes.json
+    python manage.py loaddata new_media_codes.json
     python manage.py loaddata initial_complaint_categories.json
     python manage.py loaddata initial_guidance_notes.json
 }

--- a/cla_backend/apps/legalaid/fixtures/new_media_codes.json
+++ b/cla_backend/apps/legalaid/fixtures/new_media_codes.json
@@ -1,0 +1,9 @@
+{
+    "pk": 72, 
+    "model": "legalaid.MediaCode", 
+    "fields": {
+        "code": "SHALVM", 
+        "group": 3, 
+        "name": "Shelter Housing Advice line VM"
+    }
+}

--- a/cla_backend/apps/legalaid/fixtures/new_media_codes.json
+++ b/cla_backend/apps/legalaid/fixtures/new_media_codes.json
@@ -1,4 +1,4 @@
-{
+[{
     "pk": 72, 
     "model": "legalaid.MediaCode", 
     "fields": {
@@ -6,4 +6,4 @@
         "group": 3, 
         "name": "Shelter Housing Advice line VM"
     }
-}
+}]


### PR DESCRIPTION
## What does this pull request do?

Added new fixture date for media code

This will then be added on the required data by running a command on required date (this could also be scheduled if need be).

To run the load of the fixture, this command would need to be ran on a pod in production: 

kubectl exec -ti <pod_name>  python manage.py loaddata new_media_codes.json

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
