### PR TITLE
LGA-2884 Remove unused IP addresses

### DIFF
--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -46,39 +46,11 @@ ingress:
     name: ~
     weight: ~
   whitelist:
-    # MoJ Digital Wifi & Digital VPN
-    - 81.134.202.29/32
-    # MoJ/LAA
-    - 52.17.239.55/32
-    - 62.25.109.201/32
-    - 62.25.109.203/32
-    # ATOS datacentre
-    - 157.203.176.0/24
-    - 157.203.177.0/24
-    # LAA Manchester/32
-    - 62.25.109.201/32
-    - 62.25.109.203/32
-    - 31.97.19.127/32
-    - 31.67.24.68/32
-    # ARK Data Center IP ranges.
+    # Cisco Anyconnect (Dom1) / ARK data centre
     - 194.33.192.0/25
     - 194.33.196.0/25
-    # Kubernetes - live0
-    - 34.247.134.240/32
-    - 34.251.93.81/32
-    - 52.17.133.167/32
-    # Kubernetes - live1
-    - 35.178.209.113/32
-    - 3.8.51.207/32
-    - 35.177.252.54/32
-    - 3.11.49.71/32
-    - 18.130.126.34/32
-    - 18.134.21.79/32
-    # HGS, new Civil Legal Aid call centre provider from Autumn 2019
-    - 213.78.108.84/32
+    # HGS
     - 84.43.86.100/32
-    - 185.38.246.208/32
-    - 185.91.131.4/32
     # CHS
     - 52.210.114.89/32
     # GlobalProtect VPN (Digital Mac)


### PR DESCRIPTION
## What does this pull request do?
Just a bit of cleanup leftover from:

https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?assignee=557058%3A013dab21-b9d3-42a5-8be7-ebc76789671d&selectedIssue=LGA-2884

Remove old networks that are not used by users and are not reported on logs

## Any other changes that would benefit highlighting?

Removing live0 and live1 as I can't see the benefit of keeping these. Please stop me if there's a reason. CP traffic doesn't go through ingress right?

https://lga-2884-remove-unused-ips-laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk/admin/legalaid/mattertype/
Export report works fine but can't see them, assuming this is normal for dynamic UAT. This works fine on Static UAT though.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
