### PR TITLE
Lga 3156 (spike: LGA-3075) gtm_anon_id  db cross service GA tracking

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -346,10 +346,7 @@ class CreateCaseSerializer(CaseSerializer):
 
     def create(self, validated_data):
         validated_data['gtm_anon_id'] = str(uuid.uuid4())
-        super(CreateCaseSerializer, self).create(validated_data)
-
-        instance = Case.objects.create(**validated_data)
-        return instance
+        return super(CreateCaseSerializer, self).create(validated_data)
 
     personal_details = UUIDSerializer(
         slug_field="reference", required=False, queryset=PersonalDetails.objects.all(), allow_null=True

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -346,6 +346,7 @@ class CreateCaseSerializer(CaseSerializer):
 
     def create(self, validated_data):
         validated_data['gtm_anon_id'] = str(uuid.uuid4())
+        super(CreateCaseSerializer, self).create(validated_data)
 
         instance = Case.objects.create(**validated_data)
         return instance

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -29,7 +29,7 @@ from legalaid.serializers import (
 )
 
 from .models import Operator
-from legalaid.models import PersonalDetails, Case
+from legalaid.models import PersonalDetails
 
 
 class PropertySerializer(PropertySerializerBase):

--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -1,3 +1,4 @@
+import uuid
 from rest_framework import serializers
 
 from cla_common.constants import FEEDBACK_ISSUE
@@ -28,7 +29,7 @@ from legalaid.serializers import (
 )
 
 from .models import Operator
-from legalaid.models import PersonalDetails
+from legalaid.models import PersonalDetails, Case
 
 
 class PropertySerializer(PropertySerializerBase):
@@ -304,6 +305,7 @@ class CaseSerializer(CaseSerializerFull):
             "complaint_count",
             "organisation_name",
             "organisation",
+            "gtm_anon_id",
         )
 
 
@@ -341,6 +343,12 @@ class CreateCaseSerializer(CaseSerializer):
     It allows the API to create a case with optional personal_details reference.
     No other fields can be used when creating a case atm.
     """
+
+    def create(self, validated_data):
+        validated_data['gtm_anon_id'] = str(uuid.uuid4())
+
+        instance = Case.objects.create(**validated_data)
+        return instance
 
     personal_details = UUIDSerializer(
         slug_field="reference", required=False, queryset=PersonalDetails.objects.all(), allow_null=True

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -75,6 +75,7 @@ class BaseCaseTestCase(CLAOperatorAuthBaseApiTestMixin, BaseFullCaseAPIMixin, AP
             "call_started",
             "organisation_name",
             "organisation",
+            "gtm_anon_id",
         ]
 
 

--- a/cla_backend/apps/checker/serializers.py
+++ b/cla_backend/apps/checker/serializers.py
@@ -191,6 +191,7 @@ class CaseSerializer(CaseSerializerBase):
             "callback_window_type",
             "adaptation_details",
             "thirdparty_details",
+            "gtm_anon_id",
         )
         writable_nested_fields = ["adaptation_details", "personal_details", "thirdparty_details"]
 

--- a/cla_backend/apps/checker/tests/api/test_case_api.py
+++ b/cla_backend/apps/checker/tests/api/test_case_api.py
@@ -44,6 +44,7 @@ class BaseCaseTestCase(
                 "callback_window_type",
                 "adaptation_details",
                 "thirdparty_details",
+                "gtm_anon_id",
             ],
         )
 

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -250,6 +250,7 @@ class CaseSerializer(CaseSerializerFull):
             "outcome_description",
             "source",
             "complaint_flag",
+            "gtm_anon_id",
         )
 
 

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -63,6 +63,7 @@ class BaseCaseTestCase(CLAProviderAuthBaseApiTestMixin, BaseFullCaseAPIMixin, AP
             "category",
             "source",
             "complaint_flag",
+            "gtm_anon_id",
         ]
 
     def get_extra_search_make_recipe_kwargs(self):

--- a/cla_backend/apps/legalaid/migrations/0035_case_gtm_anon_id.py
+++ b/cla_backend/apps/legalaid/migrations/0035_case_gtm_anon_id.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('legalaid', '0034_case_callback_type'),]
+
+    operations = [
+        migrations.AddField(
+            model_name='case',
+            name='gtm_anon_id',
+            field=models.UUIDField(null=True, blank=True),
+        )
+    ]

--- a/cla_backend/apps/legalaid/migrations/0035_case_gtm_anon_id.py
+++ b/cla_backend/apps/legalaid/migrations/0035_case_gtm_anon_id.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [('legalaid', '0034_case_callback_type'),]
+    dependencies = [('legalaid', '0034_case_callback_type')]
 
     operations = [
         migrations.AddField(

--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -775,6 +775,8 @@ class Case(TimeStampedModel):
     complaint_flag = models.BooleanField(default=False)
     is_urgent = models.BooleanField(default=False)
 
+    gtm_anon_id = models.UUIDField(unique=False, null=True, blank=True)
+
     class Meta(object):
         ordering = ("-created",)
         permissions = (

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -446,6 +446,7 @@ class CaseSerializerFull(CaseSerializerBase):
 
     exempt_user = serializers.NullBooleanField(required=False)
 
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = User

--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -393,6 +393,7 @@ class CaseSerializerBase(PartialUpdateExcludeReadonlySerializerMixin, ClaModelSe
     outcome_code = serializers.CharField(max_length=50, required=False, allow_blank=True)
     outcome_description = serializers.SerializerMethodField("_get_outcome_description")
     call_started = serializers.SerializerMethodField("_call_started")
+    gtm_anon_id = serializers.UUIDField(required=False)
 
     def _call_started(self, case):
         return Log.objects.filter(case=case, code="CALL_STARTED").exists()
@@ -444,7 +445,6 @@ class CaseSerializerFull(CaseSerializerBase):
     category = serializers.CharField(source="diagnosis.category.name", read_only=True)
 
     exempt_user = serializers.NullBooleanField(required=False)
-
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta(object):

--- a/cla_backend/apps/legalaid/tests/test_models.py
+++ b/cla_backend/apps/legalaid/tests/test_models.py
@@ -1419,6 +1419,7 @@ class SplitCaseTestCase(CloneModelsTestCaseMixin, TestCase):
             "organisation",
             "callback_window_type",
             "callback_type",
+            "gtm_anon_id",
         ]
 
         if internal:
@@ -1464,6 +1465,7 @@ class SplitCaseTestCase(CloneModelsTestCaseMixin, TestCase):
             "ecf_statement": case.ecf_statement,
             "personal_details": case.personal_details,
             "from_case": case,
+            "gtm_anon_id": None,
         }
 
         if internal:


### PR DESCRIPTION
## What does this pull request do?

For: cross-service GA tracking

Add gtm_anon_id to case data
Add support for gtm_anon_id for checker to post in and save into case data
Add support for call centre to GET gtm_anon_id from case data and auto generate for new case.
Add support for provider to GET gtm_anon_id as part of case data

Public: https://github.com/ministryofjustice/cla_public/pull/1263
Frontend: https://github.com/ministryofjustice/cla_frontend/pull/956
Backend: https://github.com/ministryofjustice/cla_backend/pull/1178

## Any other changes that would benefit highlighting?

Documentation: https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/4952031380/End+to+end+CLA+Google+Analytics+reporting


## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
