### PR TITLE
CFE Staging used during CLA development

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -464,7 +464,7 @@ SESSION_SECURITY_PASSIVE_URLS = []
 EMAIL_ORCHESTRATOR_URL = os.environ.get("EMAIL_ORCHESTRATOR_URL")
 
 CFE_URL = (
-    os.environ.get("CFE_HOST", "https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk") + "/v6/assessments"
+    os.environ.get("CFE_HOST", "https://cfe-civil-staging.cloud-platform.service.justice.gov.uk") + "/v6/assessments"
 )
 
 # .local.py overrides all the common settings.


### PR DESCRIPTION
Because CFE-Civil UAT is really only for the EP team to use - it allows us to break it occasionally. Since going forward this will be for the CLA team, I think I would prefer staging here, i.e. for use by the CLA team during their local development. And maybe there will be other times when CFE_URL fails to be set accidentally, and it would be better to using staging than our day-to-day UAT.
