### PR TITLE
LGA-2467 make cla_backend pipelines use postgres v14 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
       - image: postgres:14.7-bullseye
         environment:
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: circle_test
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,11 +121,11 @@ jobs:
       - image: cimg/python:2.7
         environment:
           DB_NAME: circle_test
-          DB_USER: root
+          DB_USER: postgres
           DJANGO_SETTINGS_MODULE: cla_backend.settings.circle
-      - image: circleci/postgres:11.6-alpine
+      - image: postgres:14.7-bullseye
         environment:
-          POSTGRES_USER: root
+          POSTGRES_USER: postgres
           POSTGRES_DB: circle_test
     steps:
       - checkout

--- a/cla_backend/apps/reports/sql/MISurveyExtract.sql
+++ b/cla_backend/apps/reports/sql/MISurveyExtract.sql
@@ -15,7 +15,7 @@ SELECT
     (SELECT COUNT(legalaid_thirdpartydetails.id) > 0 FROM legalaid_thirdpartydetails WHERE legalaid_thirdpartydetails.personal_details_id=pd.id) AS "Third Party Contact",
     (SELECT string_agg(laa_reference::varchar, ', ') FROM legalaid_case c WHERE c.personal_details_id=pd.id),
     (SELECT string_agg(c.laa_reference::varchar, ', ') FROM legalaid_thirdpartydetails t RIGHT JOIN legalaid_case c ON c.thirdparty_details_id=t.id WHERE t.personal_details_id=pd.id),
-    (SELECT string_agg(DISTINCT cc_org.name::varchar, ', ' ORDER BY cc_org.name ASC) FROM call_centre_organisation cc_org INNER JOIN legalaid_case c ON cc_org.id = c.organisation_id WHERE c.personal_details_id=pd.id) as "Organisation"
+    (SELECT string_agg(DISTINCT cc_org.name::varchar, ', ' ORDER BY cc_org.name::varchar ASC) FROM call_centre_organisation cc_org INNER JOIN legalaid_case c ON cc_org.id = c.organisation_id WHERE c.personal_details_id=pd.id) as "Organisation"
 FROM
     legalaid_personaldetails AS pd
 WHERE pd.contact_for_research = TRUE


### PR DESCRIPTION
## What does this pull request do?

As per the investigation completed in the spike LGA-2408, this PR uses the postgres v14 image by:

- updating the circleci postgres image from 11.6 alpine to 14.7 bullseye
- Updating the MISurveyExtract.sql file to pass our unit tests when upgrading to allow upgrade past v11.14 (see highlights for more info)

## Any other changes that would benefit highlighting?

1. When upgrading from v11.13 to v11.14 2 unit tests trigger and fail:
```
ProgrammingError: in an aggregate with DISTINCT, ORDER BY expressions must appear in argument list
LINE 18: ..._agg(DISTINCT cc_org.name::varchar, ', ' ORDER BY cc_org.nam...
```
Based on the v11.14 documentation this is due to postgres no longer ignoring unspecified cast type modifier:

> Don't discard a cast to the same type with unspecified type modifier (Tom Lane)
> 
> For example, if column f1 is of type numeric(18,3), the parser used to simply discard a cast like f1::numeric, on the grounds that it would have no run-time effect. That's true, but the exposed type of the expression should still be considered to be plain numeric, not numeric(18,3). This is important for correctly resolving the type of larger constructs, such as recursive UNIONs.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
