### PR TITLE
Autoformatting with black, files new to cfe-integration branch

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/age.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/age.py
@@ -12,4 +12,4 @@ def translate_age(today, facts):
     else:
         age = 50
     date_of_birth = datetime.date(today.year - age, today.month, today.day)
-    return {'date_of_birth': str(date_of_birth)}
+    return {"date_of_birth": str(date_of_birth)}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -4,11 +4,13 @@ class CfeResponse(object):
 
     @property
     def overall_result(self):
-        return self._cfe_data['result_summary']['overall_result']['result']
+        return self._cfe_data["result_summary"]["overall_result"]["result"]
 
     @property
     def employment_allowance(self):
-        value = self._cfe_data['result_summary']['disposable_income']['employment_income']['fixed_employment_deduction']
+        value = self._cfe_data["result_summary"]["disposable_income"]["employment_income"][
+            "fixed_employment_deduction"
+        ]
         if value < 0:
             return -value
         else:
@@ -16,29 +18,28 @@ class CfeResponse(object):
 
     @property
     def gross_upper_threshold(self):
-        return self._cfe_data['result_summary']['gross_income']['proceeding_types'][0]['upper_threshold']
+        return self._cfe_data["result_summary"]["gross_income"]["proceeding_types"][0]["upper_threshold"]
 
     def applicant_details(self):
-        return self._cfe_data['assessment']['applicant']
+        return self._cfe_data["assessment"]["applicant"]
 
     @property
     def pensioner_disregard(self):
-        return self._cfe_data['result_summary']['capital']['pensioner_capital_disregard']
+        return self._cfe_data["result_summary"]["capital"]["pensioner_capital_disregard"]
 
     @property
     def disposable_capital_assets(self):
-        return self._cfe_data['result_summary']['capital']['combined_assessed_capital']
+        return self._cfe_data["result_summary"]["capital"]["combined_assessed_capital"]
 
     @property
     def property_equities(self):
         properties = []
-        cfe_properties = self._cfe_data['assessment']['capital']['capital_items']['properties']
-        if cfe_properties['main_home']:
-            properties.append(cfe_properties['main_home'])
-        if cfe_properties['additional_properties']:
-            properties.extend(cfe_properties['additional_properties'])
-        return [property['assessed_equity'] for property in properties
-                if property['assessed_equity'] > 0]
+        cfe_properties = self._cfe_data["assessment"]["capital"]["capital_items"]["properties"]
+        if cfe_properties["main_home"]:
+            properties.append(cfe_properties["main_home"])
+        if cfe_properties["additional_properties"]:
+            properties.extend(cfe_properties["additional_properties"])
+        return [property["assessed_equity"] for property in properties if property["assessed_equity"] > 0]
 
     @property
     def property_capital(self):
@@ -46,20 +47,20 @@ class CfeResponse(object):
 
     @property
     def liquid_capital(self):
-        return self._cfe_data['result_summary']['capital']['total_liquid']
+        return self._cfe_data["result_summary"]["capital"]["total_liquid"]
 
     @property
     def gross_income(self):
-        return self._cfe_data['result_summary']['gross_income']['combined_total_gross_income']
+        return self._cfe_data["result_summary"]["gross_income"]["combined_total_gross_income"]
 
     @property
     def disposable_income(self):
-        return self._cfe_data['result_summary']['disposable_income']['combined_total_disposable_income']
+        return self._cfe_data["result_summary"]["disposable_income"]["combined_total_disposable_income"]
 
     @property
     def non_liquid_capital(self):
-        return self._cfe_data['result_summary']['capital']['total_non_liquid']
+        return self._cfe_data["result_summary"]["capital"]["total_non_liquid"]
 
     @property
     def vehicle_capital(self):
-        return self._cfe_data['result_summary']['capital']['total_vehicle']
+        return self._cfe_data["result_summary"]["capital"]["total_vehicle"]

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/deductions.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/deductions.py
@@ -24,7 +24,7 @@ def translate_deductions(deductions):
                         "category": cfe_category,
                         "operation": "debit",
                         "frequency": "monthly",
-                        "amount": pence_to_pounds(amount_pence)
+                        "amount": pence_to_pounds(amount_pence),
                     }
                 )
     else:

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/dependants.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/dependants.py
@@ -2,11 +2,13 @@ import datetime
 
 
 def _dependant_aged(todays_date, age, relationship):
-    return dict(date_of_birth=str(datetime.date(todays_date.year - age, todays_date.month, todays_date.day)),
-                in_full_time_education=False,
-                relationship=relationship,
-                income=dict(frequency="weekly", amount=0),
-                assets_value=0)
+    return dict(
+        date_of_birth=str(datetime.date(todays_date.year - age, todays_date.month, todays_date.day)),
+        in_full_time_education=False,
+        relationship=relationship,
+        income=dict(frequency="weekly", amount=0),
+        assets_value=0,
+    )
 
 
 def translate_dependants(todays_date, facts):

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
@@ -6,16 +6,18 @@ logger = __import__("logging").getLogger(__name__)
 def _are_there_missing_deductions_fields(deductions):
     missing_attr = missing_attributes(deductions, ["income_tax", "national_insurance"])
     if missing_attr:
-        logger.error("Missing field in deductions: '%s'. Ignoring all (self) employment income and deductions!"
-                     % missing_attr)
+        logger.error(
+            "Missing field in deductions: '%s'. Ignoring all (self) employment income and deductions!" % missing_attr
+        )
         return True
 
 
 def _are_there_missing_income_fields(incomes):
     missing_attr = missing_attributes(incomes, ["earnings", "self_employed"])
     if missing_attr:
-        logger.error("Missing field in incomes: '%s'. Ignoring all (self) employment income and deductions!"
-                     % missing_attr)
+        logger.error(
+            "Missing field in incomes: '%s'. Ignoring all (self) employment income and deductions!" % missing_attr
+        )
         return True
 
 
@@ -27,7 +29,7 @@ def _common_income_fields(gross, deductions):
         "frequency": "monthly",
         "prisoner_levy": 0,
         "student_debt_repayment": 0,
-        "national_insurance": -pence_to_pounds(deductions.national_insurance)
+        "national_insurance": -pence_to_pounds(deductions.national_insurance),
     }
 
 
@@ -44,22 +46,12 @@ def translate_employment(income, deductions):
 
     fields = _common_income_fields(gross, deductions)
     if income.self_employed:
-        return {
-            "self_employment_details": [
-                {
-                    "income": fields
-                }
-            ]
-        }
+        return {"self_employment_details": [{"income": fields}]}
     else:
-        fields.update({
-            "receiving_only_statutory_sick_or_maternity_pay": False,
-            "benefits_in_kind": 0,
-        })
-        return {
-            "employment_details": [
-                {
-                    "income": fields
-                }
-            ]
-        }
+        fields.update(
+            {
+                "receiving_only_statutory_sick_or_maternity_pay": False,
+                "benefits_in_kind": 0,
+            }
+        )
+        return {"employment_details": [{"income": fields}]}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/income.py
@@ -22,8 +22,8 @@ def translate_income(income_data):
                     "category": INCOME_CATEGORY_TO_REGULAR_TRANSACTION[income_category],
                     "operation": "credit",
                     "frequency": "monthly",
-                    "amount": pence_to_pounds(amount_pence)
+                    "amount": pence_to_pounds(amount_pence),
                 }
             )
-    non_zero_transactions = [x for x in regular_transactions if x['amount'] > 0]
+    non_zero_transactions = [x for x in regular_transactions if x["amount"] > 0]
     return {"regular_transactions": non_zero_transactions}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/proceeding_types.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/proceeding_types.py
@@ -1,23 +1,13 @@
-CATEGORY_TO_PROCEEDING_TYPE = {
-    "immigration": {
-        "ccms_code": "IM030",
-        "client_involvement_type": "A"
-    }
-}
+CATEGORY_TO_PROCEEDING_TYPE = {"immigration": {"ccms_code": "IM030", "client_involvement_type": "A"}}
 
-DEFAULT_PROCEEDING_TYPE = {
-    "ccms_code": "SE013",
-    "client_involvement_type": "A"
-}
+DEFAULT_PROCEEDING_TYPE = {"ccms_code": "SE013", "client_involvement_type": "A"}
 
 
 def translate_proceeding_types(category):
     proceeding_types = []
 
     if category == "immigration":
-        proceeding_types.append(
-            dict(CATEGORY_TO_PROCEEDING_TYPE["immigration"])
-        )
+        proceeding_types.append(dict(CATEGORY_TO_PROCEEDING_TYPE["immigration"]))
     else:
         proceeding_types.append(DEFAULT_PROCEEDING_TYPE)
     return proceeding_types

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/property.py
@@ -3,27 +3,29 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.conversions import pence_
 
 def _convert_house(house_data):
     return {
-        "value": pence_to_pounds(house_data['value']),
-        "outstanding_mortgage": pence_to_pounds(house_data['mortgage_left']),
-        "percentage_owned": house_data['share'],
+        "value": pence_to_pounds(house_data["value"]),
+        "outstanding_mortgage": pence_to_pounds(house_data["mortgage_left"]),
+        "percentage_owned": house_data["share"],
         "shared_with_housing_assoc": False,
-        "subject_matter_of_dispute": house_data['disputed']
+        "subject_matter_of_dispute": house_data["disputed"],
     }
 
 
 def _valid_house(house_data):
-    return 'main' in house_data and \
-        house_data['value'] is not None and \
-        house_data['mortgage_left'] is not None and \
-        house_data['share'] is not None and \
-        'disputed' in house_data
+    return (
+        "main" in house_data
+        and house_data["value"] is not None
+        and house_data["mortgage_left"] is not None
+        and house_data["share"] is not None
+        and "disputed" in house_data
+    )
 
 
 def translate_property(possible_property_data):
     property_data = [house for house in possible_property_data if _valid_house(house)]
-    main_homes = [x for x in property_data if x['main']]
-    non_mains = [x for x in property_data if not x['main']]
-    if (len(main_homes) > 0):
+    main_homes = [x for x in property_data if x["main"]]
+    non_mains = [x for x in property_data if not x["main"]]
+    if len(main_homes) > 0:
         main_home_data = main_homes[0]
         main_home = _convert_house(main_home_data)
         # all main homes after the first are additional properties
@@ -33,17 +35,8 @@ def translate_property(possible_property_data):
     additional_houses = map(_convert_house, non_mains)
 
     if main_home:
-        return {
-            "properties": {
-                "main_home": main_home,
-                "additional_properties": additional_houses
-            }
-        }
+        return {"properties": {"main_home": main_home, "additional_properties": additional_houses}}
     elif len(possible_property_data) == len(property_data):
-        return {
-            "properties": {
-                "additional_properties": additional_houses
-            }
-        }
+        return {"properties": {"additional_properties": additional_houses}}
     else:
         return {}

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/savings.py
@@ -6,26 +6,23 @@ def _savings_value(value, description, subject_matter_of_dispute):
         return {
             "value": pence_to_pounds(value),
             "description": description,
-            "subject_matter_of_dispute": subject_matter_of_dispute
+            "subject_matter_of_dispute": subject_matter_of_dispute,
         }
 
 
 def translate_savings(savings_data, subject_matter_of_dispute=False):
     liquid_capital = []
     if hasattr(savings_data, "bank_balance"):
-        liquid_capital.append(
-            _savings_value(savings_data.bank_balance, "Savings", subject_matter_of_dispute)
-        )
+        liquid_capital.append(_savings_value(savings_data.bank_balance, "Savings", subject_matter_of_dispute))
     if hasattr(savings_data, "investment_balance"):
-        liquid_capital.append(
-            _savings_value(savings_data.investment_balance, "Investment", subject_matter_of_dispute)
-        )
+        liquid_capital.append(_savings_value(savings_data.investment_balance, "Investment", subject_matter_of_dispute))
 
     non_liquid_capital = []
     if hasattr(savings_data, "asset_balance"):
         non_liquid_capital.append(
-            _savings_value(savings_data.asset_balance, "Valuable items worth over 500 pounds",
-                           subject_matter_of_dispute)
+            _savings_value(
+                savings_data.asset_balance, "Valuable items worth over 500 pounds", subject_matter_of_dispute
+            )
         )
     if hasattr(savings_data, "credit_balance"):
         non_liquid_capital.append(
@@ -35,6 +32,6 @@ def translate_savings(savings_data, subject_matter_of_dispute=False):
     return {
         "capitals": {
             "bank_accounts": none_filter(liquid_capital),
-            "non_liquid_capital": none_filter(non_liquid_capital)
+            "non_liquid_capital": none_filter(non_liquid_capital),
         }
     }

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/under_18_passported.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/under_18_passported.py
@@ -1,6 +1,8 @@
 # Breaking the translate naming convention because attribute 'not_aggregated_no_income_low_capital' should belong to applicant object instead of assessment object.
 def translate_under_18_passported(facts):
-    if (hasattr(facts, "under_18_passported") and facts.under_18_passported) and (hasattr(facts, "is_you_under_18") and facts.is_you_under_18):
+    if (hasattr(facts, "under_18_passported") and facts.under_18_passported) and (
+        hasattr(facts, "is_you_under_18") and facts.is_you_under_18
+    ):
         return {"not_aggregated_no_income_low_capital": True}
     else:
         return {}

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_deductions.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_deductions.py
@@ -8,52 +8,23 @@ class TestTranslateDeductions(TestCase):
     def test_deductions_all_attributes_gives_outgoings(self):
         expected = {
             "regular_transactions": [
-                {
-                    "category": "maintenance_out",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 45.45
-                },
-                {
-                    "category": "child_care",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 37.37
-                },
-                {
-                    "category": "rent_or_mortgage",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 42.42
-                },
-                {
-                    "category": "rent_or_mortgage",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 57.57
-                },
-                {
-                    "category": "legal_aid",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 24.24
-                }
+                {"category": "maintenance_out", "operation": "debit", "frequency": "monthly", "amount": 45.45},
+                {"category": "child_care", "operation": "debit", "frequency": "monthly", "amount": 37.37},
+                {"category": "rent_or_mortgage", "operation": "debit", "frequency": "monthly", "amount": 42.42},
+                {"category": "rent_or_mortgage", "operation": "debit", "frequency": "monthly", "amount": 57.57},
+                {"category": "legal_aid", "operation": "debit", "frequency": "monthly", "amount": 24.24},
             ],
         }
-        deductions = Deductions(maintenance=4545, childcare=3737, mortgage=4242, rent=5757,
-                                criminal_legalaid_contributions=2424)
+        deductions = Deductions(
+            maintenance=4545, childcare=3737, mortgage=4242, rent=5757, criminal_legalaid_contributions=2424
+        )
         # assert list equality w/o respect to ordering
         self.assertEqual(set(expected), set(translate_deductions(deductions)))
 
     def test_missing_field(self):
         expected = {
             "regular_transactions": [
-                {
-                    "amount": 45.45,
-                    "category": "maintenance_out",
-                    "frequency": "monthly",
-                    "operation": "debit"
-                }
+                {"amount": 45.45, "category": "maintenance_out", "frequency": "monthly", "operation": "debit"}
             ]
         }
         deductions = Deductions(maintenance=4545)
@@ -62,14 +33,8 @@ class TestTranslateDeductions(TestCase):
     def test_some_fields_zero(self):
         expected = {
             "regular_transactions": [
-                {
-                    "category": "rent_or_mortgage",
-                    "operation": "debit",
-                    "frequency": "monthly",
-                    "amount": 42.42
-                }
+                {"category": "rent_or_mortgage", "operation": "debit", "frequency": "monthly", "amount": 42.42}
             ],
         }
-        deductions = Deductions(maintenance=0, childcare=0, mortgage=0, rent=4242,
-                                criminal_legalaid_contributions=0)
+        deductions = Deductions(maintenance=0, childcare=0, mortgage=0, rent=4242, criminal_legalaid_contributions=0)
         self.assertEqual(expected, translate_deductions(deductions))

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_dependants.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_dependants.py
@@ -19,36 +19,29 @@ class TestTranslateDependants(TestCase):
         facts = Facts(dependants_old=1, dependants_young=2)
 
         output = translate_dependants(today, facts)
-        expected = {"dependants": [
-            {
-                "date_of_birth": "2008-11-23",
-                "in_full_time_education": False,
-                "relationship": "child_relative",
-                "income": {
-                    "frequency": "weekly",
-                    "amount": 0
+        expected = {
+            "dependants": [
+                {
+                    "date_of_birth": "2008-11-23",
+                    "in_full_time_education": False,
+                    "relationship": "child_relative",
+                    "income": {"frequency": "weekly", "amount": 0},
+                    "assets_value": 0,
                 },
-                "assets_value": 0
-            },
-            {
-                "date_of_birth": "2008-11-23",
-                "in_full_time_education": False,
-                "relationship": "child_relative",
-                "income": {
-                    "frequency": "weekly",
-                    "amount": 0
+                {
+                    "date_of_birth": "2008-11-23",
+                    "in_full_time_education": False,
+                    "relationship": "child_relative",
+                    "income": {"frequency": "weekly", "amount": 0},
+                    "assets_value": 0,
                 },
-                "assets_value": 0
-            },
-            {
-                "date_of_birth": "2006-11-23",
-                "in_full_time_education": False,
-                "relationship": "adult_relative",
-                "income": {
-                    "frequency": "weekly",
-                    "amount": 0
+                {
+                    "date_of_birth": "2006-11-23",
+                    "in_full_time_education": False,
+                    "relationship": "adult_relative",
+                    "income": {"frequency": "weekly", "amount": 0},
+                    "assets_value": 0,
                 },
-                "assets_value": 0
-            }
-        ]}
+            ]
+        }
         self.assertEqual(expected, output)

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
@@ -29,7 +29,7 @@ class TestCfeIncome(TestCase):
                         "tax": -400,
                         "national_insurance": -65,
                         "prisoner_levy": 0,
-                        "student_debt_repayment": 0
+                        "student_debt_repayment": 0,
                     }
                 }
             ],
@@ -49,7 +49,7 @@ class TestCfeIncome(TestCase):
                         "tax": -400,
                         "national_insurance": -65,
                         "prisoner_levy": 0,
-                        "student_debt_repayment": 0
+                        "student_debt_repayment": 0,
                     }
                 }
             ],
@@ -69,7 +69,7 @@ class TestCfeIncome(TestCase):
                         "tax": 0,
                         "national_insurance": 0,
                         "prisoner_levy": 0,
-                        "student_debt_repayment": 0
+                        "student_debt_repayment": 0,
                     }
                 }
             ],
@@ -89,7 +89,7 @@ class TestCfeIncome(TestCase):
                         "tax": 0,
                         "national_insurance": 0,
                         "prisoner_levy": 0,
-                        "student_debt_repayment": 0
+                        "student_debt_repayment": 0,
                     }
                 }
             ],

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_income.py
@@ -6,8 +6,14 @@ from cla_backend.libs.eligibility_calculator.models import Income
 
 class TestTranslateIncome(TestCase):
     def test_fully_populated_income_produces_valid_cfe_request(self):
-        income = Income(benefits=80000, tax_credits=100, child_benefits=200,
-                        maintenance_received=10000, pension=400, other_income=300)
+        income = Income(
+            benefits=80000,
+            tax_credits=100,
+            child_benefits=200,
+            maintenance_received=10000,
+            pension=400,
+            other_income=300,
+        )
 
         output = translate_income(income)
 
@@ -55,8 +61,9 @@ class TestTranslateIncome(TestCase):
         self.assertEqual(expected, output)
 
     def test_minimal_income_produces_single_cfe_value(self):
-        income = Income(benefits=80000, tax_credits=0, child_benefits=0,
-                        maintenance_received=0, pension=0, other_income=0)
+        income = Income(
+            benefits=80000, tax_credits=0, child_benefits=0, maintenance_received=0, pension=0, other_income=0
+        )
 
         output = translate_income(income)
 
@@ -73,8 +80,7 @@ class TestTranslateIncome(TestCase):
         self.assertEqual(expected, output)
 
     def test_zero_income_produces_empty_cfe_array(self):
-        income = Income(benefits=0, tax_credits=0, child_benefits=0,
-                        maintenance_received=0, pension=0, other_income=0)
+        income = Income(benefits=0, tax_credits=0, child_benefits=0, maintenance_received=0, pension=0, other_income=0)
         output = translate_income(income)
         expected = {
             "regular_transactions": [],

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_proceeding_types.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_proceeding_types.py
@@ -8,23 +8,17 @@ class TestProceedingTypes(TestCase):
     def test_category_with_None(self):
         case_data = CaseData(category=None)
         output = translate_proceeding_types(case_data.category)
-        expected = [
-            {'ccms_code': 'SE013', 'client_involvement_type': 'A'}
-        ]
+        expected = [{"ccms_code": "SE013", "client_involvement_type": "A"}]
         self.assertEqual(expected, output)
 
     def test_category_without_immigration(self):
         case_data = CaseData(category="family")
         output = translate_proceeding_types(case_data.category)
-        expected = [
-            {'ccms_code': 'SE013', 'client_involvement_type': 'A'}
-        ]
+        expected = [{"ccms_code": "SE013", "client_involvement_type": "A"}]
         self.assertEqual(expected, output)
 
     def test_category_with_immigration(self):
-        case_data = CaseData(category='immigration')
+        case_data = CaseData(category="immigration")
         output = translate_proceeding_types(case_data.category)
-        expected = [
-            {'ccms_code': 'IM030', 'client_involvement_type': 'A'}
-        ]
+        expected = [{"ccms_code": "IM030", "client_involvement_type": "A"}]
         self.assertEqual(expected, output)

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_property.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_property.py
@@ -6,62 +6,50 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.property import translate
 class TestTranslateProperty(TestCase):
     def test_multiple_properties(self):
         houses = [
-            {'disputed': False,
-             'main': True,
-             'share': 80,
-             'value': 100000 * 100,
-             'mortgage_left': 50000 * 100},
-            {'disputed': False,
-             'main': False,
-             'share': 50,
-             'value': 500000 * 100,
-             'mortgage_left': 200000 * 100
-             }
+            {"disputed": False, "main": True, "share": 80, "value": 100000 * 100, "mortgage_left": 50000 * 100},
+            {"disputed": False, "main": False, "share": 50, "value": 500000 * 100, "mortgage_left": 200000 * 100},
         ]
 
         output = translate_property(houses)
-        expected = {"properties": {
-            "main_home": {
-                "value": 100000,
-                "outstanding_mortgage": 50000,
-                "percentage_owned": 80,
-                "shared_with_housing_assoc": False,
-                "subject_matter_of_dispute": False
-            },
-            "additional_properties": [
-                {
-                    "value": 500000,
-                    "outstanding_mortgage": 200000,
-                    "percentage_owned": 50,
+        expected = {
+            "properties": {
+                "main_home": {
+                    "value": 100000,
+                    "outstanding_mortgage": 50000,
+                    "percentage_owned": 80,
                     "shared_with_housing_assoc": False,
-                    "subject_matter_of_dispute": False
-                }
-            ]
-        }}
+                    "subject_matter_of_dispute": False,
+                },
+                "additional_properties": [
+                    {
+                        "value": 500000,
+                        "outstanding_mortgage": 200000,
+                        "percentage_owned": 50,
+                        "shared_with_housing_assoc": False,
+                        "subject_matter_of_dispute": False,
+                    }
+                ],
+            }
+        }
         self.assertEqual(expected, output)
 
     def test_properties_no_main_home(self):
-        houses = [
-            {'disputed': True,
-             'main': False,
-             'share': 50,
-             'value': 500000 * 100,
-             'mortgage_left': 200000 * 100
-             }
-        ]
+        houses = [{"disputed": True, "main": False, "share": 50, "value": 500000 * 100, "mortgage_left": 200000 * 100}]
 
         output = translate_property(houses)
-        expected = {"properties": {
-            "additional_properties": [
-                {
-                    "value": 500000,
-                    "outstanding_mortgage": 200000,
-                    "percentage_owned": 50,
-                    "shared_with_housing_assoc": False,
-                    "subject_matter_of_dispute": True
-                }
-            ]
-        }}
+        expected = {
+            "properties": {
+                "additional_properties": [
+                    {
+                        "value": 500000,
+                        "outstanding_mortgage": 200000,
+                        "percentage_owned": 50,
+                        "shared_with_housing_assoc": False,
+                        "subject_matter_of_dispute": True,
+                    }
+                ]
+            }
+        }
         self.assertEqual(expected, output)
 
     def test_invalid_property_returns_no_results(self):
@@ -70,37 +58,29 @@ class TestTranslateProperty(TestCase):
 
     def test_properties_two_main_homes(self):
         houses = [
-            {'disputed': True,
-             'main': True,
-             'share': 50,
-             'value': 500000 * 100,
-             'mortgage_left': 200000 * 100
-             },
-            {'disputed': False,
-             'main': True,
-             'share': 40,
-             'value': 400000 * 100,
-             'mortgage_left': 100000 * 100
-             }
+            {"disputed": True, "main": True, "share": 50, "value": 500000 * 100, "mortgage_left": 200000 * 100},
+            {"disputed": False, "main": True, "share": 40, "value": 400000 * 100, "mortgage_left": 100000 * 100},
         ]
 
         output = translate_property(houses)
-        expected = {"properties": {
-            "main_home": {
-                "value": 500000,
-                "outstanding_mortgage": 200000,
-                "percentage_owned": 50,
-                "shared_with_housing_assoc": False,
-                "subject_matter_of_dispute": True
-            },
-            "additional_properties": [
-                {
-                    "value": 400000,
-                    "outstanding_mortgage": 100000,
-                    "percentage_owned": 40,
+        expected = {
+            "properties": {
+                "main_home": {
+                    "value": 500000,
+                    "outstanding_mortgage": 200000,
+                    "percentage_owned": 50,
                     "shared_with_housing_assoc": False,
-                    "subject_matter_of_dispute": False
-                }
-            ]
-        }}
+                    "subject_matter_of_dispute": True,
+                },
+                "additional_properties": [
+                    {
+                        "value": 400000,
+                        "outstanding_mortgage": 100000,
+                        "percentage_owned": 40,
+                        "shared_with_housing_assoc": False,
+                        "subject_matter_of_dispute": False,
+                    }
+                ],
+            }
+        }
         self.assertEqual(expected, output)

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_savings.py
@@ -8,52 +8,40 @@ class TestTranslateSavings(TestCase):
     def test_bank_balance_and_investments(self):
         savings = Savings(bank_balance=270010, investment_balance=100010, asset_balance=200000, credit_balance=300000)
         output = translate_savings(savings)
-        expected = {"capitals": {
-            "bank_accounts": [
-                {
-                    "value": 2700.10,
-                    "description": "Savings",
-                    "subject_matter_of_dispute": False
-                },
-                {
-                    "value": 1000.10,
-                    "description": "Investment",
-                    "subject_matter_of_dispute": False
-                },
-            ],
-            "non_liquid_capital": [
-                {
-                    "value": 2000,
-                    "description": "Valuable items worth over 500 pounds",
-                    "subject_matter_of_dispute": False
-                },
-                {
-                    "value": 3000,
-                    "description": "Credit balance",
-                    "subject_matter_of_dispute": False
-                },
-            ],
-        }}
+        expected = {
+            "capitals": {
+                "bank_accounts": [
+                    {"value": 2700.10, "description": "Savings", "subject_matter_of_dispute": False},
+                    {"value": 1000.10, "description": "Investment", "subject_matter_of_dispute": False},
+                ],
+                "non_liquid_capital": [
+                    {
+                        "value": 2000,
+                        "description": "Valuable items worth over 500 pounds",
+                        "subject_matter_of_dispute": False,
+                    },
+                    {"value": 3000, "description": "Credit balance", "subject_matter_of_dispute": False},
+                ],
+            }
+        }
         self.assertEqual(expected, output)
 
     def test_asset_and_credit(self):
         savings = Savings(bank_balance=0, investment_balance=0, asset_balance=80011, credit_balance=90000)
         output = translate_savings(savings)
-        expected = {"capitals": {
-            "bank_accounts": [],
-            "non_liquid_capital": [
-                {
-                    "value": 800.11,
-                    "description": "Valuable items worth over 500 pounds",
-                    "subject_matter_of_dispute": False
-                },
-                {
-                    "value": 900,
-                    "description": "Credit balance",
-                    "subject_matter_of_dispute": False
-                },
-            ],
-        }}
+        expected = {
+            "capitals": {
+                "bank_accounts": [],
+                "non_liquid_capital": [
+                    {
+                        "value": 800.11,
+                        "description": "Valuable items worth over 500 pounds",
+                        "subject_matter_of_dispute": False,
+                    },
+                    {"value": 900, "description": "Credit balance", "subject_matter_of_dispute": False},
+                ],
+            }
+        }
         self.assertEqual(expected, output)
 
     def test_empty_savings(self):
@@ -61,5 +49,5 @@ class TestTranslateSavings(TestCase):
 
         output = translate_savings(savings)
 
-        expected = {'capitals': {'bank_accounts': [], 'non_liquid_capital': []}}
+        expected = {"capitals": {"bank_accounts": [], "non_liquid_capital": []}}
         self.assertEqual(expected, output)


### PR DESCRIPTION
Because black has been used on this repo in the past.
And we might as well be consistent.

How I did this:

Newer black versions don't install on python2, so I created a separate virtual environment to install and run it:
```
python3 -m venv /tmp/venv3
/tmp/venv3/bin/pip install black
/tmp/venv3/bin/black FILENAME
```