### PR TITLE
Bug/lga 2630 provider notes field

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -239,7 +239,7 @@ class LogSerializer(LogSerializerBase):
 
 
 class CaseSerializer(CaseSerializerFull):
-    provider_notes = serializers.CharField(max_length=5000, required=False, read_only=True)
+    provider_notes = serializers.CharField(max_length=10000, required=False, read_only=True)
     organisation = serializers.PrimaryKeyRelatedField(required=False, read_only=True)
     organisation_name = serializers.SerializerMethodField()
     billable_time = serializers.IntegerField(read_only=True)

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -261,7 +261,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * (CaseSerializer().fields["provider_notes"].max_length + 1)
+        max_character_limit = "A" * CaseSerializer().fields["provider_notes"].max_length
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -261,7 +261,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * CaseSerializer.notes.max_length
+        max_character_limit = "A" * (CaseSerializer().fields["provider_notes"].max_length + 1)
 
         response = self.client.patch(
             self.detail_url,
@@ -283,7 +283,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        over_max_character_limit = "A" * CaseSerializer.notes.max_length + 1
+        over_max_character_limit = "A" * (CaseSerializer().fields["provider_notes"].max_length + 1)
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -261,7 +261,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * 10000
+        max_character_limit = "A" * CaseSerializer.provider_notes.max_length
 
         response = self.client.patch(
             self.detail_url,
@@ -283,7 +283,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        over_max_character_limit = "A" * 10001
+        over_max_character_limit = "A" * CaseSerializer.provider_notes.max_length + 1
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -261,7 +261,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * CaseSerializer.provider_notes.max_length
+        max_character_limit = "A" * CaseSerializer.notes.max_length
 
         response = self.client.patch(
             self.detail_url,
@@ -283,7 +283,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        over_max_character_limit = "A" * CaseSerializer.provider_notes.max_length + 1
+        over_max_character_limit = "A" * CaseSerializer.notes.max_length + 1
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -259,7 +259,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * 10000
+        max_character_limit = "A" * CaseSerializer.provider_notes.max_length
 
         response = self.client.patch(
             self.detail_url,
@@ -281,7 +281,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        over_max_character_limit = "A" * 10001
+        over_max_character_limit = "A" * CaseSerializer.provider_notes.max_length + 1
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -281,8 +281,6 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        print(CaseSerializer().fields["provider_notes"].max_length, "TEST!!")
-
         over_max_character_limit = "A" * (CaseSerializer().fields["provider_notes"].max_length + 1)
 
         response = self.client.patch(

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -277,7 +277,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
 
     def test_patch_provider_notes_not_allowed_max_limit_hit(self):
         """
-        Test that bad request is made when user hit max character limit.
+        Test that a bad request is made when user is over max character limit.
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -259,7 +259,7 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        max_character_limit = "A" * CaseSerializer.provider_notes.max_length
+        max_character_limit = "A" * CaseSerializer().fields["provider_notes"].max_length
 
         response = self.client.patch(
             self.detail_url,
@@ -281,7 +281,9 @@ class UpdateCaseTestCase(BaseUpdateCaseTestCase, BaseCaseTestCase):
         """
         self.assertEqual(CaseNotesHistory.objects.all().count(), 0)
 
-        over_max_character_limit = "A" * CaseSerializer.provider_notes.max_length + 1
+        print(CaseSerializer().fields["provider_notes"].max_length, "TEST!!")
+
+        over_max_character_limit = "A" * (CaseSerializer().fields["provider_notes"].max_length + 1)
 
         response = self.client.patch(
             self.detail_url,

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -372,7 +372,7 @@ class CaseSerializerBase(PartialUpdateExcludeReadonlySerializerMixin, ClaModelSe
     diagnosis = UUIDSerializer(slug_field="reference", required=False, read_only=True)
     personal_details = PersonalDetailsSerializerBase()
     notes = serializers.CharField(max_length=10000, required=False, allow_blank=True)
-    provider_notes = serializers.CharField(max_length=5000, required=False, allow_blank=True)
+    provider_notes = serializers.CharField(max_length=10000, required=False, allow_blank=True)
     matter_type1 = serializers.SlugRelatedField(
         slug_field="code",
         required=False,


### PR DESCRIPTION
## What does this pull request do?

The update of a case fails if you try and put more than 5000 characters in to the notes.  This means providers can only save notes of 5000 characters.

Agreed to increase to **10000** character limit.

## Any other changes that would benefit highlighting?

Unit tests were updated too test max word limit and going over max word limit. This includes the providers notes unit test and a call centre notes unit test.

## Checklist

[LGA-2630](https://dsdmoj.atlassian.net/browse/LGA-2630)


[LGA-2630]: https://dsdmoj.atlassian.net/browse/LGA-2630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ