### PR TITLE
LEP-478 Fixup is_eligible() caller to obtain reasons at the same time

### DIFF
--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -429,18 +429,14 @@ class EligibilityCheck(TimeStampedModel, ValidateModelMixin):
         ec = EligibilityChecker(case_data)
         eligibility_state, is_gross_income_eligible, is_disposable_income_eligible, is_disposable_capital_eligible = ec.is_eligible_with_reasons()
 
+        reasons = []
         if eligibility_state == ELIGIBILITY_STATES.NO:
-            reasons = []
-
-            def add_reason(boolean, reason):
-                if not boolean:
-                    reasons.append(reason)
-
-            add_reason(is_disposable_capital_eligible, ELIGIBILITY_REASONS.DISPOSABLE_CAPITAL)
-            add_reason(is_gross_income_eligible, ELIGIBILITY_REASONS.GROSS_INCOME)
-            add_reason(is_disposable_income_eligible, ELIGIBILITY_REASONS.DISPOSABLE_INCOME)
-        else:
-            reasons = []
+            if is_disposable_capital_eligible is False:
+                reasons.append(ELIGIBILITY_REASONS.DISPOSABLE_CAPITAL)
+            if is_gross_income_eligible is False:
+                reasons.append(ELIGIBILITY_REASONS.GROSS_INCOME)
+            if is_disposable_income_eligible is False:
+                reasons.append(ELIGIBILITY_REASONS.DISPOSABLE_INCOME)
         return eligibility_state, ec, reasons
 
     def update_state(self):

--- a/cla_backend/apps/legalaid/tests/test_models.py
+++ b/cla_backend/apps/legalaid/tests/test_models.py
@@ -633,7 +633,7 @@ class EligibilityCheckTestCase(TestCase):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_update_state(self, MockedEligibilityChecker):
         """
-        calling .is_eligible() sequentially will:
+        calling .is_eligible_with_reasons() sequentially will:
 
         1. return "unknown"
         2. return "yes"
@@ -642,11 +642,11 @@ class EligibilityCheckTestCase(TestCase):
         """
         mocked_checker = MockedEligibilityChecker()
         mocked_checker.calcs = {}
-        mocked_checker.is_eligible.side_effect = [
-            "unknown",
-            "yes",
-            "no",
-            "unknown",
+        mocked_checker.is_eligible_with_reasons.side_effect = [
+            ("unknown", False, False, False),
+            ("yes", True, True, True),
+            ("no", False, True, True),
+            ("unknown", False, True, True)
         ]
 
         # 1. PropertyExpectedException => UNKNOWN

--- a/cla_backend/apps/legalaid/tests/views/mixins/eligibility_check_api.py
+++ b/cla_backend/apps/legalaid/tests/views/mixins/eligibility_check_api.py
@@ -1139,7 +1139,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_pass(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.return_value = "yes"
+        v.is_eligible_with_reasons.return_value = ("yes", True, True, True)
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},
@@ -1152,7 +1152,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_fail(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.return_value = "no"
+        v.is_eligible_with_reasons.return_value = ("no", None, None, None)
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},
@@ -1165,7 +1165,7 @@ class EligibilityCheckAPIMixin(SimpleResourceAPIMixin):
     @mock.patch("legalaid.models.EligibilityChecker")
     def test_eligibility_check_is_eligible_unknown(self, mocked_eligibility_checker):
         v = mocked_eligibility_checker()
-        v.is_eligible.return_value = "unknown"
+        v.is_eligible_with_reasons.return_value = ("unknown", None, None, None)
         response = self.client.post(
             self.get_is_eligible_url(self.resource_lookup_value),
             data={},

--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -381,7 +381,7 @@ class EligibilityChecker(object):
 
             return cfe_result, cfe_response.is_gross_eligible, cfe_response.is_disposable_eligible, cfe_response.is_capital_eligible
         else:
-            return cfe_result, True, True, True
+            return cfe_result, None, None, None
 
     @staticmethod
     def _pounds_to_pence(value):

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -18,20 +18,22 @@ class CfeResponse(object):
     def gross_upper_threshold(self):
         return self._result_summary["gross_income"]["proceeding_types"][0]["upper_threshold"]
 
+    # The 'is_xxx_eligible checks are actually looking for reasons of ineligibility
+    # hence we check for not 'ineligible' rather than the other way round
     @property
     def is_gross_eligible(self):
         result = self._result_summary["gross_income"]["proceeding_types"][0]
-        return result["result"] in ["eligible", "not_calculated"]
+        return result["result"] != "ineligible"
 
     @property
     def is_disposable_eligible(self):
         result = self._result_summary["disposable_income"]["proceeding_types"][0]
-        return result["result"] in ["eligible", "not_calculated"]
+        return result["result"] != "ineligible"
 
     @property
     def is_capital_eligible(self):
         result = self._result_summary["capital"]["proceeding_types"][0]
-        return result["result"] in ["eligible", "not_calculated"]
+        return result["result"] != "ineligible"
 
     def applicant_details(self):
         return self._cfe_data["assessment"]["applicant"]

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -18,6 +18,21 @@ class CfeResponse(object):
     def gross_upper_threshold(self):
         return self._result_summary["gross_income"]["proceeding_types"][0]["upper_threshold"]
 
+    @property
+    def is_gross_eligible(self):
+        result = self._result_summary["gross_income"]["proceeding_types"][0]
+        return result["result"] in ["eligible", "not_calculated"]
+
+    @property
+    def is_disposable_eligible(self):
+        result = self._result_summary["disposable_income"]["proceeding_types"][0]
+        return result["result"] in ["eligible", "not_calculated"]
+
+    @property
+    def is_capital_eligible(self):
+        result = self._result_summary["capital"]["proceeding_types"][0]
+        return result["result"] in ["eligible", "not_calculated"]
+
     def applicant_details(self):
         return self._cfe_data["assessment"]["applicant"]
 

--- a/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/cfe_response.py
@@ -18,22 +18,26 @@ class CfeResponse(object):
     def gross_upper_threshold(self):
         return self._result_summary["gross_income"]["proceeding_types"][0]["upper_threshold"]
 
-    # The 'is_xxx_eligible checks are actually looking for reasons of ineligibility
-    # hence we check for not 'ineligible' rather than the other way round
+    @staticmethod
+    def _result_to_tristate(test_result):
+        """Takes the result of one of the three tests, and converts to True/False/None"""
+        if test_result in ("eligible", "contribution_required"):
+            return True
+        elif test_result == "inelgible":
+            return False
+        return None  # not_yet_known/not_calculated
+
     @property
     def is_gross_eligible(self):
-        result = self._result_summary["gross_income"]["proceeding_types"][0]
-        return result["result"] != "ineligible"
+        return CfeResponse._result_to_tristate(self._result_summary["gross_income"]["proceeding_types"][0])
 
     @property
     def is_disposable_eligible(self):
-        result = self._result_summary["disposable_income"]["proceeding_types"][0]
-        return result["result"] != "ineligible"
+        return CfeResponse._result_to_tristate(self._result_summary["disposable_income"]["proceeding_types"][0])
 
     @property
     def is_capital_eligible(self):
-        result = self._result_summary["capital"]["proceeding_types"][0]
-        return result["result"] != "ineligible"
+        return CfeResponse._result_to_tristate(self._result_summary["capital"]["proceeding_types"][0])
 
     def applicant_details(self):
         return self._cfe_data["assessment"]["applicant"]


### PR DESCRIPTION
## What does this pull request do?

Convert is_eligible() call to is_eligible_with_reasons() so that the reasons are known by the caller without having to call the checker again or to do some awkward caching of the result

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
