### PR TITLE
LGA-2512 migrate laa-cla-backend-uat to postgres v14

### DIFF
--- a/helm_deploy/cla-backend-migration/templates/deployment.yaml
+++ b/helm_deploy/cla-backend-migration/templates/deployment.yaml
@@ -23,40 +23,40 @@ spec:
             - name: TARGET_DB_HOST
               valueFrom:
                 secretKeyRef:
-                  name: database-11
+                  name: database-14
                   key: host
             - name: TARGET_DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: database-11
+                  name: database-14
                   key: name
             - name: TARGET_DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: database-11
+                  name: database-14
                   key: user
             - name: TARGET_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: database-11
+                  name: database-14
                   key: password
             - name: SOURCE_DB_HOST
               valueFrom:
                 secretKeyRef:
-                  name: database-10
+                  name: database-11
                   key: host
             - name: SOURCE_DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: database-10
+                  name: database-11
                   key: name
             - name: SOURCE_DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: database-10
+                  name: database-11
                   key: user
             - name: SOURCE_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: database-10
+                  name: database-11
                   key: password

--- a/helm_deploy/cla-backend/values-uat-static.yaml
+++ b/helm_deploy/cla-backend/values-uat-static.yaml
@@ -38,3 +38,24 @@ envVars:
     value: "80"
   MIGRATE_OAUTH_DATA:
     value: "True"
+  DB_HOST:
+    secret:
+      name: database-14
+      key: host
+  DB_PORT:
+    secret:
+      name: database-14
+      key: port
+      optional: true
+  DB_NAME:
+    secret:
+      name: database-14
+      key: name
+  DB_USER:
+    secret:
+      name: database-14
+      key: user
+  DB_PASSWORD:
+    secret:
+      name: database-14
+      key: password


### PR DESCRIPTION
## What does this pull request do?

- Updates the `cla-backend-migration/templates/deployment.yaml` file to use database-11 as the source database and database-14 as the target database
- Updates database values in `cla-backend/values-uat-static.yaml` to use database-14

## Any other changes that would benefit highlighting?

This does not update `values-uat.yaml` which uses a fake local database. We have checked and it currently is still using a v10 postgres image `bitnami/postgresql:10-debian-10`. This will be updated as part of [this cleanup ticket](https://dsdmoj.atlassian.net/browse/LGA-2518).

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
