### PR TITLE
LGA-2624 Removed / from firefox-esr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN PIP_CONSTRAINT=/tmp/constraint.txt pip install 'PyYAML==5.4.1'
 FROM base AS development
 
 # additional package required otherwise build of coveralls fails
-RUN apk add --no-cache libffi-dev firefox-esr \
+RUN apk add --no-cache libffi-dev firefox-esr
 
 RUN PIP_CONSTRAINT=/tmp/constraint.txt pip install -r ./requirements/requirements-dev.txt --no-cache-dir
 COPY . .


### PR DESCRIPTION
## What does this pull request do?

Remove a / from the dockerfile that was preventing CLA_Backend from building locally.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
