### PR TITLE
LGA 3109: Add matter types to the MITellUsMoreAboutYourProblem report

### DIFF
--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -1079,6 +1079,10 @@ class MITellUsMoreAboutYourProblem(SQLFileDateRangeReport):
             "Legalaid Category Code",
             "Legalaid Category Name",
             "Outcome Code",
+            "Matter Type 1 Code",
+            "Matter Type 1 Description",
+            "Matter Type 2 Code",
+            "Matter Type 2 Description",
         ]
 
 

--- a/cla_backend/apps/reports/forms.py
+++ b/cla_backend/apps/reports/forms.py
@@ -1078,11 +1078,11 @@ class MITellUsMoreAboutYourProblem(SQLFileDateRangeReport):
             "Diagnosis Category",
             "Legalaid Category Code",
             "Legalaid Category Name",
-            "Outcome Code",
             "Matter Type 1 Code",
-            "Matter Type 1 Description",
             "Matter Type 2 Code",
+            "Matter Type 1 Description",
             "Matter Type 2 Description",
+            "Outcome Code",
         ]
 
 

--- a/cla_backend/apps/reports/sql/MIExtractByOutcomeTellUsAboutYourProblem.sql
+++ b/cla_backend/apps/reports/sql/MIExtractByOutcomeTellUsAboutYourProblem.sql
@@ -28,11 +28,11 @@ SELECT
   ,COALESCE(log_changed_category.diagnosis_category, category.code) as "Diagnosis Category"
   ,category.code as "Legalaid Category Code"
   ,category.name as "Legalaid Category Name"
-  ,c.outcome_code as "Outcome Code"
   ,mt1.code as "Matter Type 1 Code"
-  ,mt1.description as "Matter Type 1 Description"
   ,mt2.code as "Matter Type 2 Code"
+  ,mt1.description as "Matter Type 1 Description"
   ,mt2.description as "Matter Type 2 Description"
+  ,c.outcome_code as "Outcome Code"
 FROM legalaid_case as c
 LEFT OUTER JOIN legalaid_eligibilitycheck as ec on c.eligibility_check_id = ec.id
 LEFT OUTER JOIN legalaid_category as category on ec.category_id = category.id

--- a/cla_backend/apps/reports/sql/MIExtractByOutcomeTellUsAboutYourProblem.sql
+++ b/cla_backend/apps/reports/sql/MIExtractByOutcomeTellUsAboutYourProblem.sql
@@ -29,10 +29,16 @@ SELECT
   ,category.code as "Legalaid Category Code"
   ,category.name as "Legalaid Category Name"
   ,c.outcome_code as "Outcome Code"
+  ,mt1.code as "Matter Type 1 Code"
+  ,mt1.description as "Matter Type 1 Description"
+  ,mt2.code as "Matter Type 2 Code"
+  ,mt2.description as "Matter Type 2 Description"
 FROM legalaid_case as c
 LEFT OUTER JOIN legalaid_eligibilitycheck as ec on c.eligibility_check_id = ec.id
 LEFT OUTER JOIN legalaid_category as category on ec.category_id = category.id
 LEFT OUTER JOIN legalaid_adaptationdetails as adapt on c.adaptation_details_id = adapt.id
 LEFT OUTER JOIN log_changed_category ON log_changed_category.case_id = c.id
+LEFT OUTER JOIN legalaid_mattertype as mt1 on mt1.id = c.matter_type1_id
+LEFT OUTER JOIN legalaid_mattertype as mt2 on mt2.id = c.matter_type2_id
 WHERE c.modified >= %(from_date)s AND c.modified < %(to_date)s
 ORDER BY c.modified DESC


### PR DESCRIPTION
## What does this pull request do?

#### Adds four new columns to the MI Problem Categorisation Report:
- Matter Type 1 Code
- Matter Type 1 Description
- Matter Type 2 Code
- Matter Type 2 Description

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
