### PR TITLE
LEP-435 income translator

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -387,6 +387,8 @@ class EligibilityChecker(object):
             request_data.update(translate_property(self.case_data.property_data))
         if hasattr(self.case_data.you, "income") and hasattr(self.case_data.you, "deductions"):
             request_data.update(translate_employment(self.case_data.you.income, self.case_data.you.deductions))
+        if hasattr(self.case_data.you, "income"):
+            request_data.update(translate_income(self.case_data.you.income))
         return request_data
 
     def _legacy_check(self):

--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -7,10 +7,12 @@ from django.utils import timezone
 
 from . import constants
 from . import exceptions
+
 from .cfe_civil.savings import translate_savings
 from .cfe_civil.employment import translate_employment
 from .cfe_civil.cfe_response import CfeResponse
 from .cfe_civil.property import translate_property
+from .cfe_civil.income import translate_income
 
 logger = __import__("logging").getLogger(__name__)
 

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -2,36 +2,26 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_
 
 
 def translate_income(income_data):
-    regular_transactions = []  # pension, maintenance_received, benefits
-
-    if hasattr(income_data, "tax_credits") and income_data.tax_credits > 0:
-        regular_transactions.append(regular_transaction("benefits", income_data.tax_credits))
-
-    if hasattr(income_data, "maintenance_received") and income_data.maintenance_received > 0:
-        regular_transactions.append(regular_transaction("maintenance_in", income_data.maintenance_received))
-
-    if hasattr(income_data, "pension") and income_data.pension > 0:
-        regular_transactions.append(regular_transaction("pension", income_data.pension))
-
-    if hasattr(income_data, "benefits") and income_data.benefits > 0:
-        regular_transactions.append(regular_transaction("benefits", income_data.benefits))
-
-    if hasattr(income_data, "child_benefits") and income_data.child_benefits > 0:
-        regular_transactions.append(regular_transaction("benefits", income_data.child_benefits))
-
-    if hasattr(income_data, "other_income") and income_data.other_income > 0:
-        regular_transactions.append(regular_transaction("friends_or_family", income_data.other_income))
+    regular_transactions = [
+        _regular_transaction("benefits", income_data, "tax_credits"),
+        _regular_transaction("maintenance_in", income_data, "maintenance_received"),
+        _regular_transaction("pension", income_data, "pension"),
+        _regular_transaction("benefits", income_data, "benefits"),
+        _regular_transaction("benefits", income_data, "child_benefits"),
+        _regular_transaction("friends_or_family", income_data, "other_income")
+    ]
 
     value = dict(
-        regular_transactions=regular_transactions
+        regular_transactions=[x for x in regular_transactions if x is not None]
     )
     return value
 
 
-def regular_transaction(category, amount):
-    return {
-        "category": category,
-        "operation": "credit",
-        "frequency": "monthly",
-        "amount": pence_to_pounds(amount),
-    }
+def _regular_transaction(cfe_category, income_data, attr_name):
+    if hasattr(income_data, attr_name) and getattr(income_data, attr_name) > 0:
+        return {
+            "category": cfe_category,
+            "operation": "credit",
+            "frequency": "monthly",
+            "amount": pence_to_pounds(getattr(income_data, attr_name))
+        }

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -1,46 +1,76 @@
+from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds
+
 
 def translate_income(income_data):
-    cash_transactions = {"income": []}   # pension, maintenance_received, benefits
-    employment_income = [{"payments": []}]
-    irregular_incomes = {"payments": []}
-    other_incomes = [{"payments": []}]   # pension, maintenance_received, benefits
-    regular_transactions = []   # pension, maintenance_received, benefits
-    state_benefits = [{"payments": []}]   # benefits
-    employment_details = [{"income": {}}]   # earnings
-    self_employment_details = [{"income": {}}]   # self_employment_drawings
+    regular_transactions = []  # pension, maintenance_received, benefits
 
-    if not(income_data.self_employed) and (income_data.earnings > 0):
+    if not income_data.self_employed and (income_data.earnings > 0):
         print("employment_income, employment_details")
 
     if income_data.self_employed and (income_data.self_employment_drawings > 0):
         print("self_employment_details")
 
-    if income_data.benefits > 0:
-        print("cash_transactions, other_incomes, regular_transactions, state_benefits")
-
     if income_data.tax_credits > 0:
         print("?")
-
-    if income_data.child_benefits > 0:
-        print("?")
+        regular_transactions.append(
+            {
+                "category": "benefits",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.tax_credits),
+            })
 
     if income_data.maintenance_received > 0:
         print("cash_transactions, other_incomes, regular_transactions")
+        regular_transactions.append(
+            {
+                "category": "maintenance_in",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.maintenance_received),
+            })
 
     if income_data.pension > 0:
         print("cash_transactions, other_incomes, regular_transactions")
+        regular_transactions.append(
+            {
+                "category": "pension_contribution",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.pension),
+            })
+
+    if income_data.benefits > 0:
+        print("cash_transactions, other_incomes, regular_transactions, state_benefits")
+        regular_transactions.append(
+            {
+                "category": "benefits",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.benefits),
+            })
+
+    if income_data.child_benefits > 0:
+        print("?")
+        regular_transactions.append(
+            {
+                "category": "child_care",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.child_benefits),
+            })
 
     if income_data.other_income > 0:
         print("?")
+        regular_transactions.append(
+            {
+                "category": "friends_or_family",
+                "operation": "credit",
+                "frequency": "monthly",
+                "amount": pence_to_pounds(income_data.other_income),
+            })
 
     value = dict(
-        cash_transactions=cash_transactions,
-        employment_income=employment_income,
-        irregular_incomes=irregular_incomes,
-        other_incomes=other_incomes,
-        regular_transactions=regular_transactions,
-        state_benefits=state_benefits,
-        employment_details=employment_details,
-        self_employment_details=self_employment_details
+        regular_transactions=regular_transactions
     )
     return value

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -4,14 +4,7 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_
 def translate_income(income_data):
     regular_transactions = []  # pension, maintenance_received, benefits
 
-    if not income_data.self_employed and (income_data.earnings > 0):
-        print("employment_income, employment_details")
-
-    if income_data.self_employed and (income_data.self_employment_drawings > 0):
-        print("self_employment_details")
-
     if income_data.tax_credits > 0:
-        print("?")
         regular_transactions.append(
             {
                 "category": "benefits",
@@ -21,7 +14,6 @@ def translate_income(income_data):
             })
 
     if income_data.maintenance_received > 0:
-        print("cash_transactions, other_incomes, regular_transactions")
         regular_transactions.append(
             {
                 "category": "maintenance_in",
@@ -31,17 +23,15 @@ def translate_income(income_data):
             })
 
     if income_data.pension > 0:
-        print("cash_transactions, other_incomes, regular_transactions")
         regular_transactions.append(
             {
-                "category": "pension_contribution",
+                "category": "pension",
                 "operation": "credit",
                 "frequency": "monthly",
                 "amount": pence_to_pounds(income_data.pension),
             })
 
     if income_data.benefits > 0:
-        print("cash_transactions, other_incomes, regular_transactions, state_benefits")
         regular_transactions.append(
             {
                 "category": "benefits",
@@ -51,17 +41,15 @@ def translate_income(income_data):
             })
 
     if income_data.child_benefits > 0:
-        print("?")
         regular_transactions.append(
             {
-                "category": "child_care",
+                "category": "benefits",
                 "operation": "credit",
                 "frequency": "monthly",
                 "amount": pence_to_pounds(income_data.child_benefits),
             })
 
     if income_data.other_income > 0:
-        print("?")
         regular_transactions.append(
             {
                 "category": "friends_or_family",

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -1,0 +1,46 @@
+
+def translate_income(income_data):
+    cash_transactions = {"income": []} # pension, maintenance_received, benefits
+    employment_income = [{"payments": []}]
+    irregular_incomes = {"payments": []}
+    other_incomes = [{"payments": []}] # pension, maintenance_received, benefits
+    regular_transactions = [] # pension, maintenance_received, benefits
+    state_benefits = [{"payments": []}] # benefits
+    employment_details = [{"income": {}}] # earnings
+    self_employment_details = [{"income": {}}] # self_employment_drawings
+
+    if not(income_data.self_employed) and (income_data.earnings > 0):
+        print("employment_income, employment_details")
+
+    if income_data.self_employed and (income_data.self_employment_drawings > 0):
+        print("self_employment_details")
+
+    if income_data.benefits > 0:
+        print("cash_transactions, other_incomes, regular_transactions, state_benefits")
+
+    if income_data.tax_credits > 0:
+        print("?")
+
+    if income_data.child_benefits > 0:
+        print("?")
+
+    if income_data.maintenance_received > 0:
+        print("cash_transactions, other_incomes, regular_transactions")
+
+    if income_data.pension > 0:
+        print("cash_transactions, other_incomes, regular_transactions")
+
+    if income_data.other_income > 0:
+        print("?")
+
+    value = dict(
+        cash_transactions=cash_transactions,
+        employment_income=employment_income,
+        irregular_incomes=irregular_incomes,
+        other_incomes=other_incomes,
+        regular_transactions=regular_transactions,
+        state_benefits=state_benefits,
+        employment_details=employment_details,
+        self_employment_details=self_employment_details
+    )
+    return value

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -4,22 +4,22 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_
 def translate_income(income_data):
     regular_transactions = []  # pension, maintenance_received, benefits
 
-    if income_data.tax_credits > 0:
+    if hasattr(income_data, "tax_credits") and income_data.tax_credits > 0:
         regular_transactions.append(regular_transaction("benefits", income_data.tax_credits))
 
-    if income_data.maintenance_received > 0:
+    if hasattr(income_data, "maintenance_received") and income_data.maintenance_received > 0:
         regular_transactions.append(regular_transaction("maintenance_in", income_data.maintenance_received))
 
-    if income_data.pension > 0:
+    if hasattr(income_data, "pension") and income_data.pension > 0:
         regular_transactions.append(regular_transaction("pension", income_data.pension))
 
-    if income_data.benefits > 0:
+    if hasattr(income_data, "benefits") and income_data.benefits > 0:
         regular_transactions.append(regular_transaction("benefits", income_data.benefits))
 
-    if income_data.child_benefits > 0:
+    if hasattr(income_data, "child_benefits") and income_data.child_benefits > 0:
         regular_transactions.append(regular_transaction("benefits", income_data.child_benefits))
 
-    if income_data.other_income > 0:
+    if hasattr(income_data, "other_income") and income_data.other_income > 0:
         regular_transactions.append(regular_transaction("friends_or_family", income_data.other_income))
 
     value = dict(

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -5,60 +5,33 @@ def translate_income(income_data):
     regular_transactions = []  # pension, maintenance_received, benefits
 
     if income_data.tax_credits > 0:
-        regular_transactions.append(
-            {
-                "category": "benefits",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.tax_credits),
-            })
+        regular_transactions.append(regular_transaction("benefits", income_data.tax_credits))
 
     if income_data.maintenance_received > 0:
-        regular_transactions.append(
-            {
-                "category": "maintenance_in",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.maintenance_received),
-            })
+        regular_transactions.append(regular_transaction("maintenance_in", income_data.maintenance_received))
 
     if income_data.pension > 0:
-        regular_transactions.append(
-            {
-                "category": "pension",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.pension),
-            })
+        regular_transactions.append(regular_transaction("pension", income_data.pension))
 
     if income_data.benefits > 0:
-        regular_transactions.append(
-            {
-                "category": "benefits",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.benefits),
-            })
+        regular_transactions.append(regular_transaction("benefits", income_data.benefits))
 
     if income_data.child_benefits > 0:
-        regular_transactions.append(
-            {
-                "category": "benefits",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.child_benefits),
-            })
+        regular_transactions.append(regular_transaction("benefits", income_data.child_benefits))
 
     if income_data.other_income > 0:
-        regular_transactions.append(
-            {
-                "category": "friends_or_family",
-                "operation": "credit",
-                "frequency": "monthly",
-                "amount": pence_to_pounds(income_data.other_income),
-            })
+        regular_transactions.append(regular_transaction("friends_or_family", income_data.other_income))
 
     value = dict(
         regular_transactions=regular_transactions
     )
     return value
+
+
+def regular_transaction(category, amount):
+    return {
+        "category": category,
+        "operation": "credit",
+        "frequency": "monthly",
+        "amount": pence_to_pounds(amount),
+    }

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -1,13 +1,13 @@
 
 def translate_income(income_data):
-    cash_transactions = {"income": []} # pension, maintenance_received, benefits
+    cash_transactions = {"income": []}   # pension, maintenance_received, benefits
     employment_income = [{"payments": []}]
     irregular_incomes = {"payments": []}
-    other_incomes = [{"payments": []}] # pension, maintenance_received, benefits
-    regular_transactions = [] # pension, maintenance_received, benefits
-    state_benefits = [{"payments": []}] # benefits
-    employment_details = [{"income": {}}] # earnings
-    self_employment_details = [{"income": {}}] # self_employment_drawings
+    other_incomes = [{"payments": []}]   # pension, maintenance_received, benefits
+    regular_transactions = []   # pension, maintenance_received, benefits
+    state_benefits = [{"payments": []}]   # benefits
+    employment_details = [{"income": {}}]   # earnings
+    self_employment_details = [{"income": {}}]   # self_employment_drawings
 
     if not(income_data.self_employed) and (income_data.earnings > 0):
         print("employment_income, employment_details")

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -6,7 +6,7 @@ from cla_backend.libs.eligibility_calculator.models import Income
 
 class TestTranslateIncome(TestCase):
     def test_assets(self):
-        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0, maintenance_received=0,pension=0, other_income=0, self_employed=True )
+        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0, maintenance_received=0, pension=0, other_income=0, self_employed=True)
         output = translate_income(income)
         expected = {
             "cash_transactions": {

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from cla_backend.libs.eligibility_calculator.cfe_civil.income import translate_income
+from cla_backend.libs.eligibility_calculator.models import Income
+
+
+class TestTranslateIncome(TestCase):
+    def test_assets(self):
+        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0, maintenance_received=0,pension=0, other_income=0, self_employed=True )
+        output = translate_income(income)
+        expected = {
+            "cash_transactions": {
+                "income": []
+            },
+            "employment_income": [
+                {
+                    "payments": []
+                }
+            ],
+            "irregular_incomes": {
+                "payments": []
+            },
+            "other_incomes": [
+                {
+                    "payments": []
+                }
+            ],
+            "regular_transactions": [],
+            "state_benefits": [
+                {
+                    "payments": []
+                }
+            ],
+            "employment_details": [
+                {
+                    "income": {}
+                }
+            ],
+            "self_employment_details": [
+                {
+                    "income": {}
+                }
+            ]
+        }
+        self.assertEqual(expected, output)

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -7,40 +7,22 @@ from cla_backend.libs.eligibility_calculator.models import Income
 class TestTranslateIncome(TestCase):
     def test_assets(self):
         income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0,
-                        maintenance_received=0, pension=0, other_income=0, self_employed=True)
+                        maintenance_received=10000, pension=0, other_income=0, self_employed=True)
         output = translate_income(income)
         expected = {
-            "cash_transactions": {
-                "income": []
-            },
-            "employment_income": [
+            "regular_transactions": [
                 {
-                    "payments": []
+                    "category": "maintenance_in",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 100,
+                },
+                {
+                    "category": "benefits",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 800,
                 }
             ],
-            "irregular_incomes": {
-                "payments": []
-            },
-            "other_incomes": [
-                {
-                    "payments": []
-                }
-            ],
-            "regular_transactions": [],
-            "state_benefits": [
-                {
-                    "payments": []
-                }
-            ],
-            "employment_details": [
-                {
-                    "income": {}
-                }
-            ],
-            "self_employment_details": [
-                {
-                    "income": {}
-                }
-            ]
         }
         self.assertEqual(expected, output)

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -5,18 +5,58 @@ from cla_backend.libs.eligibility_calculator.models import Income
 
 
 class TestTranslateIncome(TestCase):
-    def test_assets(self):
-        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0,
-                        maintenance_received=10000, pension=0, other_income=0, self_employed=True)
+    def test_fully_populated_income_produces_valid_cfe_request(self):
+        income = Income(benefits=80000, tax_credits=100, child_benefits=200,
+                        maintenance_received=10000, pension=400, other_income=300)
         output = translate_income(income)
         expected = {
             "regular_transactions": [
+                {
+                    "category": "benefits",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 1.0,
+                },
                 {
                     "category": "maintenance_in",
                     "operation": "credit",
                     "frequency": "monthly",
                     "amount": 100,
                 },
+                {
+                    "category": "pension",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 4.0,
+                },
+                {
+                    "category": "benefits",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 800,
+                },
+                {
+                    "category": "benefits",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 2.0,
+                },
+                {
+                    "category": "friends_or_family",
+                    "operation": "credit",
+                    "frequency": "monthly",
+                    "amount": 3.0,
+                }
+            ],
+        }
+        self.assertEqual(expected, output)
+
+    def test_minimal_income_produces_single_cfe_value(self):
+        income = Income(benefits=80000, tax_credits=0, child_benefits=0,
+                        maintenance_received=0, pension=0, other_income=0)
+        output = translate_income(income)
+        expected = {
+            "regular_transactions": [
                 {
                     "category": "benefits",
                     "operation": "credit",

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -6,7 +6,8 @@ from cla_backend.libs.eligibility_calculator.models import Income
 
 class TestTranslateIncome(TestCase):
     def test_assets(self):
-        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0, maintenance_received=0, pension=0, other_income=0, self_employed=True)
+        income = Income(earnings=0, self_employment_drawings=0, benefits=80000, tax_credits=0, child_benefits=0,
+                        maintenance_received=0, pension=0, other_income=0, self_employed=True)
         output = translate_income(income)
         expected = {
             "cash_transactions": {

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -1828,7 +1828,15 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
     def checker_with_income(self, income, tax, ni=600, self_employed=False):
         cd = fixtures.get_default_case_data()
         cd['you'].update({
-            'income': dict(earnings=income, self_employed=self_employed),
+            'income': dict(earnings=income,
+                           self_employed=self_employed,
+                           maintenance_received=0,
+                           child_benefits=0,
+                           tax_credits=0,
+                           pension=0,
+                           benefits=0,
+                           other_income=0
+                           ),
             'deductions': dict(income_tax=tax, national_insurance=ni)
         })
         case_data = CaseData(**cd)
@@ -1839,9 +1847,9 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
         cd['you'].update({
             'income': dict(
                 earnings=earnings,
+                self_employed=self_employed,
                 maintenance_received=maintenance_received,
                 child_benefits=child_benefits,
-                self_employed=self_employed,
                 tax_credits=tax_credits,
                 pension=pension,
                 benefits=benefits,

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -1834,6 +1834,23 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
         case_data = CaseData(**cd)
         return EligibilityChecker(case_data=case_data)
 
+    def checker_with_income_without_earnings(self, maintenance_received, child_benefits, earnings=0, self_employed=False, tax_credits=0, pension=0, benefits=0, other_income=0):
+        cd = fixtures.get_default_case_data()
+        cd['you'].update({
+            'income': dict(
+                earnings=earnings,
+                maintenance_received=maintenance_received,
+                child_benefits=child_benefits,
+                self_employed=self_employed,
+                tax_credits=tax_credits,
+                pension=pension,
+                benefits=benefits,
+                other_income=other_income
+            )
+        })
+        case_data = CaseData(**cd)
+        return EligibilityChecker(case_data=case_data)
+
     def test_cfe_request_with_small_gross_income(self):
         # income is in pence
         cfe_result = self.checker_with_income(10000, 100)._do_cfe_civil_check()
@@ -1845,4 +1862,8 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
 
     def test_cfe_request_with_large_gross_income(self):
         cfe_result = self.checker_with_income(1000000, 500)._do_cfe_civil_check()
+        self.assertEqual('ineligible', cfe_result.overall_result())
+
+    def test_cfe_request_with_income_without_earnings(self):
+        cfe_result = self.checker_with_income_without_earnings(1000000, 500)._do_cfe_civil_check()
         self.assertEqual('ineligible', cfe_result.overall_result())

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -1873,9 +1873,12 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
         self.assertEqual('ineligible', cfe_result.overall_result())
 
     def test_cfe_request_with_small_income_without_earnings(self):
-        cfe_result = self.checker_with_income_without_earnings(10000, 500)._do_cfe_civil_check()
+        cfe_result = self.checker_with_income_without_earnings(maintenance_received=10000,
+                                                               child_benefits=500)._do_cfe_civil_check()
         self.assertEqual('eligible', cfe_result.overall_result())
 
     def test_cfe_request_with_large_income_without_earnings(self):
-        cfe_result = self.checker_with_income_without_earnings(10000, 500, 10000, False, 10000, 10000, 10000, 100000)._do_cfe_civil_check()
+        cfe_result = self.checker_with_income_without_earnings(maintenance_received=10000, child_benefits=500,
+                                                               earnings=10000,
+                                                               other_income=100000)._do_cfe_civil_check()
         self.assertEqual('ineligible', cfe_result.overall_result())

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -1872,6 +1872,10 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
         cfe_result = self.checker_with_income(1000000, 500)._do_cfe_civil_check()
         self.assertEqual('ineligible', cfe_result.overall_result())
 
-    def test_cfe_request_with_income_without_earnings(self):
-        cfe_result = self.checker_with_income_without_earnings(1000000, 500)._do_cfe_civil_check()
+    def test_cfe_request_with_small_income_without_earnings(self):
+        cfe_result = self.checker_with_income_without_earnings(10000, 500)._do_cfe_civil_check()
+        self.assertEqual('eligible', cfe_result.overall_result())
+
+    def test_cfe_request_with_large_income_without_earnings(self):
+        cfe_result = self.checker_with_income_without_earnings(10000, 500, 10000, False, 10000, 10000, 10000, 100000)._do_cfe_civil_check()
         self.assertEqual('ineligible', cfe_result.overall_result())


### PR DESCRIPTION
## What does this pull request do?

Translate income without earnings(earnings, self_employment_drawings) into cfe-civil `regular_transactions`
JIRA: https://dsdmoj.atlassian.net/browse/LEP-435

```json
{
  "you": {
    "income": {
      #"earnings": 100000,
      "tax_credits": 0,
      "maintenance_received": 0,
      "pension": 0,
      #"self_employment_drawings": 0,
      "benefits": 0,
      #"self_employed": false,
      "child_benefits": 0,
      "other_income": 0
    }
  }
}
```

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
