### PR TITLE
Suppress INFO logging during tests

### DIFF
--- a/cla_backend/settings/circle.py
+++ b/cla_backend/settings/circle.py
@@ -1,5 +1,6 @@
 import os
 from .testing import *
+from .testing import LOGGING
 
 ADMINS = (("CLA", "cla-alerts@digital.justice.gov.uk"),)
 
@@ -17,3 +18,5 @@ DATABASES = {
 }
 
 TEST_OUTPUT_DIR = "test-reports"
+
+LOGGING['handlers']['console']['level'] = 'WARN'


### PR DESCRIPTION
 e.g. if you do:

        python manage.py test --settings=cla_backend.settings.circle cla_backend.libs.eligibility_calculator.tests.test_calculator.DoCfeCivilCheckTestCase
