### PR TITLE
LGA-2514 add script to test reports are consistent after migration

### DIFF
--- a/bin/database-migration/migration_reports.sh
+++ b/bin/database-migration/migration_reports.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+PRE_FOLDER=$1
+POST_FOLDER=$2
+cd $PRE_FOLDER || exit 1
+for i in *.csv; do
+    if [[ -e "$i" ]]; then
+        if [ ! -f sorted/"$i".sorted ]; then
+                sort <"$i" > sorted/"$i".sorted
+        fi
+        if [ ! -f $POST_FOLDER/sorted/"$i".sorted ]; then
+                sort <$POST_FOLDER/"$i"> $POST_FOLDER/sorted/"$i".sorted
+        fi
+        if ! cmp -s sorted/"$i".sorted $POST_FOLDER/sorted/"$i".sorted; then
+             echo $PRE_FOLDER/files sorted/"$i".sorted and $POST_FOLDER/sorted/"$i".sorted are different
+             echo "the following lines are not in both files"
+             comm -3 sorted/"$i".sorted $POST_FOLDER/sorted/"$i".sorted
+        else
+             echo files "$i" and $POST_FOLDER/"$i" are identical
+             echo
+        fi
+    else
+         echo "$POST_FOLDER/$i: not found" >&2
+    fi
+done


### PR DESCRIPTION
## What does this pull request do?

Add script used for testing reports are similar before and after migration. 

## Any other changes that would benefit highlighting?

To use this script:
- you must have your files in a pre-migration directory and a post-migration directory.
- Each of these directories must have an empty directory called SORTED
- make the script executable by using `chmod +x <fileName>`
- run using `./bin/database-migration/migration_reports.sh <PRE_FOLDER> <POST_FOLDER>`


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
