### PR TITLE
Submission date is today

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -361,9 +361,10 @@ class EligibilityChecker(object):
 
         return result, cfe_response
 
-    def _translate_case(self):
+    def _translate_case(self, submission_date=None):
         '''Translates CLA's CaseData to CFE-Civil request JSON'''
-        submission_date = datetime.date(2022, 5, 19)
+        if not submission_date:
+            submission_date = datetime.date.today()
         # produce the simplest possible plain request to CFE to prove the route
         request_data = {
             "assessment": {


### PR DESCRIPTION
Previously the date was hard-coded.

The correct date for the calculation would be the day of application, but CLA might be days or weeks in the future. Today seems a reasonable date to choose.

At some point we'll have tests of this function, so I've provided an optional param to fix the date to a known one.