### PR TITLE
Fix calcs for multiple properties

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -31,14 +31,18 @@ class CfeResponse(object):
 
     @property
     def property_equities(self):
-        if self.property_capital > 0:
-            return [self.property_capital]
-        else:
-            return []
+        properties = []
+        cfe_properties = self._cfe_data['assessment']['capital']['capital_items']['properties']
+        if cfe_properties['main_home']:
+            properties.append(cfe_properties['main_home'])
+        if cfe_properties['additional_properties']:
+            properties.extend(cfe_properties['additional_properties'])
+        return [property['assessed_equity'] for property in properties
+                if property['assessed_equity'] > 0]
 
     @property
     def property_capital(self):
-        return self._cfe_data['assessment']['capital']['capital_items']['properties']['main_home']['assessed_equity']
+        return sum(self.property_equities)
 
     @property
     def liquid_capital(self):


### PR DESCRIPTION
Before this PR, the calcs only looked at the value of the first property. When you input multiple properties, the calcs diverge from what legacy calcualtor's calcs give:
![Screenshot 2024-01-09 at 09 29 25](https://github.com/ministryofjustice/cla_backend/assets/307612/10c5b4f4-de63-422e-9176-5f3265ebdb62)
![Screenshot 2024-01-09 at 09 30 03](https://github.com/ministryofjustice/cla_backend/assets/307612/75ef3cff-7014-4d8b-b4df-36a7a891bb5b)

This PR adds together all the property equities to get the property_capital. With this change the results match the calcs from the legacy calculator
