### PR TITLE
LEP-456 Remove older version of section_incomplete logic

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -10,12 +10,12 @@ from . import constants
 from . import exceptions
 from .cfe_civil.age import translate_age
 from .cfe_civil.deductions import translate_deductions
-from .cfe_civil.dependants import translate_dependants, has_dependants_key
-from .cfe_civil.savings import translate_savings, has_savings_key
-from .cfe_civil.employment import translate_employment, has_employment_key
+from .cfe_civil.dependants import translate_dependants
+from .cfe_civil.savings import translate_savings
+from .cfe_civil.employment import translate_employment
 from .cfe_civil.cfe_response import CfeResponse
-from .cfe_civil.property import translate_property, has_property_key
-from .cfe_civil.income import translate_income, has_income_key
+from .cfe_civil.property import translate_property
+from .cfe_civil.income import translate_income
 from .cfe_civil.applicant import translate_applicant
 from .cfe_civil.proceeding_types import translate_proceeding_types, DEFAULT_PROCEEDING_TYPE
 from cla_common.constants import ELIGIBILITY_STATES
@@ -376,24 +376,28 @@ class EligibilityChecker(object):
         return case_data.facts.on_nass_benefits and case_data.category == "immigration"
 
     def _do_cfe_civil_check(self):
-        cfe_request_dict = self._translate_case(self.case_data)
-
-        # if we don't have basic information, we can't tell CFE its missing (dependants and partner)
-        # so it has to be bounced here otherwise CFE may/will give an incorrect answer based on missing information
-        if self._complete_applicant_data(cfe_request_dict, self.case_data.facts):
-            cfe_raw_response = requests.post(settings.CFE_URL, json=cfe_request_dict)
-            logger.debug("Eligibility request (CFE): %s" % json.dumps(cfe_request_dict, indent=4, sort_keys=True))
-            cfe_response = CfeResponse(cfe_raw_response.json())
-            result, calcs = self._translate_response(cfe_response)
-            logger.info("Eligibility result (CFE): %s %s" % (result, cfe_response.overall_result))
-            logger.debug(
-                "Eligibility result (CFE): %s" % (json.dumps(cfe_response._cfe_data, indent=4, sort_keys=True)))
-
-            return result, calcs, cfe_response
-        else:
+        if not EligibilityChecker._is_applicant_detail_section_complete(self.case_data):
+            # data is so incomplete that we can't even call CFE sensibly
             result = ELIGIBILITY_STATES.UNKNOWN
             logger.info("Eligibility result (CFE): %s %s" % (result, "couldnt call CFE"))
             return result, None, None
+
+        cfe_request_dict = self._translate_case(self.case_data)
+
+        cfe_raw_response = requests.post(settings.CFE_URL, json=cfe_request_dict)
+        logger.debug("Eligibility request (CFE): %s" % json.dumps(cfe_request_dict, indent=4, sort_keys=True))
+
+        cfe_response = CfeResponse(cfe_raw_response.json())
+        result, calcs = self._translate_response(cfe_response)
+        logger.info("Eligibility result (CFE): %s %s" % (result, cfe_response.overall_result))
+        logger.debug(
+            "Eligibility result (CFE): %s" % (json.dumps(cfe_response._cfe_data, indent=4, sort_keys=True)))
+
+        return result, calcs, cfe_response
+
+    @staticmethod
+    def _is_applicant_detail_section_complete(case_data):
+        return hasattr(case_data.facts, "dependants_young") and hasattr(case_data.facts, "has_partner")
 
     @staticmethod
     def _translate_case(case_data, submission_date=None):
@@ -427,13 +431,9 @@ class EligibilityChecker(object):
             request_data.update(translate_dependants(submission_date, case_data.facts))
 
         request_data.update(EligibilityChecker._translate_capital_data(case_data))
-        if not EligibilityChecker._complete_cfe_capital_data(request_data):
-            request_data['assessment']['section_capital'] = 'incomplete'
 
         if hasattr(case_data, "you"):
             request_data.update(EligibilityChecker._translate_income_data(case_data.you))
-        if not EligibilityChecker._complete_cfe_income_data(request_data):
-            request_data['assessment']['section_gross_income'] = 'incomplete'
 
         return request_data
 
@@ -571,18 +571,6 @@ class EligibilityChecker(object):
         if hasattr(case_data, "disputed_savings"):
             request_data.update(translate_savings(case_data.disputed_savings, subject_matter_of_dispute=True))
         return request_data
-
-    @staticmethod
-    def _complete_applicant_data(request_data, facts):
-        return has_dependants_key(request_data) and hasattr(facts, "has_partner")
-
-    @staticmethod
-    def _complete_cfe_income_data(request_data):
-        return has_employment_key(request_data) and has_income_key(request_data)
-
-    @staticmethod
-    def _complete_cfe_capital_data(request_data):
-        return has_property_key(request_data) and has_savings_key(request_data)
 
     def _translate_response(self, cfe_response):
         '''Translates CFE-Civil's response to ELIGIBILITY_STATES and calcs'''

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/dependants.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/dependants.py
@@ -1,11 +1,5 @@
 import datetime
 
-_DEPENDANTS_KEY = "dependants"
-
-
-def has_dependants_key(dict):
-    return _DEPENDANTS_KEY in dict
-
 
 def _dependant_aged(todays_date, age, relationship):
     return dict(date_of_birth=str(datetime.date(todays_date.year - age, todays_date.month, todays_date.day)),
@@ -24,4 +18,4 @@ def translate_dependants(todays_date, facts):
         adults = [_dependant_aged(todays_date, 17, "adult_relative") for _ in range(facts.dependants_old)]
     else:
         adults = []
-    return {_DEPENDANTS_KEY: children + adults}
+    return {"dependants": children + adults}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
@@ -20,21 +20,13 @@ def _common_income_fields(income, deductions):
     }
 
 
-_EMPLOYMENT_KEY = "employment_details"
-_SELF_EMPLOYMENT_KEY = "self_employment_details"
-
-
-def has_employment_key(dict):
-    return _EMPLOYMENT_KEY in dict or _SELF_EMPLOYMENT_KEY in dict
-
-
 def translate_employment(income, deductions):
     if _all_income_fields(income) and _all_deductions_fields(deductions):
         if income.earnings > 0:
             fields = _common_income_fields(income, deductions)
             if income.self_employed:
                 return {
-                    _SELF_EMPLOYMENT_KEY: [
+                    "self_employment_details": [
                         {
                             "income": fields
                         }
@@ -46,13 +38,13 @@ def translate_employment(income, deductions):
                     "benefits_in_kind": 0,
                 })
                 return {
-                    _EMPLOYMENT_KEY: [
+                    "employment_details": [
                         {
                             "income": fields
                         }
                     ]
                 }
         else:
-            return {_EMPLOYMENT_KEY: []}
+            return {"employment_details": []}
     else:
         return {}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -10,12 +10,6 @@ INCOME_CATEGORY_TO_REGULAR_TRANSACTION = {
     "other_income": "friends_or_family",
 }
 
-_CFE_INCOME_KEY = "regular_transactions"
-
-
-def has_income_key(dict):
-    return _CFE_INCOME_KEY in dict
-
 
 def translate_income(income_data):
     regular_transactions = []
@@ -32,4 +26,4 @@ def translate_income(income_data):
                 }
             )
     non_zero_transactions = [x for x in regular_transactions if x['amount'] > 0]
-    return {_CFE_INCOME_KEY: non_zero_transactions}
+    return {"regular_transactions": non_zero_transactions}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
@@ -19,13 +19,6 @@ def _valid_house(house_data):
         'disputed' in house_data
 
 
-_CFE_PROPERTY_KEY = "properties"
-
-
-def has_property_key(dict):
-    return _CFE_PROPERTY_KEY in dict
-
-
 def translate_property(possible_property_data):
     property_data = [house for house in possible_property_data if _valid_house(house)]
     main_homes = [x for x in property_data if x['main']]
@@ -41,14 +34,14 @@ def translate_property(possible_property_data):
 
     if main_home:
         return {
-            _CFE_PROPERTY_KEY: {
+            "properties": {
                 "main_home": main_home,
                 "additional_properties": additional_houses
             }
         }
     elif len(possible_property_data) == len(property_data):
         return {
-            _CFE_PROPERTY_KEY: {
+            "properties": {
                 "additional_properties": additional_houses
             }
         }

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
@@ -11,13 +11,6 @@ def _savings_value(value, description, subject_matter_of_dispute):
         }
 
 
-_CFE_SAVINGS_KEY = "capitals"
-
-
-def has_savings_key(request_data):
-    return _CFE_SAVINGS_KEY in request_data
-
-
 def translate_savings(savings_data, subject_matter_of_dispute=False):
     if has_all_attributes(savings_data, ["bank_balance", "investment_balance", "asset_balance", "credit_balance"]):
         liquid_capital = [
@@ -31,7 +24,7 @@ def translate_savings(savings_data, subject_matter_of_dispute=False):
         ]
 
         return {
-            _CFE_SAVINGS_KEY: {
+            "capitals": {
                 "bank_accounts": none_filter(liquid_capital),
                 "non_liquid_capital": none_filter(non_liquid_capital)
             }

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -2029,13 +2029,15 @@ class DoCfeCivilCheckTestCase(unittest.TestCase):
         self.assertEqual("not_yet_known", cfe_result.overall_result)
 
     def test_under_60_with_capital(self):
-        facts = dict(is_you_or_your_partner_over_60=False, is_you_under_18=False, has_partner=False)
+        facts = dict(is_you_or_your_partner_over_60=False, is_you_under_18=False, has_partner=False,
+                     dependants_young=0, dependants_old=0)
         checker = self.checker_with_assets(20000 * 100, facts)
         cfe_result = self.do_cfe_civil_check(checker)
         self.assertEqual('ineligible', cfe_result.overall_result)
 
     def test_over_60_with_capital(self):
-        facts = dict(is_you_or_your_partner_over_60=True, is_you_under_18=False, has_partner=False)
+        facts = dict(is_you_or_your_partner_over_60=True, is_you_under_18=False, has_partner=False,
+                     dependants_young=0, dependants_old=0)
         checker = self.checker_with_assets(20000 * 100, facts)
         cfe_result = self.do_cfe_civil_check(checker)
         self.assertEqual('eligible', cfe_result.overall_result)


### PR DESCRIPTION
The older version of this logic (_complete_cfe_capital_data() and _complete_cfe_income_data()) is removed, that is an accidental left-over from when it was replaced in [lep-456-complete-logic-is-centralized](https://github.com/ministryofjustice/cla_backend/pull/1067/files).

