### PR TITLE
LGA-3172 Bug Fix, Add in DOM1 VPN to Whitelist

### DIFF
--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -61,7 +61,9 @@ ingress:
     # MoJ Official
     - 51.149.250.0/24
     # DOM1 VPN Addresses
+    # ARK Corsham Internet Egress Exponential-E
     - 51.149.249.0/29
+    # ARK Farnborough Internet Egress Exponential-E
     - 51.149.249.32/29
 
 localPostgres:

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -60,6 +60,9 @@ ingress:
     - 35.176.148.126/32
     # MoJ Official
     - 51.149.250.0/24
+    # DOM1 VPN Addresses
+    - 51.149.249.0/29
+    - 51.149.249.32/29
 
 localPostgres:
   enabled: false


### PR DESCRIPTION
## What does this pull request do?

Adds in the 51.149.249 address to the whitelist for DOM1 users, using the Cisco VPN. IP Addresses taken from other MOJ projects https://github.com/ministryofjustice/licences/blob/d53b24c6580856a481f97be86aaca52647d1e12c/helm_deploy/values-preprod.yaml#L81

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

https://dsdmoj.atlassian.net/browse/LGA-3172
