### PR TITLE
LGA-2905 - Fix flaky test_search_find_multiple_results_by_person_name unit test

### DIFF
--- a/cla_backend/apps/complaints/tests/test_complaints_api.py
+++ b/cla_backend/apps/complaints/tests/test_complaints_api.py
@@ -114,6 +114,9 @@ class SearchComplaintTestCase(
         self.assertEqual(response.data["results"][0]["case_reference"], "ref2")
 
     def test_search_find_multiple_results_by_person_name(self):
+        # remove the complaint that is created by the mixin as we don't need it
+        self.resource.delete()
+
         # """
         # GET search by name should work
         # """


### PR DESCRIPTION
## What does this pull request do?

Fix flaky test_search_find_multiple_results_by_person_name unit test by removing default resource

## Any other changes that would benefit highlighting?

It has been reported that the `complaints.tests.test_complaints_api.SearchComplaintTestCase.test_search_find_multiple_results_by_person_name` unit tests sometimes fails due to 3 results being returned when only 2 results are expected.

In the setUp of `SearchComplaintTestCase`  , 3 complaints are created, but only 2 of those cases have a personal_details field which contain the searched text `abc

However the `SearchComplaintTestCase` classes uses the mixin `SimpleResourceAPIMixin`
And `SimpleResourceAPIMixin` creates a Complaint object(which needs a case and a case creates a personal_details object which it needs)

The fields for the resource created by `SimpleResourceAPIMixin` have all random values (i think) so  there is a possibility that a field will contain the searched text of `abc`

I think someone had already came across this issue in another test and deleted the resource created by SimpleResourceAPIMixin  at the start of their test [https://github.com/ministryofjustice/cla_backend/blob/783f80d3521193435f7a9ea9f601[…]57951a/cla_backend/apps/complaints/tests/test_complaints_api.py](https://github.com/ministryofjustice/cla_backend/blob/783f80d3521193435f7a9ea9f601f3628357951a/cla_backend/apps/complaints/tests/test_complaints_api.py#L96)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
