### PR TITLE
Fix is_applicant_detail_section_complete

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
@@ -30,7 +30,7 @@ def translate_employment(income, deductions):
         return {"employment_details": []}
 
     fields = _common_income_fields(gross, deductions)
-    if income.self_employed:
+    if hasattr(income, "self_employed") and income.self_employed:
         return {"self_employment_details": [{"income": fields}]}
     else:
         fields.update(


### PR DESCRIPTION
* Changed `is_you_under_18` to `under_18_passported`. Because if case is under_18_passported, then I would agree that that is enough info to be calling CFE with. However if the applicant is under 18, but not under_18_passported, then we can not skip the other rules.
* Moved `has_partner` to the GI/DI/capital sections_complete. If we do not know if they have a partner, then we can still run CFE, and any non-means rules will run fine. Its just that all the GI/DI/capital figures are incomplete until we clear up if they have a partner.
