### PR TITLE
Bug/LGA 2568 complaints search error

### DIFF
--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -39,8 +39,8 @@ load_end_to_end_test_data() {
         python manage.py loaddata test_callbacks.json
         python manage.py loaddata test_user_with_case.json
         python manage.py loaddata test_assign_f2f_case.json
-        python manage.py loaddata test_complaints.json
         python manage.py loaddata test_eod.json
+        python manage.py loaddata test_complaints.json
 
     fi
 }

--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -39,6 +39,8 @@ load_end_to_end_test_data() {
         python manage.py loaddata test_callbacks.json
         python manage.py loaddata test_user_with_case.json
         python manage.py loaddata test_assign_f2f_case.json
+        python manage.py loaddata test_complaints.json
+        python manage.py loaddata test_eod.json
 
     fi
 }

--- a/cla_backend/apps/complaints/fixtures/test_complaints.json
+++ b/cla_backend/apps/complaints/fixtures/test_complaints.json
@@ -1,36 +1,17 @@
 [
   {
+    "model": "complaints.complaint",
+    "pk": 1,
     "fields": {
-      "id": 6,
-      "eod": "0d8384af987849598d40a8bb460d27a9",
-      "owner": null,
-      "created_by": {
-        "username": "test_operator_manager",
-        "first_name": "",
-        "last_name": ""
-      },
-      "category_name": null,
-      "full_name": "Jo Smith",
-      "category_of_law": "Discrimination, disability and other issues",
-      "case_reference": "TC-0001-0002",
-      "closed": null,
-      "voided": null,
-      "holding_letter": null,
-      "full_letter": null,
-      "out_of_sla": false,
-      "holding_letter_out_of_sla": false,
-      "status_label": "received",
-      "requires_action_at": "2023-07-25T09:56:59.967Z",
-      "created": "2023-07-24T09:56:59.967Z",
-      "modified": "2023-07-24T09:56:59.968Z",
-      "description": "Unhappy",
-      "source": "",
-      "level": 11,
-      "justified": null,
-      "resolved": null,
-      "category": null
-    },
-      "model": "complaints.complaint",
-      "pk": 1
+        "eod": 1,
+        "owner": null,
+        "created_by": 6,
+        "description": "Unhappy",
+        "source": "",
+        "level": 11,
+        "justified": null,
+        "resolved": null,
+        "category": null
+    }
   }
 ]

--- a/cla_backend/apps/complaints/fixtures/test_complaints.json
+++ b/cla_backend/apps/complaints/fixtures/test_complaints.json
@@ -1,7 +1,5 @@
 [
   {
-    "model": "complaints.complaint",
-    "pk": 1,
     "fields": {
         "eod": 1,
         "owner": null,
@@ -12,6 +10,8 @@
         "justified": null,
         "resolved": null,
         "category": null
-    }
+    },
+    "model": "complaints.complaint",
+    "pk": 1
   }
 ]

--- a/cla_backend/apps/complaints/fixtures/test_complaints.json
+++ b/cla_backend/apps/complaints/fixtures/test_complaints.json
@@ -1,32 +1,36 @@
 [
-    {
-        "id": 6,
-        "eod": "0d8384af987849598d40a8bb460d27a9",
-        "owner": null,
-        "created_by": {
-            "username": "test_operator_manager",
-            "first_name": "foo",
-            "last_name": "bar"
-        },
-        "category_name": null,
-        "full_name": "Jo Smith",
-        "category_of_law": "Discrimination, disability and other issues",
-        "case_reference": "TC-0001-0002",
-        "closed": null,
-        "voided": null,
-        "holding_letter": null,
-        "full_letter": null,
-        "out_of_sla": false,
-        "holding_letter_out_of_sla": false,
-        "status_label": "received",
-        "requires_action_at": "2023-07-25T09:56:59.967Z",
-        "created": "2023-07-24T09:56:59.967Z",
-        "modified": "2023-07-24T09:56:59.968Z",
-        "description": "Unhappy",
-        "source": "",
-        "level": 11,
-        "justified": null,
-        "resolved": null,
-        "category": null
-    }  
+  {
+    "fields": {
+      "id": 6,
+      "eod": "0d8384af987849598d40a8bb460d27a9",
+      "owner": null,
+      "created_by": {
+        "username": "test_operator_manager",
+        "first_name": "",
+        "last_name": ""
+      },
+      "category_name": null,
+      "full_name": "Jo Smith",
+      "category_of_law": "Discrimination, disability and other issues",
+      "case_reference": "TC-0001-0002",
+      "closed": null,
+      "voided": null,
+      "holding_letter": null,
+      "full_letter": null,
+      "out_of_sla": false,
+      "holding_letter_out_of_sla": false,
+      "status_label": "received",
+      "requires_action_at": "2023-07-25T09:56:59.967Z",
+      "created": "2023-07-24T09:56:59.967Z",
+      "modified": "2023-07-24T09:56:59.968Z",
+      "description": "Unhappy",
+      "source": "",
+      "level": 11,
+      "justified": null,
+      "resolved": null,
+      "category": null
+    },
+      "model": "complaints.complaint",
+      "pk": 1
+  }
 ]

--- a/cla_backend/apps/complaints/fixtures/test_complaints.json
+++ b/cla_backend/apps/complaints/fixtures/test_complaints.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": 6,
+        "eod": "0d8384af987849598d40a8bb460d27a9",
+        "owner": null,
+        "created_by": {
+            "username": "test_operator_manager",
+            "first_name": "foo",
+            "last_name": "bar"
+        },
+        "category_name": null,
+        "full_name": "Jo Smith",
+        "category_of_law": "Discrimination, disability and other issues",
+        "case_reference": "TC-0001-0002",
+        "closed": null,
+        "voided": null,
+        "holding_letter": null,
+        "full_letter": null,
+        "out_of_sla": false,
+        "holding_letter_out_of_sla": false,
+        "status_label": "received",
+        "requires_action_at": "2023-07-25T09:56:59.967Z",
+        "created": "2023-07-24T09:56:59.967Z",
+        "modified": "2023-07-24T09:56:59.968Z",
+        "description": "Unhappy",
+        "source": "",
+        "level": 11,
+        "justified": null,
+        "resolved": null,
+        "category": null
+    }  
+]

--- a/cla_backend/apps/complaints/fixtures/test_eod.json
+++ b/cla_backend/apps/complaints/fixtures/test_eod.json
@@ -1,12 +1,16 @@
 [
-    {
-        "categories": [
-            {
-                "category": "scope",
-                "is_major": false
-            }
-        ],
-        "notes": "Unhappy",
-        "reference": "0d8384af987849598d40a8bb460d27a9"
-    }
+  {
+    "fields": {
+      "categories": [
+        {
+          "category": "scope",
+          "is_major": false
+        }
+      ],
+      "notes": "Unhappy",
+      "reference": "0d8384af987849598d40a8bb460d27a9"
+    },
+    "model": "legalaid.eod_details",
+    "pk": 1
+  }
 ]

--- a/cla_backend/apps/complaints/fixtures/test_eod.json
+++ b/cla_backend/apps/complaints/fixtures/test_eod.json
@@ -1,0 +1,12 @@
+[
+    {
+        "categories": [
+            {
+                "category": "scope",
+                "is_major": false
+            }
+        ],
+        "notes": "Unhappy",
+        "reference": "0d8384af987849598d40a8bb460d27a9"
+    }
+]

--- a/cla_backend/apps/complaints/fixtures/test_eod.json
+++ b/cla_backend/apps/complaints/fixtures/test_eod.json
@@ -1,16 +1,11 @@
 [
   {
     "fields": {
-      "categories": [
-        {
-          "category": "scope",
-          "is_major": false
-        }
-      ],
+      "case": 1,
       "notes": "Unhappy",
       "reference": "0d8384af987849598d40a8bb460d27a9"
     },
-    "model": "legalaid.eod_details",
+    "model": "legalaid.eoddetails",
     "pk": 1
   }
 ]


### PR DESCRIPTION
## What does this pull request do?

Creates fixtures to use for complaints end-to-end tests






## Notes on this bug

To replicate - create several complaints and then search for any term related to the complaint (name of user, case reference will do)

There is a new line call for a distinct query that has been added to the SearchFilter method filter_queryset.
https://github.com/encode/django-rest-framework/blob/721efa28176507434a2f4b006f2f31b9a33ca2aa/rest_framework/filters.py#L126

If this is removed and instead you just return `queryset` then the 500 error goes away. `distinct` doesn't even work if there is only one record in the queryset.

Using PGAdmin, can get the same error by applying sql directly to the postgres DB.

`SELECT DISTINCT (
                    SELECT cla_eventlog_log.created FROM cla_eventlog_log
                    WHERE
                        cla_eventlog_log.content_type_id=58
                        AND cla_eventlog_log.object_id=complaints_complaint.id
                        AND cla_eventlog_log.code='HOLDING_LETTER_SENT'
                    ORDER BY cla_eventlog_log.created DESC
                    LIMIT 1
                    ) AS "holding_letter", (
                    SELECT cla_eventlog_log.created FROM cla_eventlog_log
                    WHERE
                        cla_eventlog_log.content_type_id=58
                        AND cla_eventlog_log.object_id=complaints_complaint.id
                        AND cla_eventlog_log.code='FULL_RESPONSE_SENT'
                    ORDER BY cla_eventlog_log.created DESC
                    LIMIT 1
                    ) AS "full_letter", (
                    SELECT cla_eventlog_log.created FROM cla_eventlog_log
                    WHERE
                        cla_eventlog_log.content_type_id=58
                        AND cla_eventlog_log.object_id=complaints_complaint.id
                        AND cla_eventlog_log.code IN ('COMPLAINT_CLOSED', 'COMPLAINT_VOID')
                    ORDER BY cla_eventlog_log.created DESC
                    LIMIT 1
                    ) AS "closed", (
                    SELECT cla_eventlog_log.created FROM cla_eventlog_log
                    WHERE
                        cla_eventlog_log.content_type_id=58
                        AND cla_eventlog_log.object_id=complaints_complaint.id
                        AND cla_eventlog_log.code='COMPLAINT_VOID'
                    ORDER BY cla_eventlog_log.created DESC
                    LIMIT 1
                    ) AS "voided", "complaints_complaint"."id", "complaints_complaint"."created", "complaints_complaint"."modified", "complaints_complaint"."eod_id", "complaints_complaint"."description", "complaints_complaint"."source", "complaints_complaint"."level", "complaints_complaint"."justified", "complaints_complaint"."resolved", "complaints_complaint"."category_id", "complaints_complaint"."owner_id", "complaints_complaint"."created_by_id", "legalaid_eoddetails"."id", "legalaid_eoddetails"."created", "legalaid_eoddetails"."modified", "legalaid_eoddetails"."case_id", "legalaid_eoddetails"."notes", "legalaid_eoddetails"."reference", "legalaid_case"."id", "legalaid_case"."created", "legalaid_case"."modified", "legalaid_case"."reference", "legalaid_case"."eligibility_check_id", "legalaid_case"."diagnosis_id", "legalaid_case"."personal_details_id", "legalaid_case"."created_by_id", "legalaid_case"."requires_action_by", "legalaid_case"."requires_action_at", "legalaid_case"."callback_window_type", "legalaid_case"."callback_attempt", "legalaid_case"."locked_by_id", "legalaid_case"."locked_at", "legalaid_case"."provider_id", "legalaid_case"."organisation_id", "legalaid_case"."notes", "legalaid_case"."provider_notes", "legalaid_case"."laa_reference", "legalaid_case"."thirdparty_details_id", "legalaid_case"."adaptation_details_id", "legalaid_case"."billable_time", "legalaid_case"."matter_type1_id", "legalaid_case"."matter_type2_id", "legalaid_case"."media_code_id", "legalaid_case"."outcome_code", "legalaid_case"."outcome_code_id", "legalaid_case"."level", "legalaid_case"."exempt_user", "legalaid_case"."exempt_user_reason", "legalaid_case"."ecf_statement", "legalaid_case"."from_case_id", "legalaid_case"."provider_assigned_at", "legalaid_case"."assigned_out_of_hours", "legalaid_case"."provider_viewed", "legalaid_case"."provider_accepted", "legalaid_case"."provider_closed", "legalaid_case"."source", "legalaid_case"."search_field", "legalaid_case"."complaint_flag", "legalaid_case"."is_urgent", "legalaid_eligibilitycheck"."id", "legalaid_eligibilitycheck"."created", "legalaid_eligibilitycheck"."modified", "legalaid_eligibilitycheck"."reference", "legalaid_eligibilitycheck"."category_id", "legalaid_eligibilitycheck"."you_id", "legalaid_eligibilitycheck"."partner_id", "legalaid_eligibilitycheck"."disputed_savings_id", "legalaid_eligibilitycheck"."your_problem_notes", "legalaid_eligibilitycheck"."notes", "legalaid_eligibilitycheck"."state", "legalaid_eligibilitycheck"."dependants_young", "legalaid_eligibilitycheck"."dependants_old", "legalaid_eligibilitycheck"."on_passported_benefits", "legalaid_eligibilitycheck"."has_passported_proceedings_letter", "legalaid_eligibilitycheck"."on_nass_benefits", "legalaid_eligibilitycheck"."specific_benefits", "legalaid_eligibilitycheck"."disregards", "legalaid_eligibilitycheck"."is_you_or_your_partner_over_60", "legalaid_eligibilitycheck"."has_partner", "legalaid_eligibilitycheck"."calculations", "legalaid_category"."id", "legalaid_category"."created", "legalaid_category"."modified", "legalaid_category"."name", "legalaid_category"."code", "legalaid_category"."raw_description", "legalaid_category"."ecf_available", "legalaid_category"."mandatory", "legalaid_category"."description", "legalaid_category"."order", "legalaid_personaldetails"."id", "legalaid_personaldetails"."created", "legalaid_personaldetails"."modified", "legalaid_personaldetails"."title", "legalaid_personaldetails"."full_name", "legalaid_personaldetails"."postcode", "legalaid_personaldetails"."street", "legalaid_personaldetails"."mobile_phone", "legalaid_personaldetails"."home_phone", "legalaid_personaldetails"."email", "legalaid_personaldetails"."date_of_birth", "legalaid_personaldetails"."ni_number", "legalaid_personaldetails"."contact_for_research", "legalaid_personaldetails"."contact_for_research_via", "legalaid_personaldetails"."vulnerable_user", "legalaid_personaldetails"."safe_to_contact", "legalaid_personaldetails"."safe_to_email", "legalaid_personaldetails"."case_count", "legalaid_personaldetails"."reference", "legalaid_personaldetails"."diversity", "legalaid_personaldetails"."diversity_modified", "legalaid_personaldetails"."search_field", "complaints_category"."id", "complaints_category"."created", "complaints_category"."modified", "complaints_category"."name" FROM "complaints_complaint" INNER JOIN "legalaid_eoddetails" ON ( "complaints_complaint"."eod_id" = "legalaid_eoddetails"."id" ) INNER JOIN "legalaid_case" ON ( "legalaid_eoddetails"."case_id" = "legalaid_case"."id" ) LEFT OUTER JOIN "legalaid_personaldetails" ON ( "legalaid_case"."personal_details_id" = "legalaid_personaldetails"."id" ) LEFT OUTER JOIN "legalaid_eligibilitycheck" ON ( "legalaid_case"."eligibility_check_id" = "legalaid_eligibilitycheck"."id" ) LEFT OUTER JOIN "legalaid_category" ON ( "legalaid_eligibilitycheck"."category_id" = "legalaid_category"."id" ) LEFT OUTER JOIN "complaints_category" ON ( "complaints_complaint"."category_id" = "complaints_category"."id" ) WHERE (NOT ("complaints_complaint"."id" IN (SELECT DISTINCT ON (U0."object_id") U0."object_id" FROM "cla_eventlog_log" U0 WHERE (U0."code" IN (COMPLAINT_CLOSED, COMPLAINT_VOID) AND U0."content_type_id" = 58) ORDER BY U0."object_id" ASC)) AND (UPPER("legalaid_personaldetails"."full_name"::text) LIKE UPPER(%TC-0001-0001%) OR UPPER("legalaid_personaldetails"."postcode"::text) LIKE UPPER(%TC-0001-0001%) OR UPPER("legalaid_personaldetails"."street"::text) LIKE UPPER(%TC-0001-0001%) OR UPPER("legalaid_personaldetails"."search_field"::text) LIKE UPPER(%TC-0001-0001%) OR UPPER("legalaid_case"."reference"::text) LIKE UPPER(%TC-0001-0001%) OR UPPER("legalaid_case"."laa_reference"::text) LIKE UPPER(%TC-0001-0001%))) ORDER BY "complaints_complaint"."created" DESC
`

Will be related to this error.

[DBError: could not identify an equality operator for type json when annotating a model with JSONField · Issue #55 · rpkilby/jsonfield](https://github.com/rpkilby/jsonfield/issues/55)

Cannot see how to remove the JsonFields from the query (even though they are not required or used) so decided to

- override the `filter_queryset` method for this particular search so we can remove the distinct call at the end.
- check if the same error is happening elsewhere
- write end to end tests to catch the search behaviour so if it fails then can spot it

## Other places using filter_queryset
Other SearchFilters are not impacted by this problem, either because they override `filter_queryset` and/or because they don’t have any `JsonFields`.

[guidance](https://github.com/ministryofjustice/cla_backend/blob/7a3a163768a002b2228f31a1470112458f8b4a23/cla_backend/apps/guidance/views.py#L12)

[Knowledgebase](https://github.com/ministryofjustice/cla_backend/blob/7a3a163768a002b2228f31a1470112458f8b4a23/cla_backend/apps/knowledgebase/views.py#L24)

[provider and call handler search cases](https://github.com/ministryofjustice/cla_backend/blob/7a3a163768a002b2228f31a1470112458f8b4a23/cla_backend/apps/legalaid/views.py#L440)

The SearchFilter is used for CaseArchivedViewSet but it is not clear this is used at present so no changes will be made here.

Looks like archived cases where loaded from a file https://github.com/ministryofjustice/cla_backend/blob/master/cla_backend/apps/historic/management/commands/load_historic_cases.py 

The route exists but trying to goto gives you a 404 https://github.com/ministryofjustice/cla_backend/blob/master/cla_backend/apps/call_centre/urls.py#L27

[urls.py](https://github.com/ministryofjustice/cla_backend/blob/master/cla_backend/apps/call_centre/urls.py)

This is how the frontend calls that route https://github.com/ministryofjustice/cla_frontend/blob/master/cla_frontend/assets-src/javascripts/app/js/services/models.js#L785Looks like you can't goto a dashboard for archived cases but get to a specific archived case
## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
