### PR TITLE
LGA-2739 - ITHC secure cookies and headers

### DIFF
--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -191,6 +191,7 @@ MIDDLEWARE_CLASSES = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "status.middleware.MaintenanceModeMiddleware",
+    "django_cookies_samesite.middleware.CookiesSameSite",
 )
 
 ROOT_URLCONF = "cla_backend.urls"
@@ -338,6 +339,7 @@ CSRF_COOKIE_SECURE = not DEBUG
 SESSION_COOKIE_SECURE = not DEBUG
 
 SECURE_CONTENT_TYPE_NOSNIFF = True
+SESSION_COOKIE_SAMESITE = "strict"
 
 # Django rest-framework-overrides
 REST_FRAMEWORK = {

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -182,6 +182,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "iia425u_J_pwntnEyqBuI1xBDqOX8nZ4uC73e
 
 MIDDLEWARE_CLASSES = (
     "django.middleware.locale.LocaleMiddleware",
+    "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -328,6 +328,16 @@ if "SENTRY_DSN" in os.environ:
 LOGIN_FAILURE_LIMIT = 5
 LOGIN_FAILURE_COOLOFF_TIME = 60  # in minutes
 
+# Whether to use the non-RFC standard httpOnly flag (IE, FF3+, others)
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = True
+
+# Whether the session cookie should be secure (https:// only).
+CSRF_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SECURE = not DEBUG
+
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
 # Django rest-framework-overrides
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": ("oauth2_provider.ext.rest_framework.OAuth2Authentication",),

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -69,6 +69,8 @@ django-braces==1.8.1
     # via
     #   -r requirements/source/requirements-base.in
     #   django-oauth-toolkit
+django-cookies-samesite==0.9.0
+    # via -r requirements/source/requirements-base.in
 django-debug-toolbar==1.2.2
     # via -r requirements/source/requirements-dev.in
 django-docopt-command==0.2.0
@@ -295,6 +297,8 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
+ua-parser==0.10.0
+    # via django-cookies-samesite
 unittest-xml-reporting==2.5.1
     # via -r requirements/source/requirements-testing.in
 urllib3-secure-extra==0.1.0

--- a/requirements/generated/requirements-docs.txt
+++ b/requirements/generated/requirements-docs.txt
@@ -50,6 +50,8 @@ django-braces==1.8.1
     # via
     #   -r requirements/source/requirements-base.in
     #   django-oauth-toolkit
+django-cookies-samesite==0.9.0
+    # via -r requirements/source/requirements-base.in
 django-docopt-command==0.2.0
     # via -r requirements/source/requirements-base.in
 django-extended-choices==0.3.0
@@ -227,6 +229,8 @@ typing==3.10.0.0
     # via
     #   pathlib2
     #   sphinx
+ua-parser==0.10.0
+    # via django-cookies-samesite
 urllib3==1.26.14
     # via
     #   botocore

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -46,6 +46,8 @@ django-braces==1.8.1
     # via
     #   -r requirements/source/requirements-base.in
     #   django-oauth-toolkit
+django-cookies-samesite==0.9.0
+    # via -r requirements/source/requirements-base.in
 django-docopt-command==0.2.0
     # via -r requirements/source/requirements-base.in
 django-extended-choices==0.3.0
@@ -194,6 +196,8 @@ transifex-client==0.11b3
     # via -r requirements/source/requirements-base.in
 typing==3.10.0.0
     # via pathlib2
+ua-parser==0.10.0
+    # via django-cookies-samesite
 urllib3==1.26.14
     # via
     #   botocore

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -60,6 +60,8 @@ django-braces==1.8.1
     # via
     #   -r requirements/source/requirements-base.in
     #   django-oauth-toolkit
+django-cookies-samesite==0.9.0
+    # via -r requirements/source/requirements-base.in
 django-docopt-command==0.2.0
     # via -r requirements/source/requirements-base.in
 django-extended-choices==0.3.0
@@ -242,6 +244,8 @@ transifex-client==0.11b3
     # via -r requirements/source/requirements-base.in
 typing==3.10.0.0
     # via pathlib2
+ua-parser==0.10.0
+    # via django-cookies-samesite
 unittest-xml-reporting==2.5.1
     # via -r requirements/source/requirements-testing.in
 urllib3-secure-extra==0.1.0

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -60,3 +60,5 @@ django-session-security==2.2.3
 
 # Govuk Notify Service
 notifications-python-client==6.0.0
+
+django-cookies-samesite==0.9.0


### PR DESCRIPTION
## What does this pull request do?

Add secure cookie settings and headers per ithc recommendation

## Any other changes that would benefit highlighting?

`SESSION_COOKIE_SAMESITE` is part of django core from 2.1. Using https://github.com/jotes/django-cookies-samesite in the meantime to add the samesite attribute

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
