### PR TITLE
Clarify what run_local does

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To start the containers:
 
 You can connect to the fox admin application from http://localhost:8010/admin and log in as cla_admin
 
-The run_local.sh script is reliable but slow. Usually you can quickly restart containers with just:
+The run_local.sh script is reliable but slow, because it rebuilds and restarts all the containers. Usually you can quickly restart just the stopped containers with:
 
     docker-compose run start_applications
 


### PR DESCRIPTION
So you can better tell when you need to use `./run_local.sh` and when you can simply do `docker-compose run start_applications`

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
