### PR TITLE
stop disputed and non-disputed savings overwriting each other

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -582,7 +582,14 @@ class EligibilityChecker(object):
             request_data.update(translate_property(case_data.property_data))
 
         if hasattr(case_data, "disputed_savings"):
-            request_data.update(translate_savings(case_data.disputed_savings, subject_matter_of_dispute=True))
+            disputed_savings = translate_savings(case_data.disputed_savings, subject_matter_of_dispute=True)
+            if 'capitals' in request_data:
+                capitals = request_data['capitals']
+                disputed_capitals = disputed_savings['capitals']
+                for key in capitals.keys():
+                    capitals[key] += disputed_capitals[key]
+            else:
+                request_data.update(disputed_savings)
         return request_data
 
     def _translate_response(self, cfe_response):

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
@@ -1,5 +1,4 @@
-from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds, none_filter, \
-    has_all_attributes
+from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_to_pounds, none_filter
 
 
 def _savings_value(value, description, subject_matter_of_dispute):
@@ -12,22 +11,19 @@ def _savings_value(value, description, subject_matter_of_dispute):
 
 
 def translate_savings(savings_data, subject_matter_of_dispute=False):
-    if has_all_attributes(savings_data, ["bank_balance", "investment_balance", "asset_balance", "credit_balance"]):
-        liquid_capital = [
-            _savings_value(savings_data.bank_balance, "Savings", subject_matter_of_dispute),
-            _savings_value(savings_data.investment_balance, "Investment", subject_matter_of_dispute)
-        ]
-        non_liquid_capital = [
-            _savings_value(savings_data.asset_balance, "Valuable items worth over 500 pounds",
-                           subject_matter_of_dispute),
-            _savings_value(savings_data.credit_balance, "Credit balance", subject_matter_of_dispute)
-        ]
+    liquid_capital = [
+        _savings_value(savings_data.bank_balance, "Savings", subject_matter_of_dispute),
+        _savings_value(savings_data.investment_balance, "Investment", subject_matter_of_dispute)
+    ]
+    non_liquid_capital = [
+        _savings_value(savings_data.asset_balance, "Valuable items worth over 500 pounds",
+                       subject_matter_of_dispute),
+        _savings_value(savings_data.credit_balance, "Credit balance", subject_matter_of_dispute)
+    ]
 
-        return {
-            "capitals": {
-                "bank_accounts": none_filter(liquid_capital),
-                "non_liquid_capital": none_filter(non_liquid_capital)
-            }
+    return {
+        "capitals": {
+            "bank_accounts": none_filter(liquid_capital),
+            "non_liquid_capital": none_filter(non_liquid_capital)
         }
-    else:
-        return {}
+    }

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
@@ -55,11 +55,3 @@ class TestTranslateSavings(TestCase):
             ],
         }}
         self.assertEqual(expected, output)
-
-    def test_empty_savings_generates_empty_dict(self):
-        savings = Savings()
-
-        output = translate_savings(savings)
-
-        expected = {}
-        self.assertEqual(expected, output)


### PR DESCRIPTION
## What does this pull request do?

merge rather than overwrite savings and disputed savings

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
