### PR TITLE
Remove check for all income/deduction fields in employment translator

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/conversions.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/conversions.py
@@ -8,14 +8,3 @@ def pence_to_pounds(pence):
 
 def none_filter(array):
     return [x for x in array if x is not None]
-
-
-def has_all_attributes(object, attr_list):
-    present = [hasattr(object, attr) for attr in attr_list]
-    return len([x for x in present if x is False]) == 0
-
-
-def missing_attributes(object, expected_attributes):
-    for attr in expected_attributes:
-        if not hasattr(object, attr):
-            return attr


### PR DESCRIPTION
Previously we wanted all the fields present, because it was tied up with figuring out if the "section was complete". However "section complete" functionality is entirely separate. So we can simply translate any and every field in CaseData and not worry about completeness.
