### PR TITLE
LEP-484 match VCR requests on POST bodies, and fix time in VCR tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If the requests to cfe-civil were to change, the tests will fail (as the configu
 The date of the request has been frozen so that this doesn't happen during normal test runs
 
 Although CFE changes should always be backwards compatible, we should re-record every now and again, to test against the latest CFE responses. 
-Command for doing that.
+This can be done by setting the record_mode option to 'all' and re-running the tests
 
 ## Lint and pre-commit hooks
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ To run all tests, this could be done from within the development container (as a
 
     ./run_local.sh test
 
+## CFE-Civil and vcrpy
+
+When the cfe-civil API was adopted to perform eligibility checks, it was decided to use a testing tool called vcrpy. 
+
+Docs for VCR are here: https://github.com/kevin1024/vcrpy/blob/v3.0.0/docs/configuration.rst  (We use older version of vcr due to needing python2 support)
+
+The idea is that the real interactions with the remote host are recorded (once) and subsequent test runs are then 'played back' rather than hitting the 
+remote service. This has 2 benefits:
+1. Using the real service means that responses are always correct - mocks can have undetected errors in them, and can be complex to maintain
+2. Not calling the real service during CI test runs means that the tests are not fragile due to network outages 
+
+If the requests to cfe-civil were to change, the tests will fail (as the configuration contains the post body).
+The date of the request has been frozen so that this doesn't happen during normal test runs
+
+Although CFE changes should always be backwards compatible, we should re-record every now and again, to test against the latest CFE responses. 
+Command for doing that.
+
 ## Lint and pre-commit hooks
 
 To lint with Black and flake8, install pre-commit hooks:

--- a/cla_backend/libs/eligibility_calculator/tests/test_vcr.py
+++ b/cla_backend/libs/eligibility_calculator/tests/test_vcr.py
@@ -1,15 +1,20 @@
 import functools
 import vcr
 import os
+from freezegun import freeze_time
 
-custom_vcr = vcr.VCR()
+# match on POST body otherwise CFE-civil will just match on URL which isn't very good
+custom_vcr = vcr.VCR(match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'body'])
 
 
 def use_vcr_cassette(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        test_dir = os.path.dirname(f.func_code.co_filename)
-        cassette_name = test_dir + "/cassettes/" + f.func_name + ".yml"
-        with custom_vcr.use_cassette(cassette_name):
-            return f(*args, **kwargs)
+        # freeze time to an arbitrary (pre MTR) date so that the cfe-civil requests
+        # all have the same fixed submission date (and hence the same payload)
+        with freeze_time("2024-01-15"):
+            test_dir = os.path.dirname(f.func_code.co_filename)
+            cassette_name = test_dir + "/cassettes/" + f.func_name + ".yml"
+            with custom_vcr.use_cassette(cassette_name):
+                return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## What does this pull request do?

When setting up VCRpy to record cfe-civil interactions, a combination of the VCRpy defaults (not matching POST bodies) and not controlling the submission date in the tests led to VCR recordings changing body when being re-recorded. 
This changes both these facts, so that if the cfe-civil payload were to ever change, then a pyVCR-recorded test will now fail, and any re-recordings will just change date-sensitive headers but not the POST payload 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
