### PR TITLE
LGA-2569 - Force ValidationError message to a string

### DIFF
--- a/cla_backend/apps/core/drf/fields.py
+++ b/cla_backend/apps/core/drf/fields.py
@@ -105,7 +105,7 @@ class ThreePartDateField(serializers.Field):
                 try:
                     dt_object = datetime.date(int(year), int(month), int(day))
                 except ValueError as ve:
-                    raise serializers.ValidationError(ve)
+                    raise serializers.ValidationError(str(ve))
 
                 if int(year) < 1900:
                     raise serializers.ValidationError("year must be >= 1900")

--- a/cla_backend/apps/legalaid/tests/views/mixins/personal_details_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/personal_details_api.py
@@ -138,6 +138,13 @@ class PersonalDetailsAPIMixin(NestedSimpleResourceAPIMixin):
 
         self.assertPersonalDetailsEqual(response.data, check)
 
+    def test_invalid_dob(self):
+        data = self._get_default_post_data()
+
+        data["dob"] = {"year": 1988, "month": 13, "day": 10}
+        response = self._create(data=data)
+        self.assertEqual(response.data["dob"], ["month must be in 1..12"])
+
     # GET
 
     def test_get(self):


### PR DESCRIPTION
## What does this pull request do?

Force ValidationError message to a string

## Any other changes that would benefit highlighting?

The previous field implementations did not forcibly coerce returned values into the correct type in many cases. For example, an ValueError would return a string output if used in a string context. We now more strictly coerce to the correct return type, leading to more constrained and expected behavior

https://www.django-rest-framework.org/community/3.0-announcement/#coercing-output-types

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
