### PR TITLE
LGA-3156 Allow null for old cases being updated on CHS

### DIFF
--- a/cla_backend/apps/legalaid/serializers.py
+++ b/cla_backend/apps/legalaid/serializers.py
@@ -393,7 +393,7 @@ class CaseSerializerBase(PartialUpdateExcludeReadonlySerializerMixin, ClaModelSe
     outcome_code = serializers.CharField(max_length=50, required=False, allow_blank=True)
     outcome_description = serializers.SerializerMethodField("_get_outcome_description")
     call_started = serializers.SerializerMethodField("_call_started")
-    gtm_anon_id = serializers.UUIDField(required=False)
+    gtm_anon_id = serializers.UUIDField(required=False, allow_null=True)
 
     def _call_started(self, case):
         return Log.objects.filter(case=case, code="CALL_STARTED").exists()


### PR DESCRIPTION
## What does this pull request do?

Allow null gtm_anon_id for old cases on CHS because it updates case when someone updates personal details and otherwise expects a value for gtm_anon_id, which isn't on there.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
