### PR TITLE
LGA 2988: Manually assign education cases to all providers

### DIFF
--- a/cla_backend/apps/cla_provider/helpers.py
+++ b/cla_backend/apps/cla_provider/helpers.py
@@ -108,9 +108,6 @@ class ProviderAllocationHelper(object):
         """
         @return: list
         """
-        if settings.EDUCATION_ALLOCATION_FEATURE_FLAG:
-            if category.code == "education":
-                return self.get_valid_education_provider_allocations(category)
         if not self._providers_in_category:
             self._providers_in_category = ProviderAllocation.objects.filter(category=category, provider__active=True)
 
@@ -120,9 +117,6 @@ class ProviderAllocationHelper(object):
         """
         @return: list
         """
-        if settings.EDUCATION_ALLOCATION_FEATURE_FLAG:
-            if category.code == "education":
-                return [pa.provider for pa in self.get_valid_education_provider_allocations(category)]
         if category:
             return [pa.provider for pa in self.get_qualifying_providers_allocation(category)]
 

--- a/cla_backend/apps/cla_provider/tests/test_helpers.py
+++ b/cla_backend/apps/cla_provider/tests/test_helpers.py
@@ -539,21 +539,21 @@ class TestEducationAllocationFeatureFlag(TestCase):
     def setUp(self):
         self.education_category = make_recipe("legalaid.category", code="education")
 
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_suggested_provider")
-    def test_feature_flag_enabled(self, get_suggested_provider):
+    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_best_fit_education_provider")
+    def test_feature_flag_enabled(self, get_best_fit_education_provider):
         settings.EDUCATION_ALLOCATION_FEATURE_FLAG = True
         helper = ProviderAllocationHelper()
-        helper.get_best_fit_education_provider(self.education_category)
+        helper.get_suggested_provider(self.education_category)
 
-        assert get_suggested_provider.called, "get_suggested_provider was not called"
+        assert get_best_fit_education_provider.called, "get_best_fit_education_provider was not called"
 
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_suggested_provider")
-    def test_feature_flag_disabled(self, get_suggested_provider):
+    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_best_fit_education_provider")
+    def test_feature_flag_disabled(self, get_best_fit_education_provider):
         settings.EDUCATION_ALLOCATION_FEATURE_FLAG = False
         helper = ProviderAllocationHelper()
-        helper.get_best_fit_education_provider(self.education_category)
+        helper.get_suggested_provider(self.education_category)
 
-        assert not get_suggested_provider.called, "get_suggested_provider was called"
+        assert not get_best_fit_education_provider.called, "get_best_fit_education_provider was called"
 
 
 class TestGetValidEducationProviders(TestCase):

--- a/cla_backend/apps/cla_provider/tests/test_helpers.py
+++ b/cla_backend/apps/cla_provider/tests/test_helpers.py
@@ -535,47 +535,25 @@ class TestIsProviderUnderCapacity(TestCase):
         assert self.helper.is_provider_under_capacity(provider_allocation) is True
 
 
-class TestEducationAllocationCalled(TestCase):
-    def setUp(self):
-        self.education_category = make_recipe("legalaid.category", code="education")
-        self.not_education_category = make_recipe("legalaid.category", code="Not education")
-
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_valid_education_provider_allocations")
-    def test_education_category(self, get_valid_education_provider_allocations):
-        settings.EDUCATION_ALLOCATION_FEATURE_FLAG = True
-        helper = ProviderAllocationHelper()
-        helper.get_qualifying_providers_allocation(self.education_category)
-
-        assert get_valid_education_provider_allocations.called, "get_valid_education_provider_allocations was not called"
-
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_valid_education_provider_allocations")
-    def test_not_education_category(self, get_valid_education_provider_allocations):
-        settings.EDUCATION_ALLOCATION_FEATURE_FLAG = True
-        helper = ProviderAllocationHelper()
-        helper.get_qualifying_providers_allocation(self.not_education_category)
-
-        assert not get_valid_education_provider_allocations.called, "get_valid_education_provider_allocations was called"
-
-
 class TestEducationAllocationFeatureFlag(TestCase):
     def setUp(self):
         self.education_category = make_recipe("legalaid.category", code="education")
 
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_valid_education_provider_allocations")
-    def test_feature_flag_enabled(self, get_valid_education_provider_allocations):
+    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_suggested_provider")
+    def test_feature_flag_enabled(self, get_suggested_provider):
         settings.EDUCATION_ALLOCATION_FEATURE_FLAG = True
         helper = ProviderAllocationHelper()
-        helper.get_qualifying_providers_allocation(self.education_category)
+        helper.get_best_fit_education_provider(self.education_category)
 
-        assert get_valid_education_provider_allocations.called, "get_valid_education_provider_allocations was not called"
+        assert get_suggested_provider.called, "get_suggested_provider was not called"
 
-    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_valid_education_provider_allocations")
-    def test_feature_flag_disabled(self, get_valid_education_provider_allocations):
+    @mock.patch("cla_provider.helpers.ProviderAllocationHelper.get_suggested_provider")
+    def test_feature_flag_disabled(self, get_suggested_provider):
         settings.EDUCATION_ALLOCATION_FEATURE_FLAG = False
         helper = ProviderAllocationHelper()
-        helper.get_qualifying_providers_allocation(self.education_category)
+        helper.get_best_fit_education_provider(self.education_category)
 
-        assert not get_valid_education_provider_allocations.called, "get_valid_education_provider_allocations was called"
+        assert not get_suggested_provider.called, "get_suggested_provider was called"
 
 
 class TestGetValidEducationProviders(TestCase):


### PR DESCRIPTION
## What does this pull request do?

Modifies the `get_qualifying_providers_allocation` and `get_qualifying_providers` functions to always return all providers in a category regardless of their working days or capacity.

This ensures that all education providers are passed to the frontend so cases can be manually allocated to all SPs.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
