### PR TITLE
Fix savings translator for empty input

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/conversions.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/conversions.py
@@ -4,7 +4,3 @@ from decimal import Decimal
 def pence_to_pounds(pence):
     decimal_value = (Decimal(pence) / 100).quantize(Decimal(".01"))
     return float(decimal_value)
-
-
-def none_filter(array):
-    return [x for x in array if x is not None]

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
@@ -7,12 +7,14 @@ from cla_backend.libs.eligibility_calculator.models import Savings
 class TestTranslateSavings(TestCase):
     def test_bank_balance_and_investments(self):
         savings = Savings(bank_balance=270010, investment_balance=100010, asset_balance=0)
+
         output = translate_savings(savings)
+
         expected = {"capitals": {
             "bank_accounts": [
                 {
                     "value": 2700.10,
-                    "description": "Savings",
+                    "description": "Bank balance",
                     "subject_matter_of_dispute": False
                 },
                 {
@@ -21,21 +23,31 @@ class TestTranslateSavings(TestCase):
                     "subject_matter_of_dispute": False
                 },
             ],
-            "non_liquid_capital": [],
         }}
         self.assertEqual(expected, output)
 
     def test_assets(self):
         savings = Savings(bank_balance=0, investment_balance=0, asset_balance=80011)
+
         output = translate_savings(savings)
-        expected = {"capitals": {
-            "bank_accounts": [],
-            "non_liquid_capital": [
-                {
-                    "value": 800.11,
-                    "description": "Asset",
-                    "subject_matter_of_dispute": False
-                },
-            ]
-        }}
+
+        expected = {
+            "capitals": {
+                "non_liquid_capital": [
+                    {
+                        "value": 800.11,
+                        "description": "Asset",
+                        "subject_matter_of_dispute": False
+                    },
+                ]
+            }
+        }
+        self.assertEqual(expected, output)
+
+    def test_empty_savings(self):
+        savings = Savings()
+
+        output = translate_savings(savings)
+
+        expected = {}
         self.assertEqual(expected, output)


### PR DESCRIPTION
Fix for bug in the savings translator - you get exception when sending an empty input: `translate_savings(Savings())`

To reproduce: on the /about page you say you have savings, and on pressing "Continue" it complains:
`PropertyExpectedException: 'Savings' requires attribute 'bank_balance' and was not given at __init__`

As discussed: https://mojdt.slack.com/archives/C04AW468PU4/p1702658658739109

Also this doesn't add empty sections to CFE's request. I think it is clearer. It will throw a spanner into the works of this though: https://github.com/ministryofjustice/cla_backend/pull/1047#discussion_r1428135677