### PR TITLE
LGA-3011-Fix-incorrect-dob-thresholds

### DIFF
--- a/cla_backend/apps/knowledgebase/migrations/0002_auto_20240304_1603.py
+++ b/cla_backend/apps/knowledgebase/migrations/0002_auto_20240304_1603.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('knowledgebase', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='article',
+            name='email',
+            field=models.EmailField(max_length=254, null=True, blank=True),
+        ),
+    ]


### PR DESCRIPTION
## What does this pull request do?

Fixes incorrect DOB thresholds when generating the age field on the Case Demographic Report

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
