### PR TITLE
LGA-2673 - Temporarily disable pushing notifications to the socket server

### DIFF
--- a/cla_backend/apps/notifications/models.py
+++ b/cla_backend/apps/notifications/models.py
@@ -2,7 +2,7 @@
 from django.db import models
 from django.conf import settings
 from django.utils import timezone
-from django.db.models.signals import post_save, post_delete
+from django.db.models.signals import post_delete
 from model_utils.models import TimeStampedModel
 
 from .constants import NOTIFICATION_TYPES
@@ -27,5 +27,4 @@ class Notification(TimeStampedModel):
     objects = NotificationManager()
 
 
-post_save.connect(send_notifications_to_users, sender=Notification)
 post_delete.connect(send_notifications_to_users, sender=Notification)


### PR DESCRIPTION
## What does this pull request do?

Temporarily disable pushing notifications to the socket server

## Any other changes that would benefit highlighting?

At the moment after receiving the notification, the socket server does not send the notification to the user due to it being setup incorrectly See https://github.com/ministryofjustice/cla_frontend/pull/919 for more details

Also the scheduling of these notifications with long ETA's is causing duplicating messages(thousands) to fill up the message queue, this means reports or anything else that depends on the message queue will not work until the queue is purged manually

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
