### PR TITLE
Add full test case of CFE integration

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -53,17 +53,17 @@ class CfeResponse(object):
 
     @property
     def liquid_capital(self):
-        return self._capital_total("total_liquid")
+        return self._result_capital_aggregated("total_liquid")
 
     @property
     def non_liquid_capital(self):
-        return self._capital_total("total_non_liquid")
+        return self._result_capital_aggregated("total_non_liquid")
 
     @property
     def vehicle_capital(self):
-        return self._capital_total("total_vehicle")
+        return self._result_capital_aggregated("total_vehicle")
 
-    def _capital_total(self, key):
+    def _result_capital_aggregated(self, key):
         return self._result_capital[key] + self._result_partner_capital[key]
 
     @property


### PR DESCRIPTION
A higher level test of the CFE integration and calculations. The idea is to give us confidence in all the fields being taken into account, and that partner works correctly, which is currently missing a test.

It's would be slightly flaky in future, when the calculations&thresholds in CFE change. But it's only one test, so maybe acceptable. Is this acceptable? Open to suggestions.