### PR TITLE
LGA-2727 - Remove deprecated batch/v1beta1 API version of CronJob

### DIFF
--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-house-keeping
@@ -18,7 +18,7 @@ spec:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-missing-codes
@@ -38,7 +38,7 @@ spec:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-mi-cb1-report
@@ -58,7 +58,7 @@ spec:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-delete-unused-cases
@@ -78,7 +78,7 @@ spec:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-fix-outcome-codes


### PR DESCRIPTION
## What does this pull request do?

Remove deprecated batch/v1beta1 API version of CronJob

## Any other changes that would benefit highlighting?

[The batch/v1beta1 API version of CronJob is no longer served as of v1.25.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
