### PR TITLE
LGA-2994: Update CircleCI Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
-  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-cli: circleci/aws-cli@4.1  # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@9.0  # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
                   echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
             - aws-ecr/build_image:
                 push_image: true
+                account_id: $AWS_ECR_REGISTRY_ID
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_REPOSITORY # this will use the env var
@@ -90,6 +91,7 @@ jobs:
           steps:
             - aws-ecr/build_image:
                 push_image: true
+                account_id: $AWS_ECR_REGISTRY_ID
                 path: bin/database-migration
                 build_path: bin/database-migration
                 tag: database-migration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,16 @@ jobs:
                   echo "Created tags $TARGET_TAGS"
                   echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
                   echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
-            - aws-ecr/build-image:
+            - aws-ecr/build_and_push_image:
+		auth:
+		  - aws-cli/setup:
+	            role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
+          	    region: $ECR_REGION # this will use the env var
                 push-image: true
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_REPOSITORY # this will use the env var
-                extra-build-args: |
+                extra_build_args: |
                   --build-arg target=production
             # Validate the python version as 2.7
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,8 @@ jobs:
                   echo "Created tags $TARGET_TAGS"
                   echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
                   echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
-            - aws-ecr/build_and_push_image:
-                auth:
-                  - aws-cli/setup:
-                      role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
-                      region: $ECR_REGION # this will use the env var
+            - aws-ecr/build_image:
+                push_image: true
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_REPOSITORY # this will use the env var
@@ -91,11 +88,8 @@ jobs:
             equal: ["database-migration", << parameters.image >>]
           # Build and push database migration Docker image
           steps:
-            - aws-ecr/build_and_push_image:
-                auth:
-                  - aws-cli/setup:
-                      role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
-                      region: $ECR_REGION # this will use the env var
+            - aws-ecr/build_image:
+                push_image: true
                 path: bin/database-migration
                 build_path: bin/database-migration
                 tag: database-migration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
-  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-ecr: circleci/aws-ecr@9.0 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,10 @@ jobs:
                   echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
                   echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
             - aws-ecr/build_and_push_image:
-		auth:
-		  - aws-cli/setup:
-	            role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
-          	    region: $ECR_REGION # this will use the env var
-                push-image: true
+                auth:
+                  - aws-cli/setup:
+                      role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
+                      region: $ECR_REGION # this will use the env var
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_REPOSITORY # this will use the env var
@@ -92,10 +91,13 @@ jobs:
             equal: ["database-migration", << parameters.image >>]
           # Build and push database migration Docker image
           steps:
-            - aws-ecr/build-image:
-                push-image: true
+            - aws-ecr/build_and_push_image:
+                auth:
+                  - aws-cli/setup:
+                      role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
+                      region: $ECR_REGION # this will use the env var
                 path: bin/database-migration
-                build-path: bin/database-migration
+                build_path: bin/database-migration
                 tag: database-migration
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_REPOSITORY # this will use the env var


### PR DESCRIPTION
## What does this pull request do?

- Updates the AWS ECR Orb to the latest version: [v9.0.2](https://github.com/CircleCI-Public/aws-ecr-orb/releases/tag/v9.0.2)
- Updates the AWS CLI Orb to the latest version: [v4.1.3](https://github.com/CircleCI-Public/aws-cli-orb/releases/tag/v4.1.3)
- Adds `account_id` to `build_image`

### Why are we doing this?
The previous versions of the AWS Orbs were reliant on a version of ubuntu which is being depreciated by CircleCI. 
These orbs need to be updated so we can continue to deploy with our CircleCI pipeline.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
