### PR TITLE
LGA-3155 Update nodes field to extrapolate the json data

### DIFF
--- a/cla_backend/apps/legalaid/management/commands/generate_restricted_views.py
+++ b/cla_backend/apps/legalaid/management/commands/generate_restricted_views.py
@@ -127,6 +127,8 @@ def create_view(view_name, table, columns):
         columns (list[str]): List of column names to include in the view
     """
     command = "CREATE VIEW %s AS SELECT %s FROM %s"
+    if "diagnosis_diagnosistraversal.nodes" in columns:
+        columns = columns.replace("diagnosis_diagnosistraversal.nodes", "json_array_elements(nodes) as nodes")
     with connection.cursor() as cursor:
         cursor.execute(command, [AsIs(view_name), AsIs(columns), AsIs(table)])
         logger.info("Created view: {view_name} with columns: {columns}".format(view_name=view_name, columns=columns))


### PR DESCRIPTION
## What does this pull request do?

Updates the nodes field to remove the square brackets so that it can be identified as a json on metabase. This only happens in the generated view and will have no affect on the table.

Data will now appear as below:
<img width="278" alt="Screenshot 2024-06-26 at 08 30 00" src="https://github.com/ministryofjustice/cla_backend/assets/65071578/26d80da5-e107-40bf-893e-b0d5e2dea69c">

The code ./manage.py generate_restricted_views will need to be run on the environments.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

https://dsdmoj.atlassian.net/browse/LGA-3155
