### PR TITLE
Logging improved - including CaseData

### DIFF
--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import datetime
 import re
@@ -422,6 +423,8 @@ class EligibilityCheck(TimeStampedModel, ValidateModelMixin):
         that we don't have enough data to determine the state so we set the
         `state` property to UNKNOWN.
         """
+        case_data = self.to_case_data()
+        logger.debug('CaseData %s' % json.dumps(case_data.to_dict(), indent=4, sort_keys=True))
         ec = EligibilityChecker(self.to_case_data())
 
         try:

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -36,6 +36,8 @@ from .models import (
     ContactResearchMethod,
 )
 
+logger = __import__("logging").getLogger(__name__)
+
 
 class CategorySerializerBase(serializers.HyperlinkedModelSerializer):
     class Meta(object):
@@ -337,6 +339,7 @@ class EligibilityCheckSerializerBase(ClaModelSerializer):
         # need to check the category before saving the current instance
         has_category_changed = self.__has_category_changed()
         obj = super(EligibilityCheckSerializerBase, self).save(**kwargs)
+        logger.info("Eligibility check - save form %s" % kwargs)
         obj.update_state()
         if has_category_changed:
             # if the category has been updated then reset mattertype on

--- a/cla_backend/libs/eligibility_calculator/models.py
+++ b/cla_backend/libs/eligibility_calculator/models.py
@@ -129,6 +129,26 @@ class CaseData(ModelMixin, object):
         "disputed_savings": Savings,
     }
 
+    def to_dict(self):
+        from django.db.models.query import ValuesQuerySet
+
+        def dump_object(obj):
+            props = {}
+            for key in obj.PROPERTY_META.keys():
+                try:
+                    value = getattr(obj, key)
+                except Exception:
+                    value = None
+                if isinstance(value, ModelMixin):
+                    value = dump_object(value)
+                elif isinstance(value, ValuesQuerySet):
+                    value = list(value)
+                props[key] = value
+            return props
+
+        data = dump_object(self)
+        return data
+
     @property
     def non_disputed_liquid_capital(self):
         # total capital not including properties


### PR DESCRIPTION
Adds logging of:
* CaseData
* Exceptions raised by legacy_check()

Logging of the big dictionaries is rather verbose for normal use, so these are demoted to DEBUG level. These can be displayed if you change the log_level, but for local development it's easiest to just temporarily change the log statements to `logger.info(`...