### PR TITLE
is_eligible() returns yes/no/unknown

### DIFF
--- a/cla_backend/apps/legalaid/tests/test_models.py
+++ b/cla_backend/apps/legalaid/tests/test_models.py
@@ -7,7 +7,6 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from eligibility_calculator.models import CaseData, ModelMixin
-from eligibility_calculator.exceptions import PropertyExpectedException
 
 from cla_common.constants import (
     ELIGIBILITY_STATES,
@@ -634,20 +633,20 @@ class EligibilityCheckTestCase(TestCase):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_update_state(self, MockedEligibilityChecker):
         """
-        calling .is_eligible() sequencially will:
+        calling .is_eligible() sequentially will:
 
-        1. through PropertyExpectedException
-        2. return True
-        3. return False
-        4. through PropertyExpectedException again
+        1. return "unknown"
+        2. return "yes"
+        3. return "no"
+        4. return "unknown" again
         """
         mocked_checker = MockedEligibilityChecker()
         mocked_checker.calcs = {}
         mocked_checker.is_eligible.side_effect = [
-            PropertyExpectedException(),
-            True,
-            False,
-            PropertyExpectedException(),
+            "unknown",
+            "yes",
+            "no",
+            "unknown",
         ]
 
         # 1. PropertyExpectedException => UNKNOWN

--- a/cla_backend/apps/legalaid/tests/views/mixins/eligibility_check_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/eligibility_check_api.py
@@ -6,8 +6,6 @@ from django.core.urlresolvers import reverse
 
 from rest_framework import status
 
-from eligibility_calculator.exceptions import PropertyExpectedException
-
 from legalaid.models import Category, EligibilityCheck, Property, Person, Income, Savings
 
 from core.tests.test_base import SimpleResourceAPIMixin, NestedSimpleResourceAPIMixin
@@ -1141,7 +1139,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_pass(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.return_value = True
+        v.is_eligible.return_value = "yes"
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},
@@ -1154,7 +1152,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_fail(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.return_value = False
+        v.is_eligible.return_value = "no"
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},
@@ -1167,7 +1165,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_unknown(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.side_effect = PropertyExpectedException
+        v.is_eligible.return_value = "unknown"
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},

--- a/cla_backend/apps/means_test_api/views.py
+++ b/cla_backend/apps/means_test_api/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from eligibility_calculator.calculator import EligibilityChecker
 from eligibility_calculator.models import CaseData
+from cla_common.constants import ELIGIBILITY_STATES
 
 
 @api_view(["POST"])
@@ -18,7 +19,7 @@ def eligibility_batch_check(request):
 def pass_fail(scenario):
     case_data = CaseData(**to_case_data(scenario))
     scenario = EligibilityChecker(case_data)
-    return "P" if scenario.is_eligible() else "F"
+    return "P" if scenario.is_eligible() == ELIGIBILITY_STATES.YES else "F"
 
 
 def to_case_data(scenario):

--- a/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_calculator.py
@@ -1042,7 +1042,7 @@ class TestApplicantSinglePensionerNotOnBenefits(CalculatorTestBase):
         }
         expected_results.update(expected_property_results[self.expected_results_key])
 
-        self.assertFalse(is_elig)
+        self.assertEqual('no', is_elig)
         self.assertDictEqual(checker.calcs, expected_results)
 
     def test_pensioner_limit_10k_diregard_fail(self):
@@ -1060,7 +1060,7 @@ class TestApplicantSinglePensionerNotOnBenefits(CalculatorTestBase):
 
         is_elig, checker = self._test_pensioner(case_data)
 
-        self.assertFalse(is_elig)
+        self.assertEqual('no', is_elig)
         self.assertDictEqual(
             checker.calcs,
             {
@@ -1676,7 +1676,7 @@ class IsEligibleTestCase(unittest.TestCase):
             is_passported=False, is_nass_benefits=False, is_disposable_capital=False
         )
 
-        self.assertFalse(ec.is_eligible())
+        self.assertEqual('no', ec.is_eligible())
         ec.is_disposable_capital_eligible.assert_called_once_with()
         self.assertFalse(ec.is_gross_income_eligible.called)
         self.assertFalse(ec.is_disposable_income_eligible.called)
@@ -1696,7 +1696,7 @@ class IsEligibleTestCase(unittest.TestCase):
         )
 
         self.assertFalse(mocked_on_passported_benefits.called)
-        self.assertFalse(ec.is_eligible())
+        self.assertEqual('no', ec.is_eligible())
         ec.is_disposable_capital_eligible.assert_called_once_with()
         ec.is_gross_income_eligible.assert_called_once_with()
         self.assertFalse(ec.is_disposable_income_eligible.called)
@@ -1718,7 +1718,7 @@ class IsEligibleTestCase(unittest.TestCase):
         )
 
         self.assertFalse(mocked_on_passported_benefits.called)
-        self.assertFalse(ec.is_eligible())
+        self.assertEqual('no', ec.is_eligible())
         ec.is_disposable_capital_eligible.assert_called_once_with()
         ec.is_gross_income_eligible.assert_called_once_with()
         ec.is_disposable_capital_eligible.assert_called_once_with()
@@ -1769,7 +1769,7 @@ class IsEligibleTestCase(unittest.TestCase):
         )
 
         ec.is_disposable_capital_eligible = mock.MagicMock(return_value=False)
-        self.assertFalse(ec.is_eligible())
+        self.assertEqual('no', ec.is_eligible())
         self.assertFalse(mocked_on_passported_benefits.called)
         self.assertTrue(mocked_on_nass_benefits.called)
 
@@ -1788,7 +1788,7 @@ class IsEligibleTestCase(unittest.TestCase):
             is_disposable_income=False,
         )
 
-        self.assertFalse(ec.is_eligible())
+        self.assertEqual('no', ec.is_eligible())
         self.assertTrue(ec.is_gross_income_eligible.called)
         self.assertFalse(mocked_on_passported_benefits.called)
         self.assertTrue(mocked_on_nass_benefits.called)


### PR DESCRIPTION
## What
is_eligible() returns ELIGIBILITY_STATES - "yes"/"no"/"unknown" instead of True/False/PropertyExpectedException

<img width="1162" alt="Screenshot 2024-01-09 at 11 53 21" src="https://github.com/ministryofjustice/cla_backend/assets/307612/f3d4e012-d834-473b-8695-39d64110607b">


To fit with this change to the is_eligible() return, the callers have been adjusted:

* is_eligible() is called from apps/legalaid/models.py::EligibilityCheck.get_eligibility_state() when eligibility checks are done from cla_public or cla_frontend
* is_eligible() is also called during some tests with DEBUG=1 from means_test_api

## Why

The reason is that the CFE checker will not naturally raise an exception to signal "unknown" ("not_calculated_yet" in CFE language).

And exceptions that travel several calls up are difficult for new developers to understand, especially when used for expected behaviour on the happy path (rather than an error). You can see why it was used in the past, when the calculation accessed data that was not present, but when the calculation is in CFE this is no longer possible without artificially raising the exception. And there is no need.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
