### PR TITLE
LGA-2625 deploy to production requires staging and training

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ workflows:
 
       - production_deploy_approval:
           requires:
-            - staging_deploy_live
+            - training_deploy_live
           type: approval
           filters:
             branches:


### PR DESCRIPTION
## What does this pull request do?

Approval to deploy changes to production only after deploy to training is green

## Any other changes that would benefit highlighting?

Implemented this in a way so that the pipelines first pass staging, then pass training then pass production 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
