### PR TITLE
LGA 2852 Fix delete unused cases cronjob failing

### DIFF
--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -208,6 +208,12 @@ class DeleteOldData(Task):
         PersonalDetails.contact_for_research_methods.through.objects.filter(
             personaldetails_id__in=pds.values_list("pk", flat=True)
         ).delete()
+
+        # This deletes any DiversityDataCheck entries which have the PersonalDetails ID as a foreign key,
+        # failing to delete these entries first results in an IntegrityError as DiversityDataCheck would contain
+        # a non-existant PersonalDetails foreign key.
+        DiversityDataCheck.objects.filter(personaldetails_id__in=pds.values_list("pk", flat=True)).delete()
+
         self._delete_objects(pds)
 
     def cleanup_adaptation_details(self):

--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -209,7 +209,6 @@ class DeleteOldData(Task):
             personaldetails_id__in=pds.values_list("pk", flat=True)
         ).delete()
 
-
         # This deletes any DiversityDataCheck entries which have the PersonalDetails ID as a foreign key,
         # failing to delete these entries first results in an IntegrityError as DiversityDataCheck would contain
         # a non-existant PersonalDetails foreign key.

--- a/cla_backend/apps/cla_butler/tasks.py
+++ b/cla_backend/apps/cla_butler/tasks.py
@@ -209,10 +209,11 @@ class DeleteOldData(Task):
             personaldetails_id__in=pds.values_list("pk", flat=True)
         ).delete()
 
+
         # This deletes any DiversityDataCheck entries which have the PersonalDetails ID as a foreign key,
         # failing to delete these entries first results in an IntegrityError as DiversityDataCheck would contain
         # a non-existant PersonalDetails foreign key.
-        DiversityDataCheck.objects.filter(personaldetails_id__in=pds.values_list("pk", flat=True)).delete()
+        DiversityDataCheck.objects.filter(personal_details_id__in=pds.values_list("pk", flat=True)).delete()
 
         self._delete_objects(pds)
 

--- a/cla_backend/apps/cla_butler/tests/mommy_recipes.py
+++ b/cla_backend/apps/cla_butler/tests/mommy_recipes.py
@@ -1,6 +1,5 @@
 # coding=utf-8
-from legalaid.tests.mommy_recipes import eod_details
-from model_mommy.recipe import Recipe, foreign_key
+from model_mommy.recipe import Recipe
 
 from ..models import DiversityDataCheck
 

--- a/cla_backend/apps/cla_butler/tests/mommy_recipes.py
+++ b/cla_backend/apps/cla_butler/tests/mommy_recipes.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+from legalaid.tests.mommy_recipes import eod_details
+from model_mommy.recipe import Recipe, foreign_key
+
+from ..models import DiversityDataCheck
+
+
+diversitydatacheck = Recipe(DiversityDataCheck, status='ok', action='check')

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -91,6 +91,31 @@ class TasksTestCase(TestCase):
 
         self.assertEqual(len(EODDetails.objects.all()), 0)
 
+    def test_cleanup_personal_details_delete_diversity_data_check(self):
+        contact_method = make_recipe("legalaid.contact_research_method")
+        pd = make_recipe("legalaid.personal_details")
+
+        make_recipe("cla_butler.diversitydatacheck", personal_details=pd)
+
+        self.assertEqual(len(DiversityDataCheck.objects.all()), 1)
+
+        self.delete_old_data.cleanup_personal_details()
+
+        self.assertEqual(len(DiversityDataCheck.objects.all()), 0)
+
+    def test_cleanup_personal_details_keep_diversity_data_check(self):
+        contact_method = make_recipe("legalaid.contact_research_method")
+        pd = make_recipe("legalaid.personal_details")
+
+        case = make_recipe("legalaid.case", personal_details=pd)
+        make_recipe("cla_butler.diversitydatacheck", personal_details=pd)
+
+        self.assertEqual(len(DiversityDataCheck.objects.all()), 1)
+
+        self.delete_old_data.cleanup_personal_details()
+
+        self.assertEqual(len(DiversityDataCheck.objects.all()), 1)
+
     def test_cleanup_personal_details_no_case_attached_successful(self):
         contact_method = make_recipe("legalaid.contact_research_method")
         make_recipe("legalaid.personal_details", contact_for_research_methods=[contact_method])

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -91,8 +91,8 @@ class TasksTestCase(TestCase):
 
         self.assertEqual(len(EODDetails.objects.all()), 0)
 
+
     def test_cleanup_personal_details_delete_diversity_data_check(self):
-        contact_method = make_recipe("legalaid.contact_research_method")
         pd = make_recipe("legalaid.personal_details")
 
         make_recipe("cla_butler.diversitydatacheck", personal_details=pd)
@@ -104,10 +104,9 @@ class TasksTestCase(TestCase):
         self.assertEqual(len(DiversityDataCheck.objects.all()), 0)
 
     def test_cleanup_personal_details_keep_diversity_data_check(self):
-        contact_method = make_recipe("legalaid.contact_research_method")
         pd = make_recipe("legalaid.personal_details")
 
-        case = make_recipe("legalaid.case", personal_details=pd)
+        make_recipe("legalaid.case", personal_details=pd)
         make_recipe("cla_butler.diversitydatacheck", personal_details=pd)
 
         self.assertEqual(len(DiversityDataCheck.objects.all()), 1)

--- a/cla_backend/apps/cla_butler/tests/test_tasks.py
+++ b/cla_backend/apps/cla_butler/tests/test_tasks.py
@@ -91,7 +91,6 @@ class TasksTestCase(TestCase):
 
         self.assertEqual(len(EODDetails.objects.all()), 0)
 
-
     def test_cleanup_personal_details_delete_diversity_data_check(self):
         pd = make_recipe("legalaid.personal_details")
 


### PR DESCRIPTION
## What does this pull request do?

### [LGA 2852](https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?selectedIssue=LGA-2852)

- Fixes a bug where the the CronJob delete-unused-cases was repeatably failing every day at 5:00 due to
```
django.db.utils.IntegrityError: update or delete on table "legalaid_personaldetails" violates foreign key constraint "x" on table "cla_butler_diversitydatacheck
```
- This fixes the issue by deleting linked `diversity data check` data before removing `personal details`.

## Any other changes that would benefit highlighting?

- Adds unit testing for cases where diversity data should be deleted or not.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
