### PR TITLE
LEP-483 Fix exception for missing income-tax

### DIFF
--- a/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
+++ b/cla_backend/libs/eligibility_calculator/cfe_civil/employment.py
@@ -7,11 +7,11 @@ logger = __import__("logging").getLogger(__name__)
 def _common_income_fields(gross, deductions):
     return {
         "gross": gross,
-        "tax": -pence_to_pounds(deductions.income_tax),
+        "tax": -pence_to_pounds(deductions.income_tax) if hasattr(deductions, "income_tax") else 0,
         "frequency": "monthly",
         "prisoner_levy": 0,
         "student_debt_repayment": 0,
-        "national_insurance": -pence_to_pounds(deductions.national_insurance),
+        "national_insurance": -pence_to_pounds(deductions.national_insurance) if hasattr(deductions, "national_insurance") else 0,
     }
 
 

--- a/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
+++ b/cla_backend/libs/eligibility_calculator/tests/cfe_civil/test_employment.py
@@ -95,3 +95,54 @@ class TestCfeIncome(TestCase):
             ],
         }
         self.assertEqual(expected, output)
+
+    def test_no_keys(self):
+        income = Income()
+        deductions = Deductions()
+        output = translate_employment(income, deductions)
+        expected = {"employment_details": []}
+        self.assertEqual(expected, output)
+
+    def test_missing_income_tax(self):
+        income = Income()
+        deductions = Deductions(national_insurance=1)
+        output = translate_employment(income, deductions)
+        expected = {
+            "employment_details": [
+                {
+                    "income": {
+                        "benefits_in_kind": 0,
+                        "frequency": "monthly",
+                        "gross": 0,
+                        "national_insurance": -0.01,
+                        "prisoner_levy": 0,
+                        "receiving_only_statutory_sick_or_maternity_pay": False,
+                        "student_debt_repayment": 0,
+                        "tax": 0,
+                    }
+                }
+            ]
+        }
+        self.assertEqual(expected, output)
+
+    def test_missing_national_insurance(self):
+        income = Income()
+        deductions = Deductions(income_tax=1)
+        output = translate_employment(income, deductions)
+        expected = {
+            "employment_details": [
+                {
+                    "income": {
+                        "benefits_in_kind": 0,
+                        "frequency": "monthly",
+                        "gross": 0,
+                        "national_insurance": 0,
+                        "prisoner_levy": 0,
+                        "receiving_only_statutory_sick_or_maternity_pay": False,
+                        "student_debt_repayment": 0,
+                        "tax": -0.01,
+                    }
+                }
+            ]
+        }
+        self.assertEqual(expected, output)


### PR DESCRIPTION
Looks like we forgot to test for the attribute existing before access it.

What keys are present in CaseData depends on what gets stored by the API client, and there are are no controls - so we have to cope with any not being present..

test_missing_income_tax reproduces the exception seen:

    PropertyExpectedException
    Deductions requires attribute income_tax and was not given at __init__
    cla_backend/libs/eligibility_calculator/cfe_civil/employment.py:10

test_missing_national_insurance reproduces a similar one for national insurance.
