### PR TITLE
LGA-2884 Allow access from Global Protect VPN

### DIFF
--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -46,7 +46,7 @@ ingress:
     name: ~
     weight: ~
   whitelist:
-    # MoJ
+    # MoJ Digital Wifi & Digital VPN
     - 81.134.202.29/32
     # MoJ/LAA
     - 52.17.239.55/32
@@ -81,6 +81,11 @@ ingress:
     - 185.91.131.4/32
     # CHS
     - 52.210.114.89/32
+    # GlobalProtect VPN (Digital Mac)
+    - 18.169.147.172/32
+    - 35.176.93.186/32
+    - 18.130.148.126/32
+    - 35.176.148.126/32
 
 localPostgres:
   enabled: false


### PR DESCRIPTION
## What does this pull request do?

Digital VPN is [disappearing soon](https://mojdt.slack.com/archives/C67Q5TN57/p1698421193318189). 

This PR gives access via Global Protect VPN instead.

IP addresses from GP are listed here:
* https://github.com/ministryofjustice/moj-ip-addresses/blob/main/moj-cidr-addresses.yml#L296
* https://mojdt.slack.com/archives/C06ATC097B5/p1702994991148149

Tested:
<img width="868" alt="Screenshot 2024-01-12 at 18 56 35" src="https://github.com/ministryofjustice/cla_backend/assets/307612/734e9ea4-b15c-4848-94f8-1ca5491a852a">

This PR doesn't remove access from "MoJ Digital Wifi & Digital VPN". Rather than switch off access from that in this same deployment, I suggest we have a short period of overlap, where both VPNs can be used, to allow all devs to check the new arrangement works for everyone. So removing the "MOJ Digital VPN" IP from this list can be a follow up change.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
