### PR TITLE
Fix - NASS was ignored if normal passporting benefit was present

### DIFF
--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -440,7 +440,7 @@ class EligibilityChecker(object):
         if hasattr(case_data, "category"):
             request_data["proceeding_types"] = translate_proceeding_types(case_data.category)
         if hasattr(case_data, "facts"):
-            request_data['applicant'] = EligibilityChecker._translate_applicant_data(submission_date, case_data.facts)
+            request_data["applicant"] = EligibilityChecker._translate_applicant_data(submission_date, case_data.facts)
             request_data["assessment"].update(translate_under_18_passported(case_data.facts))
             request_data.update(translate_dependants(submission_date, case_data.facts))
 

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/applicant.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/applicant.py
@@ -1,9 +1,10 @@
 def translate_applicant(applicant_facts):
+    cfe_applicant = {}
+
     if hasattr(applicant_facts, "on_passported_benefits") and applicant_facts.on_passported_benefits:
-        return {"receives_qualifying_benefit": applicant_facts.on_passported_benefits}
+        cfe_applicant["receives_qualifying_benefit"] = applicant_facts.on_passported_benefits
 
     if hasattr(applicant_facts, "on_nass_benefits") and applicant_facts.on_nass_benefits:
-        return {"receives_asylum_support": applicant_facts.on_nass_benefits}
+        cfe_applicant["receives_asylum_support"] = applicant_facts.on_nass_benefits
 
-    else:
-        return {}
+    return cfe_applicant

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_applicant.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_applicant.py
@@ -4,18 +4,18 @@ from cla_backend.libs.eligibility_calculator.cfe_civil.applicant import translat
 from cla_backend.libs.eligibility_calculator.models import Facts
 
 
-class TestTranslateApplicant(TestCase):
-    def test_applicant_receives_qualifying_benefit_set_to_None_produces_valid_cfe_request(self):
+class TestOneBenefitKnown(TestCase):
+    def test_applicant_on_passported_benefits_None(self):
         applicant_facts = Facts(on_passported_benefits=None)
         output = translate_applicant(applicant_facts)
         self.assertEqual({}, output)
 
-    def test_applicant_receives_qualifying_benefit_set_to_False_produces_valid_cfe_request(self):
+    def test_applicant_on_passported_benefits_False(self):
         applicant_facts = Facts(on_passported_benefits=False)
         output = translate_applicant(applicant_facts)
         self.assertEqual({}, output)
 
-    def test_applicant_receives_qualifying_benefit_set_to_True_produces_valid_cfe_request(self):
+    def test_applicant_on_passported_benefits_True(self):
         applicant_facts = Facts(on_passported_benefits=True)
         output = translate_applicant(applicant_facts)
         expected = {
@@ -23,20 +23,59 @@ class TestTranslateApplicant(TestCase):
         }
         self.assertEqual(expected, output)
 
-    def test_applicant_receives_asylum_support_set_to_None_produces_valid_cfe_request(self):
+    def test_applicant_on_nass_benefits_None(self):
         applicant_facts = Facts(on_nass_benefits=None)
         output = translate_applicant(applicant_facts)
         self.assertEqual({}, output)
 
-    def test_applicant_receives_asylum_support_set_to_False_produces_valid_cfe_request(self):
+    def test_applicant_on_nass_benefits_False(self):
         applicant_facts = Facts(on_nass_benefits=False)
         output = translate_applicant(applicant_facts)
         self.assertEqual({}, output)
 
-    def test_applicant_receives_asylum_support_set_to_True_produces_valid_cfe_request(self):
+    def test_applicant_on_nass_benefits_True(self):
         applicant_facts = Facts(on_nass_benefits=True)
         output = translate_applicant(applicant_facts)
         expected = {
             "receives_asylum_support": True,
         }
         self.assertEqual(expected, output)
+
+
+class TestBothBenefitsKnown(TestCase):
+    def test_on_both_benefits(self):
+        applicant_facts = Facts(on_passported_benefits=True, on_nass_benefits=True)
+        output = translate_applicant(applicant_facts)
+        expected = {
+            "receives_qualifying_benefit": True,
+            "receives_asylum_support": True,
+        }
+        self.assertEqual(expected, output)
+
+    def test_on_passported_benefit_only(self):
+        applicant_facts = Facts(on_passported_benefits=True, on_nass_benefits=False)
+        output = translate_applicant(applicant_facts)
+        expected = {
+            "receives_qualifying_benefit": True,
+        }
+        self.assertEqual(expected, output)
+
+    def test_on_nass_only(self):
+        applicant_facts = Facts(on_passported_benefits=False, on_nass_benefits=True)
+        output = translate_applicant(applicant_facts)
+        expected = {
+            "receives_asylum_support": True,
+        }
+        self.assertEqual(expected, output)
+
+    def test_on_neither_benefit(self):
+        applicant_facts = Facts(on_passported_benefits=False, on_nass_benefits=False)
+        output = translate_applicant(applicant_facts)
+        self.assertEqual({}, output)
+
+
+class TestNeitherBenefitKnown(TestCase):
+    def test_neither_set(self):
+        applicant_facts = Facts()
+        output = translate_applicant(applicant_facts)
+        self.assertEqual({}, output)


### PR DESCRIPTION
Not that NASS is in either of the UIs, but it's in the API so we should support it as best we can.

NASS passporting is more powerful than normal passporting, skipping the capital test too, so if the case qualifies for both then we must tell CFE about both.