### PR TITLE
LGA-3046: Improve Callback capping performance

### DIFF
--- a/cla_backend/apps/checker/admin.py
+++ b/cla_backend/apps/checker/admin.py
@@ -6,6 +6,7 @@ from django.contrib import admin, messages
 from django.http.response import HttpResponseRedirect
 from checker.models import ReasonForContacting, CallbackTimeSlot
 from checker.forms import CallbackTimeSlotCSVUploadForm
+import datetime as dt
 
 
 class ReasonForContactingAdmin(admin.ModelAdmin):
@@ -18,6 +19,7 @@ class CallbackTimeSlotAdmin(admin.ModelAdmin):
     change_list_template = "admin/checker/callback-time-slots/custom_change_list.html"
     list_display = ("date", "time", "capacity", "remaining_capacity")
     date_hierarchy = "date"
+    ordering = ("date", "time")
 
     def get_urls(self):
         urls = super(CallbackTimeSlotAdmin, self).get_urls()
@@ -41,6 +43,25 @@ class CallbackTimeSlotAdmin(admin.ModelAdmin):
                     reverse("admin:%s_%s_changelist" % (self.model._meta.app_label, self.model._meta.model_name))
                 )
         return render(request, "admin/checker/callback-time-slots/csv-upload.html", {"form": form})
+
+    def get_queryset(self, request):
+        """If there are no query arguments then only return a weeks worth of slots.
+            This decreases the initial page load time by showing the most relevant data first
+
+        Args:
+            request (django.request)
+
+        Returns:
+            QuerySet: QuerySet of relevant callback time slots
+        """
+        if len(request.GET.items()) == 0:
+            today = dt.date.today()
+            week_range = (today, today + dt.timedelta(days=7))
+            qs = CallbackTimeSlot.objects.filter(date__range=week_range)
+            return qs
+        qs = super(CallbackTimeSlotAdmin, self).get_queryset(request)
+
+        return qs
 
 
 admin.site.register(ReasonForContacting, ReasonForContactingAdmin)

--- a/cla_backend/apps/checker/admin.py
+++ b/cla_backend/apps/checker/admin.py
@@ -45,8 +45,8 @@ class CallbackTimeSlotAdmin(admin.ModelAdmin):
         return render(request, "admin/checker/callback-time-slots/csv-upload.html", {"form": form})
 
     def get_queryset(self, request):
-        """If there are no query arguments then only return a weeks worth of slots.
-            This decreases the initial page load time by showing the most relevant data first
+        """ If there are no query arguments then only return a weeks worth of slots.
+            This decreases the initial page load time by initially only loading the most relevant data
 
         Args:
             request (django.request)

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -2,12 +2,13 @@ from cla_common.constants import OPERATOR_HOURS, CALLBACK_TYPES
 from cla_common.call_centre_availability import OpeningHours, current_datetime, SLOT_INTERVAL_MINS
 from checker.models import CallbackTimeSlot
 from checker.utils import get_timeslot_of_datetime
+from django.utils import timezone
 from legalaid.models import Case
 import datetime
 
 
 class CheckerOpeningHours(OpeningHours):
-    def time_slots(self, cases_in_range, day=None, is_third_party_callback=False):
+    def time_slots(self, callback_times, day=None, is_third_party_callback=False):
         """Gets all callback time slots on a given day.
         If is_third_party_callback = False capacity is ignored,
         otherwise the capacity will be based from the set of cases in range.
@@ -28,28 +29,27 @@ class CheckerOpeningHours(OpeningHours):
         def has_capacity(slot):
             key = "%s %s" % (day.strftime(DATE_KEY_FORMAT), slot.strftime("%H%M"))
             if key not in capacity:
-                return self.check_capacity_compared_to_prev_week(slot, cases_in_range)
+                return self.check_capacity_compared_to_prev_week(slot, callback_times)
             return capacity[key] > 0
 
-        capacity = self.get_callback_with_capacity(day, cases_in_range)
+        capacity = self.get_callback_with_capacity(day, callback_times)
         slots = filter(has_capacity, slots)
         return slots
 
-    def get_callback_with_capacity(self, day, cases):
+    def get_callback_with_capacity(self, day, callback_times):
         callback_slots = CallbackTimeSlot.objects.filter(date=day).all()
         capacity = {}
         for callback_slot in callback_slots:
             key = "%s %s" % (day.strftime(DATE_KEY_FORMAT), callback_slot.time)
-            used_capacity = cases.filter(
-                requires_action_at__range=(
-                    callback_slot.callback_start_datetime(),
-                    callback_slot.callback_end_datetime() - datetime.timedelta(seconds=1),
-                )
-            ).count()
+            used_capacity = count_callbacks_in_range(
+                callback_times,
+                callback_slot.callback_start_datetime(),
+                callback_slot.callback_end_datetime() - datetime.timedelta(seconds=1),
+            )
             capacity[key] = callback_slot.capacity - used_capacity
         return capacity
 
-    def check_capacity_compared_to_prev_week(self, slot_dt, cases_in_range):
+    def check_capacity_compared_to_prev_week(self, slot_dt, callback_times):
         """In the situation where no CallbackTimeSlot capacity has been defined for a given date
         the capacity of same timeslot for the previous week should be used.
 
@@ -59,12 +59,14 @@ class CheckerOpeningHours(OpeningHours):
         Returns:
             Bool: If the slot would have capacity when compared to the capacity set by the previous week's slot.
         """
+        slot_dt = timezone.make_aware(slot_dt)
         previous_timeslot = get_timeslot_of_datetime(slot_dt - datetime.timedelta(weeks=1))
         if not previous_timeslot:
             return True  # If there are no timeslots found for the previous year then fallback safely.
-        num_slots_booked = cases_in_range.filter(
-            requires_action_at__range=(slot_dt, slot_dt + datetime.timedelta(minutes=SLOT_INTERVAL_MINS))
-        ).count()
+
+        num_slots_booked = count_callbacks_in_range(
+            callback_times, slot_dt, slot_dt + datetime.timedelta(minutes=SLOT_INTERVAL_MINS)
+        )
 
         # Compares the slots booked in the current week's timeslot to last weeks' capacity.
         return num_slots_booked < previous_timeslot.capacity
@@ -74,20 +76,38 @@ DATE_KEY_FORMAT = "%Y%m%d"
 CALL_CENTER_HOURS = CheckerOpeningHours(**OPERATOR_HOURS)
 
 
-def get_cases_with_callbacks_in_range(start_dt, end_dt):
-    """Gets all cases which have a callback booked via the Checker web form, excluding third party callbacks.
+def get_list_callback_times(start_dt, end_dt):
+    """ Gets a list of requested callback times made via the web form within the given range.
+        Excludes callbacks requested for a third party.
 
     Args:
         start_dt (datetime.datetime): Start of time range
         end_dt (datetime.datetime): End of time range
 
     Returns:
-        django.QuerySet: QuerySet of all relevant cases.
+        list[datetime.datetime]: List of requested callback times.
     """
     valid_cases = Case.objects.filter(
         requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF
-    ).all()
+    ).values_list("requires_action_at", flat=True)
     return valid_cases
+
+
+def count_callbacks_in_range(callback_times, start_dt, end_dt):
+    """Returns the number of callbacks that are in the given range.
+
+    Args:
+        callback_times (list[datetime.datetime]): List of callback datetimes
+        start_dt (datetime.datetime]): Start of the time range
+        end_dt (datetime.datetime]): End of the time range
+
+    Returns:
+        Int: Num callbacks in the given range
+    """
+    times_in_range = list(
+        filter(lambda callback_time: callback_time >= start_dt and callback_time < end_dt, callback_times)
+    )
+    return len(times_in_range)
 
 
 def get_available_slots(num_days=7, is_third_party_callback=False):
@@ -107,13 +127,11 @@ def get_available_slots(num_days=7, is_third_party_callback=False):
     if num_days > 1:
         days.extend(CALL_CENTER_HOURS.available_days(num_days - 1))
 
-    # As making a Case query is expensive, we want to make a single query for relevant cases and compare all time slots to this set of cases.
-    cases_with_callbacks_in_range = get_cases_with_callbacks_in_range(start_dt, end_dt)
+    # As making a Case query is expensive, we want to make a single query for relevant callback times and compare all time slots to this set of times.
+    callback_times = get_list_callback_times(start_dt, end_dt)
 
     valid_slots = []
     for day in days:
-        valid_slots.extend(
-            CALL_CENTER_HOURS.time_slots(cases_with_callbacks_in_range, day.date(), is_third_party_callback)
-        )
+        valid_slots.extend(CALL_CENTER_HOURS.time_slots(callback_times, day.date(), is_third_party_callback))
 
     return valid_slots

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -1,4 +1,4 @@
-from cla_common.constants import OPERATOR_HOURS
+from cla_common.constants import OPERATOR_HOURS, CALLBACK_TYPES
 from cla_common.call_centre_availability import OpeningHours, current_datetime, SLOT_INTERVAL_MINS
 from checker.models import CallbackTimeSlot
 from checker.utils import get_timeslot_of_datetime
@@ -7,7 +7,19 @@ import datetime
 
 
 class CheckerOpeningHours(OpeningHours):
-    def time_slots(self, day=None, is_third_party_callback=False):
+    def time_slots(self, cases_in_range, day=None, is_third_party_callback=False):
+        """Gets all callback time slots on a given day.
+        If is_third_party_callback = False capacity is ignored,
+        otherwise the capacity will be based from the set of cases in range.
+
+        Args:
+            cases_in_range (QuerySet): Set of cases with callbacks
+            day (datetime.date, optional): Date to get slots for. Defaults to None.
+            is_third_party_callback (bool, optional): Is the callback for a third party. Defaults to False.
+
+        Returns:
+            slots: List of valid callback time slots.
+        """
         slots = super(CheckerOpeningHours, self).time_slots(day)
 
         if is_third_party_callback:  # Third party callbacks always have capacity.
@@ -16,22 +28,28 @@ class CheckerOpeningHours(OpeningHours):
         def has_capacity(slot):
             key = "%s %s" % (day.strftime(DATE_KEY_FORMAT), slot.strftime("%H%M"))
             if key not in capacity:
-                return self.check_capacity_compared_to_prev_week(slot)
+                return self.check_capacity_compared_to_prev_week(slot, cases_in_range)
             return capacity[key] > 0
 
-        capacity = self.get_callback_with_capacity(day)
+        capacity = self.get_callback_with_capacity(day, cases_in_range)
         slots = filter(has_capacity, slots)
         return slots
 
-    def get_callback_with_capacity(self, day):
+    def get_callback_with_capacity(self, day, cases):
         callback_slots = CallbackTimeSlot.objects.filter(date=day).all()
         capacity = {}
         for callback_slot in callback_slots:
             key = "%s %s" % (day.strftime(DATE_KEY_FORMAT), callback_slot.time)
-            capacity[key] = callback_slot.remaining_capacity
+            used_capacity = cases.filter(
+                requires_action_at__range=(
+                    callback_slot.callback_start_datetime(),
+                    callback_slot.callback_end_datetime() - datetime.timedelta(seconds=1),
+                )
+            ).count()
+            capacity[key] = callback_slot.capacity - used_capacity
         return capacity
 
-    def check_capacity_compared_to_prev_week(self, slot_dt):
+    def check_capacity_compared_to_prev_week(self, slot_dt, cases_in_range):
         """In the situation where no CallbackTimeSlot capacity has been defined for a given date
         the capacity of same timeslot for the previous week should be used.
 
@@ -44,7 +62,7 @@ class CheckerOpeningHours(OpeningHours):
         previous_timeslot = get_timeslot_of_datetime(slot_dt - datetime.timedelta(weeks=1))
         if not previous_timeslot:
             return True  # If there are no timeslots found for the previous year then fallback safely.
-        num_slots_booked = Case.objects.filter(
+        num_slots_booked = cases_in_range.filter(
             requires_action_at__range=(slot_dt, slot_dt + datetime.timedelta(minutes=SLOT_INTERVAL_MINS))
         ).count()
 
@@ -54,6 +72,22 @@ class CheckerOpeningHours(OpeningHours):
 
 DATE_KEY_FORMAT = "%Y%m%d"
 CALL_CENTER_HOURS = CheckerOpeningHours(**OPERATOR_HOURS)
+
+
+def get_cases_with_callbacks_in_range(start_dt, end_dt):
+    """Gets all cases which have a callback booked via the Checker web form, excluding third party callbacks.
+
+    Args:
+        start_dt (datetime.datetime): Start of time range
+        end_dt (datetime.datetime): End of time range
+
+    Returns:
+        django.QuerySet: QuerySet of all relevant cases.
+    """
+    valid_cases = Case.objects.filter(
+        requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF
+    ).all()
+    return valid_cases
 
 
 def get_available_slots(num_days=7, is_third_party_callback=False):
@@ -66,13 +100,20 @@ def get_available_slots(num_days=7, is_third_party_callback=False):
     Returns:
         Dict: Dictionary of callback slots in the form: {"YYYYMMDD":  {"HHMM": {"start": datetime, "end": datetime}}}
     """
-
-    days = [current_datetime()]
+    start_dt = current_datetime()
+    end_dt = start_dt + datetime.timedelta(days=7)
+    days = [start_dt]
     # Generate time slots options for call on another day select options
     if num_days > 1:
         days.extend(CALL_CENTER_HOURS.available_days(num_days - 1))
 
+    # As making a Case query is expensive, we want to make a single query for relevant cases and compare all time slots to this set of cases.
+    cases_with_callbacks_in_range = get_cases_with_callbacks_in_range(start_dt, end_dt)
+
     valid_slots = []
     for day in days:
-        valid_slots.extend(CALL_CENTER_HOURS.time_slots(day.date(), is_third_party_callback))
+        valid_slots.extend(
+            CALL_CENTER_HOURS.time_slots(cases_with_callbacks_in_range, day.date(), is_third_party_callback)
+        )
+
     return valid_slots

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -121,7 +121,7 @@ def get_available_slots(num_days=7, is_third_party_callback=False):
         Dict: Dictionary of callback slots in the form: {"YYYYMMDD":  {"HHMM": {"start": datetime, "end": datetime}}}
     """
     start_dt = current_datetime()
-    end_dt = start_dt + datetime.timedelta(days=7)
+    end_dt = start_dt + datetime.timedelta(days=num_days)
     days = [start_dt]
     # Generate time slots options for call on another day select options
     if num_days > 1:

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -87,10 +87,10 @@ def get_list_callback_times(start_dt, end_dt):
     Returns:
         list[datetime.datetime]: List of requested callback times.
     """
-    valid_cases = Case.objects.filter(
+    callback_times = Case.objects.filter(
         requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF
     ).values_list("requires_action_at", flat=True)
-    return valid_cases
+    return callback_times
 
 
 def count_callbacks_in_range(callback_times, start_dt, end_dt):


### PR DESCRIPTION
## What does this pull request do?

### Optimises the `/checker/api/v1/callback_time_slots` endpoint by:
- Making a single Case query to load relevant data at the start of the operation, rather than once per time slot.
- Minimised data load by only loading a list of time slots rather than whole case objects.
- Adds caching to the API query page.


### Decreases page load time of the admin site by:
- Only loading a weeks worth of data, until requested for more, rather than all callback time slot data.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
