### PR TITLE
LGA 2821: Fix CronJobs failing due to not having AWS Credentials

### DIFF
--- a/helm_deploy/cla-backend/templates/cron.yaml
+++ b/helm_deploy/cla-backend/templates/cron.yaml
@@ -16,6 +16,7 @@ spec:
             command: ["python", "manage.py", "housekeeping"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -36,6 +37,7 @@ spec:
             command: ["python", "manage.py", "monitor_missing_outcome_codes"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -56,6 +58,7 @@ spec:
             command: ["python", "manage.py", "mi_cb1_report"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -76,6 +79,7 @@ spec:
             command: ["python", "manage.py", "delete_cases_without_personal_data"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -96,6 +100,7 @@ spec:
             command: ["python", "manage.py", "fix_missing_outcome_codes"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure
 ---
 # Removes all extract reports that were created over two years ago.
@@ -117,4 +122,5 @@ spec:
             command: ["python", "manage.py", "remove_expired_reports"]
             env:
               {{ include "cla-backend.app.vars" . | nindent 12 }}
+          serviceAccountName: {{ include "cla-backend.serviceAccountName" . }}
           restartPolicy: OnFailure


### PR DESCRIPTION
## What does this pull request do?

### [LGA 2821](https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?selectedIssue=LGA-2821)

- Gives all CronJobs a serviceAccountName so they are being executed with permissions to interact with AWS resources such as S3/ RDS

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
