### PR TITLE
bug/LGA 2770: Renamed EMAIL_ORCHESTRATOR_FLAG to USE_EMAIL_ORCHESTRATOR_FLAG

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -464,7 +464,7 @@ SESSION_SECURITY_PASSIVE_URLS = []
 
 EMAIL_ORCHESTRATOR_URL = os.environ.get("EMAIL_ORCHESTRATOR_URL", "Not set")
 
-USE_EMAIL_ORCHESTRATOR_FLAG = os.environ.get("EMAIL_ORCHESTRATOR_FLAG", "False") == "True"
+USE_EMAIL_ORCHESTRATOR_FLAG = os.environ.get("USE_EMAIL_ORCHESTRATOR_FLAG", "False") == "True"
 
 # .local.py overrides all the common settings.
 try:


### PR DESCRIPTION
## What does this pull request do?

Changes `EMAIL_ORCHESTRATOR_FLAG` to `USE_EMAIL_ORCHESTRATOR_FLAG`, as is named elsewhere.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
