### PR TITLE
Feature/lga 3153 date field mi report

### DIFF
--- a/cla_backend/apps/reports/sql/MIDemographicReport.sql
+++ b/cla_backend/apps/reports/sql/MIDemographicReport.sql
@@ -14,7 +14,7 @@ SELECT
     legalaid_case.reference AS "Case ID",
     legalaid_provider.name AS "Provider ID",
     category.code AS "Category Name",
-    legalaid_case.created AS "Date Case Created",
+    TO_CHAR(legalaid_case.created, 'DD-MM-YYYY') AS "Date Case Created",
     matter_type_1.code AS "Matter Type 1",
     matter_type_2.code AS "Matter Type 2",
     CASE diagnosis.state
@@ -65,7 +65,7 @@ SELECT
       ELSE 'Non-English'
     END as "Language",
     legalaid_case.outcome_code as "Outcome code",
-    latest_outcome.created as "Outcome Created At",
+    TO_CHAR(latest_outcome.created, 'DD-MM-YYYY') as "Outcome Created At",
     legalaid_case.thirdparty_details_id::bool as "Has Third Party",
     call_centre_organisation.name as "Organisation",
     personal_details.vulnerable_user as "Vulnerable User",

--- a/cla_backend/apps/reports/sql/MIDemographicReport.sql
+++ b/cla_backend/apps/reports/sql/MIDemographicReport.sql
@@ -14,7 +14,7 @@ SELECT
     legalaid_case.reference AS "Case ID",
     legalaid_provider.name AS "Provider ID",
     category.code AS "Category Name",
-    TO_CHAR(legalaid_case.created, 'DD-MM-YYYY') AS "Date Case Created",
+    TO_CHAR(legalaid_case.created, 'DD-MM-YY') AS "Date Case Created",
     matter_type_1.code AS "Matter Type 1",
     matter_type_2.code AS "Matter Type 2",
     CASE diagnosis.state
@@ -65,7 +65,7 @@ SELECT
       ELSE 'Non-English'
     END as "Language",
     legalaid_case.outcome_code as "Outcome code",
-    TO_CHAR(latest_outcome.created, 'DD-MM-YYYY') as "Outcome Created At",
+    TO_CHAR(latest_outcome.created, 'DD-MM-YY') as "Outcome Created At",
     legalaid_case.thirdparty_details_id::bool as "Has Third Party",
     call_centre_organisation.name as "Organisation",
     personal_details.vulnerable_user as "Vulnerable User",


### PR DESCRIPTION
## What does this pull request do?

Amend the date field of date case created and outcome created at from yyyy-mm-dd hh:mm:ss to dd-mm-yy as below
<img width="169" alt="Screenshot 2024-06-19 at 16 03 48" src="https://github.com/ministryofjustice/cla_backend/assets/65071578/000b57dd-a3f3-4ad5-8408-c6da2ac6cc0d">


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
