### PR TITLE
Fix liquid capital calculation

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -361,7 +361,7 @@ class EligibilityChecker(object):
                 "disposable_capital_assets": int(cfe_response.disposable_capital_assets * 100),
                 "property_equities": [int(x * 100) for x in cfe_response.property_equities],
                 "property_capital": int(cfe_response.property_capital * 100),
-                "liquid_capital": int(cfe_response.liquid_capital * 100),
+                "liquid_capital": int((cfe_response.liquid_capital + cfe_response.non_liquid_capital + cfe_response.vehicle_capital) * 100),
                 "gross_income": 0,
                 "partner_allowance": 0,
                 "disposable_income": 0,

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -43,3 +43,11 @@ class CfeResponse(object):
     @property
     def liquid_capital(self):
         return self._cfe_data['result_summary']['capital']['total_liquid']
+
+    @property
+    def non_liquid_capital(self):
+        return self._cfe_data['result_summary']['capital']['total_non_liquid']
+
+    @property
+    def vehicle_capital(self):
+        return self._cfe_data['result_summary']['capital']['total_vehicle']

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -943,7 +943,7 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
             "dependants_allowance": 0,
             "employment_allowance": 0,
             "partner_employment_allowance": 0,
-            "liquid_capital": 0,
+            "liquid_capital": 79999,
         }
         expected_property_results = {
             "pre_mortgage_cap_removal": {
@@ -976,7 +976,7 @@ class TestApplicantPensionerCoupleOnBenefits(CalculatorTestBase):
             "dependants_allowance": 0,
             "employment_allowance": 0,
             "partner_employment_allowance": 0,
-            "liquid_capital": 0,
+            "liquid_capital": 79999,
         }
         expected_property_results = {
             "pre_mortgage_cap_removal": {


### PR DESCRIPTION
Analysis revealed that calcs.liquid_capital actually means "total capital not including properties".
(We are planning on renaming the field to reflect that: https://github.com/ministryofjustice/cla_backend/pull/1064 )

This ticket restores the tests that were "fixed" https://github.com/ministryofjustice/cla_backend/pull/1055/files#r1430269652
and ensures that CFE's non_liquid_capital amount is also included in calcs.liquid_capital so that the tests pass.