### PR TITLE
Renamed analytics to Analytics

### DIFF
--- a/cla_backend/apps/complaints/models.py
+++ b/cla_backend/apps/complaints/models.py
@@ -30,7 +30,8 @@ class ComplaintManager(models.Manager):
 
 
 class Complaint(TimeStampedModel):
-    _allow_analytics = True
+    class Analytics:
+        _allow_analytics = True
 
     eod = models.ForeignKey("legalaid.EODDetails")
 

--- a/cla_backend/apps/diagnosis/models.py
+++ b/cla_backend/apps/diagnosis/models.py
@@ -16,7 +16,7 @@ class DiagnosisTraversalManager(models.Manager):
 
 
 class DiagnosisTraversal(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     reference = UUIDField(auto=True, unique=True)

--- a/cla_backend/apps/knowledgebase/models.py
+++ b/cla_backend/apps/knowledgebase/models.py
@@ -3,7 +3,7 @@ from model_utils.models import TimeStampedModel
 
 
 class Article(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     organisation = models.CharField(max_length=255, null=True, blank=True)

--- a/cla_backend/apps/legalaid/migrations/0035_grant_anon_user_permissions.py
+++ b/cla_backend/apps/legalaid/migrations/0035_grant_anon_user_permissions.py
@@ -11,15 +11,15 @@ def get_all_non_restricted_models(models):
     # Get all models from all installed apps
     for model in models:
         # Get all columns for each table
-        if hasattr(model, "analytics") and hasattr(model.analytics, "_allow_analytics"):
-            if model.analytics._allow_analytics:
+        if hasattr(model, "analytics") and hasattr(model.Analytics, "_allow_analytics"):
+            if model.Analytics._allow_analytics:
                 for column in model._meta.get_fields():
                     if not column.is_relation:
                         non_restricted_models.append([model._meta.db_table, column.name])
         # Remove restricted fields from allowed columns
-        if hasattr(model, "analytics") and hasattr(model.analytics, "_restricted_fields"):
-            if len(model.analytics._restricted_fields) > 0:
-                for column in model.analytics._restricted_fields:
+        if hasattr(model, "analytics") and hasattr(model.Analytics, "_restricted_fields"):
+            if len(model.Analytics._restricted_fields) > 0:
+                for column in model.Analytics._restricted_fields:
                     non_restricted_models.remove([model._meta.db_table, column])
     # Returns all allowed columns for user
     return non_restricted_models

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -68,7 +68,7 @@ def _check_reference_unique(reference):
 
 
 class Category(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     name = models.CharField(max_length=500)
@@ -123,7 +123,7 @@ class Deductions(CloneModelMixin, TimeStampedModel):
 
 
 class ContactResearchMethod(CloneModelMixin, TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     method = models.CharField(max_length=10)
@@ -134,7 +134,7 @@ class ContactResearchMethod(CloneModelMixin, TimeStampedModel):
 
 
 class PersonalDetails(CloneModelMixin, TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
         _restricted_fields = [
             "date_of_birth",
@@ -237,7 +237,7 @@ class PersonalDetails(CloneModelMixin, TimeStampedModel):
 
 
 class ThirdPartyDetails(CloneModelMixin, TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
         _restricted_fields = ["personal_relationship_note"]
 
@@ -262,7 +262,7 @@ class ThirdPartyDetails(CloneModelMixin, TimeStampedModel):
 
 
 class AdaptationDetails(CloneModelMixin, TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
         _restricted_fields = ["notes"]
 
@@ -287,7 +287,7 @@ class EODDetailsManager(models.Manager):
 
 
 class EODDetails(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
         _restricted_fields = ["notes"]
 
@@ -330,7 +330,7 @@ class EODDetails(TimeStampedModel):
 
 
 class EODDetailsCategory(models.Model):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     eod_details = models.ForeignKey(EODDetails, related_name="categories")
@@ -409,7 +409,7 @@ class ValidateModelMixin(models.Model):
 
 
 class EligibilityCheck(TimeStampedModel, ValidateModelMixin):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     reference = UUIDField(auto=True, unique=True)
@@ -649,7 +649,7 @@ class Property(TimeStampedModel):
 
 
 class MatterType(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     category = models.ForeignKey(Category)
@@ -680,7 +680,7 @@ class MediaCode(TimeStampedModel):
 
 
 class Case(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
         _restricted_field = ["notes", "provider_notes", "source"]
 
@@ -1037,7 +1037,7 @@ class CaseNotesHistory(TimeStampedModel):
 
 
 class CaseKnowledgebaseAssignment(TimeStampedModel):
-    class analytics:
+    class Analytics:
         _allow_analytics = True
 
     case = models.ForeignKey(Case)


### PR DESCRIPTION
## What does this pull request do?

Renames analytics to Analytics to match the case of other class names to match [PEP-8: Class Names](https://peps.python.org/pep-0008/#class-names)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
