### PR TITLE
LEP-456 make 'data complete' check more explicit

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/capital.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/capital.py
@@ -1,0 +1,34 @@
+from cla_backend.libs.eligibility_calculator.cfe_civil.property import PropertyTranslator
+from cla_backend.libs.eligibility_calculator.cfe_civil.savings import SavingsTranslator
+
+
+class CapitalTranslator(object):
+    def __init__(self, case_data, person):
+        self._case_data = case_data
+        self._person = person
+
+    def is_complete(self):
+        return self._is_savings_complete() and self._is_property_complete()
+
+    def _is_savings_complete(self):
+        return self._person is not None and hasattr(self._person, "savings") and self._savings_translator.is_complete()
+
+    def _is_property_complete(self):
+        return hasattr(self._case_data, "property_data") and self._property_translator.is_complete()
+
+    @property
+    def _savings_translator(self):
+        return SavingsTranslator(self._person.savings)
+
+    @property
+    def _property_translator(self):
+        return PropertyTranslator(self._case_data.property_data)
+
+    def translate(self):
+        request_data = {}
+        if self._is_savings_complete():
+            request_data.update(self._savings_translator.translate())
+
+        if self._is_property_complete():
+            request_data.update(self._property_translator.translate())
+        return request_data

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/deductions.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/deductions.py
@@ -1,4 +1,4 @@
-from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds
+from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds, has_all_attributes
 
 _OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION = {
     "maintenance": "maintenance_out",
@@ -9,22 +9,26 @@ _OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION = {
 }
 
 
-def translate_deductions(deductions):
-    regular_transactions = []
+class DeductionsTranslator(object):
+    def __init__(self, deductions):
+        self._deductions = deductions
 
-    for outgoing_category, cfe_category in _OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION.items():
-        if hasattr(deductions, outgoing_category):
-            amount_pence = getattr(deductions, outgoing_category)
-            if amount_pence:
-                regular_transactions.append(
-                    {
-                        "category": cfe_category,
-                        "operation": "debit",
-                        "frequency": "monthly",
-                        "amount": pence_to_pounds(amount_pence)
-                    }
-                )
-    if len(regular_transactions) != len(_OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION):
-        return {}
-    else:
+    def is_complete(self):
+        return has_all_attributes(self._deductions, _OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION.keys())
+
+    def translate(self):
+        regular_transactions = []
+
+        for outgoing_category, cfe_category in _OUTGOING_CATEGORY_TO_REGULAR_TRANSACTION.items():
+            if hasattr(self._deductions, outgoing_category):
+                amount_pence = getattr(self._deductions, outgoing_category)
+                if amount_pence:
+                    regular_transactions.append(
+                        {
+                            "category": cfe_category,
+                            "operation": "debit",
+                            "frequency": "monthly",
+                            "amount": pence_to_pounds(amount_pence)
+                        }
+                    )
         return {"regular_transactions": regular_transactions}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
@@ -24,14 +24,17 @@ _EMPLOYMENT_KEY = "employment_details"
 _SELF_EMPLOYMENT_KEY = "self_employment_details"
 
 
-def has_employment_key(dict):
-    return _EMPLOYMENT_KEY in dict or _SELF_EMPLOYMENT_KEY in dict
+class EmploymentTranslator(object):
+    def __init__(self, income, deductions):
+        self._income = income
+        self._deductions = deductions
 
+    def is_complete(self):
+        return _all_income_fields(self._income) and _all_deductions_fields(self._deductions)
 
-def translate_employment(income, deductions):
-    if _all_income_fields(income) and _all_deductions_fields(deductions):
-        fields = _common_income_fields(income, deductions)
-        if income.self_employed:
+    def translate(self):
+        fields = _common_income_fields(self._income, self._deductions)
+        if self._income.self_employed:
             return {
                 _SELF_EMPLOYMENT_KEY: [
                     {
@@ -51,5 +54,3 @@ def translate_employment(income, deductions):
                     }
                 ]
             }
-    else:
-        return {}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/gross_income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/gross_income.py
@@ -1,0 +1,37 @@
+
+from cla_backend.libs.eligibility_calculator.cfe_civil.employment import EmploymentTranslator
+from cla_backend.libs.eligibility_calculator.cfe_civil.income import NonEmploymentIncomeTranslator
+
+
+class GrossIncomeTranslator(object):
+    def __init__(self, person):
+        self._person = person
+
+    def is_complete(self):
+        return self._is_employment_complete() and self.is_non_employment_complete()
+
+    def _is_employment_complete(self):
+        return hasattr(self._person, "income") and hasattr(self._person,
+                                                           "deductions") and self._employment_translator.is_complete()
+
+    def is_non_employment_complete(self):
+        return hasattr(self._person, "income") and self._other_income_translator.is_complete()
+
+    @property
+    def _employment_translator(self):
+        return EmploymentTranslator(self._person.income, self._person.deductions)
+
+    @property
+    def _other_income_translator(self):
+        return NonEmploymentIncomeTranslator(self._person.income)
+
+    def translate(self):
+        request_data = {}
+
+        if self._is_employment_complete():
+            request_data.update(self._employment_translator.translate())
+
+        if self.is_non_employment_complete():
+            request_data.update(self._other_income_translator.translate())
+
+        return request_data

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -1,7 +1,6 @@
-from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds
+from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds, has_all_attributes
 
-
-INCOME_CATEGORY_TO_REGULAR_TRANSACTION = {
+_INCOME_CATEGORY_TO_REGULAR_TRANSACTION = {
     "tax_credits": "benefits",
     "maintenance_received": "maintenance_in",
     "pension": "pension",
@@ -13,25 +12,26 @@ INCOME_CATEGORY_TO_REGULAR_TRANSACTION = {
 _CFE_INCOME_KEY = "regular_transactions"
 
 
-def has_income_key(dict):
-    return _CFE_INCOME_KEY in dict
+class NonEmploymentIncomeTranslator(object):
+    def __init__(self, income_data):
+        self._income_data = income_data
 
+    def is_complete(self):
+        return has_all_attributes(self._income_data, _INCOME_CATEGORY_TO_REGULAR_TRANSACTION.keys())
 
-def translate_income(income_data):
-    regular_transactions = []
+    def translate(self):
+        regular_transactions = []
 
-    for income_category in INCOME_CATEGORY_TO_REGULAR_TRANSACTION:
-        if hasattr(income_data, income_category):
-            amount_pence = getattr(income_data, income_category)
-            regular_transactions.append(
-                {
-                    "category": INCOME_CATEGORY_TO_REGULAR_TRANSACTION[income_category],
-                    "operation": "credit",
-                    "frequency": "monthly",
-                    "amount": pence_to_pounds(amount_pence)
-                }
-            )
-    non_zero_transactions = [x for x in regular_transactions if x['amount'] > 0]
-    # All attributes need to be present, otherwise value isn't valid
-    return {_CFE_INCOME_KEY: non_zero_transactions} if len(regular_transactions) == len(
-        INCOME_CATEGORY_TO_REGULAR_TRANSACTION) else {}
+        for income_category, cfe_category in _INCOME_CATEGORY_TO_REGULAR_TRANSACTION.items():
+            if hasattr(self._income_data, income_category):
+                amount_pence = getattr(self._income_data, income_category)
+                regular_transactions.append(
+                    {
+                        "category": cfe_category,
+                        "operation": "credit",
+                        "frequency": "monthly",
+                        "amount": pence_to_pounds(amount_pence)
+                    }
+                )
+        non_zero_transactions = [x for x in regular_transactions if x['amount'] > 0]
+        return {_CFE_INCOME_KEY: non_zero_transactions}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
@@ -22,35 +22,36 @@ def _valid_house(house_data):
 _CFE_PROPERTY_KEY = "properties"
 
 
-def has_property_key(dict):
-    return _CFE_PROPERTY_KEY in dict
+class PropertyTranslator(object):
+    def __init__(self, possible_property_data):
+        self._possible_property_data = possible_property_data
+        self._property_data = [house for house in self._possible_property_data if _valid_house(house)]
 
+    def is_complete(self):
+        return len(self._possible_property_data) == len(self._property_data)
 
-def translate_property(possible_property_data):
-    property_data = [house for house in possible_property_data if _valid_house(house)]
-    main_homes = [x for x in property_data if x['main']]
-    non_mains = [x for x in property_data if not x['main']]
-    if (len(main_homes) > 0):
-        main_home_data = main_homes[0]
-        main_home = _convert_house(main_home_data)
-        # all main homes after the first are additional properties
-        non_mains = non_mains + main_homes[1:]
-    else:
-        main_home = None
-    additional_houses = map(_convert_house, non_mains)
+    def translate(self):
+        main_homes = [x for x in self._property_data if x['main']]
+        non_mains = [x for x in self._property_data if not x['main']]
+        if (len(main_homes) > 0):
+            main_home_data = main_homes[0]
+            main_home = _convert_house(main_home_data)
+            # all main homes after the first are additional properties
+            non_mains = non_mains + main_homes[1:]
+        else:
+            main_home = None
+        additional_houses = map(_convert_house, non_mains)
 
-    if main_home:
-        return {
-            _CFE_PROPERTY_KEY: {
-                "main_home": main_home,
-                "additional_properties": additional_houses
+        if main_home:
+            return {
+                _CFE_PROPERTY_KEY: {
+                    "main_home": main_home,
+                    "additional_properties": additional_houses
+                }
             }
-        }
-    elif len(possible_property_data) == len(property_data):
-        return {
-            _CFE_PROPERTY_KEY: {
-                "additional_properties": additional_houses
+        else:
+            return {
+                _CFE_PROPERTY_KEY: {
+                    "additional_properties": additional_houses
+                }
             }
-        }
-    else:
-        return {}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
@@ -11,28 +11,25 @@ def _savings_value(value, description):
         }
 
 
-_CFE_SAVINGS_KEY = "capitals"
+class SavingsTranslator(object):
+    def __init__(self, savings_data):
+        self._savings_data = savings_data
 
+    def is_complete(self):
+        return has_all_attributes(self._savings_data, ["bank_balance", "investment_balance", "asset_balance"])
 
-def has_savings_key(request_data):
-    return _CFE_SAVINGS_KEY in request_data
-
-
-def translate_savings(savings_data):
-    if has_all_attributes(savings_data, ["bank_balance", "investment_balance", "asset_balance"]):
+    def translate(self):
         liquid_capital = [
-            _savings_value(savings_data.bank_balance, "Savings"),
-            _savings_value(savings_data.investment_balance, "Investment")
+            _savings_value(self._savings_data.bank_balance, "Savings"),
+            _savings_value(self._savings_data.investment_balance, "Investment")
         ]
         non_liquid_capital = [
-            _savings_value(savings_data.asset_balance, "Valuable items worth over 500 pounds")
+            _savings_value(self._savings_data.asset_balance, "Valuable items worth over 500 pounds")
         ]
 
         return {
-            _CFE_SAVINGS_KEY: {
+            "capitals": {
                 "bank_accounts": none_filter(liquid_capital),
                 "non_liquid_capital": none_filter(non_liquid_capital)
             }
         }
-    else:
-        return {}

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_deductions.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_deductions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cla_backend.libs.eligibility_calculator.cfe_civil.deductions import translate_deductions
+from cla_backend.libs.eligibility_calculator.cfe_civil.deductions import DeductionsTranslator
 from cla_backend.libs.eligibility_calculator.models import Deductions
 
 
@@ -42,9 +42,13 @@ class TestTranslateDeductions(TestCase):
         }
         deductions = Deductions(maintenance=4545, childcare=3737, mortgage=4242, rent=5757,
                                 criminal_legalaid_contributions=2424)
+        translator = DeductionsTranslator(deductions)
+
+        self.assertTrue(translator.is_complete())
         # assert list equality w/o respect to ordering
-        self.assertEqual(set(expected), set(translate_deductions(deductions)))
+        self.assertEqual(set(expected), set(translator.translate()))
 
     def test_missing_field_gives_no_outgoings(self):
         deductions = Deductions(maintenance=4545, childcare=3737, mortgage=4242, rent=5757)
-        self.assertEqual({}, translate_deductions(deductions))
+        translator = DeductionsTranslator(deductions)
+        self.assertFalse(translator.is_complete())

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cla_backend.libs.eligibility_calculator.cfe_civil.employment import translate_employment
+from cla_backend.libs.eligibility_calculator.cfe_civil.employment import EmploymentTranslator
 from cla_backend.libs.eligibility_calculator.models import Income, Deductions
 
 
@@ -8,7 +8,7 @@ class TestCfeIncome(TestCase):
     def test_employment(self):
         income = Income(earnings=250000, self_employed=False)
         deductions = Deductions(income_tax=40000, national_insurance=6500)
-        output = translate_employment(income, deductions)
+        translator = EmploymentTranslator(income, deductions)
         expected = {
             "employment_details": [
                 {
@@ -25,12 +25,13 @@ class TestCfeIncome(TestCase):
                 }
             ],
         }
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_self_employment(self):
         income = Income(earnings=250000, self_employed=True)
         deductions = Deductions(income_tax=40000, national_insurance=6500)
-        output = translate_employment(income, deductions)
+        translator = EmploymentTranslator(income, deductions)
         expected = {
             "self_employment_details": [
                 {
@@ -45,4 +46,5 @@ class TestCfeIncome(TestCase):
                 }
             ],
         }
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cla_backend.libs.eligibility_calculator.cfe_civil.income import translate_income
+from cla_backend.libs.eligibility_calculator.cfe_civil.income import NonEmploymentIncomeTranslator
 from cla_backend.libs.eligibility_calculator.models import Income
 
 
@@ -9,7 +9,7 @@ class TestTranslateIncome(TestCase):
         income = Income(benefits=80000, tax_credits=100, child_benefits=200,
                         maintenance_received=10000, pension=400, other_income=300)
 
-        output = translate_income(income)
+        translator = NonEmploymentIncomeTranslator(income)
 
         expected = {
             "regular_transactions": [
@@ -51,14 +51,14 @@ class TestTranslateIncome(TestCase):
                 },
             ]
         }
-        self.maxDiff = None
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_minimal_income_produces_single_cfe_value(self):
         income = Income(benefits=80000, tax_credits=0, child_benefits=0,
                         maintenance_received=0, pension=0, other_income=0)
 
-        output = translate_income(income)
+        translator = NonEmploymentIncomeTranslator(income)
 
         expected = {
             "regular_transactions": [
@@ -70,13 +70,15 @@ class TestTranslateIncome(TestCase):
                 }
             ],
         }
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_zero_income_produces_empty_cfe_array(self):
         income = Income(benefits=0, tax_credits=0, child_benefits=0,
                         maintenance_received=0, pension=0, other_income=0)
-        output = translate_income(income)
+        translator = NonEmploymentIncomeTranslator(income)
         expected = {
             "regular_transactions": [],
         }
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_property.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_property.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cla_backend.libs.eligibility_calculator.cfe_civil.property import translate_property
+from cla_backend.libs.eligibility_calculator.cfe_civil.property import PropertyTranslator
 
 
 class TestTranslateProperty(TestCase):
@@ -19,7 +19,7 @@ class TestTranslateProperty(TestCase):
              }
         ]
 
-        output = translate_property(houses)
+        translator = PropertyTranslator(houses)
         expected = {"properties": {
             "main_home": {
                 "value": 100000,
@@ -38,7 +38,8 @@ class TestTranslateProperty(TestCase):
                 }
             ]
         }}
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_properties_no_main_home(self):
         houses = [
@@ -50,7 +51,7 @@ class TestTranslateProperty(TestCase):
              }
         ]
 
-        output = translate_property(houses)
+        translator = PropertyTranslator(houses)
         expected = {"properties": {
             "additional_properties": [
                 {
@@ -62,11 +63,12 @@ class TestTranslateProperty(TestCase):
                 }
             ]
         }}
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_invalid_property_returns_no_results(self):
         houses = [{}]
-        self.assertEqual({}, translate_property(houses))
+        self.assertFalse(PropertyTranslator(houses).is_complete())
 
     def test_properties_two_main_homes(self):
         houses = [
@@ -84,7 +86,7 @@ class TestTranslateProperty(TestCase):
              }
         ]
 
-        output = translate_property(houses)
+        translator = PropertyTranslator(houses)
         expected = {"properties": {
             "main_home": {
                 "value": 500000,
@@ -103,4 +105,5 @@ class TestTranslateProperty(TestCase):
                 }
             ]
         }}
-        self.assertEqual(expected, output)
+        self.assertTrue(expected, translator.is_complete())
+        self.assertEqual(expected, translator.translate())

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
@@ -1,13 +1,13 @@
 from unittest import TestCase
 
-from cla_backend.libs.eligibility_calculator.cfe_civil.savings import translate_savings
+from cla_backend.libs.eligibility_calculator.cfe_civil.savings import SavingsTranslator
 from cla_backend.libs.eligibility_calculator.models import Savings
 
 
 class TestTranslateSavings(TestCase):
     def test_bank_balance_and_investments(self):
         savings = Savings(bank_balance=270010, investment_balance=100010, asset_balance=200000)
-        output = translate_savings(savings)
+        translator = SavingsTranslator(savings)
         expected = {"capitals": {
             "bank_accounts": [
                 {
@@ -30,11 +30,12 @@ class TestTranslateSavings(TestCase):
 
             ],
         }}
-        self.assertEqual(expected, output)
+        self.assertTrue(translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_assets(self):
         savings = Savings(bank_balance=0, investment_balance=0, asset_balance=80011)
-        output = translate_savings(savings)
+        translator = SavingsTranslator(savings)
         expected = {"capitals": {
             "bank_accounts": [],
             "non_liquid_capital": [
@@ -46,12 +47,10 @@ class TestTranslateSavings(TestCase):
 
             ],
         }}
-        self.assertEqual(expected, output)
+        self.assertTrue(translator.is_complete())
+        self.assertEqual(expected, translator.translate())
 
     def test_empty_savings_generates_empty_dict(self):
         savings = Savings()
-
-        output = translate_savings(savings)
-
-        expected = {}
-        self.assertEqual(expected, output)
+        translator = SavingsTranslator(savings)
+        self.assertFalse(translator.is_complete())


### PR DESCRIPTION
## What does this pull request do?

Convert 'section is complete' check from implicit (the CFE data has ben created) to explicit is_complete() 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
