### PR TITLE
Add additional IPs from shared LAA whitelist

### DIFF
--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -4,6 +4,10 @@ set -e
 ROOT=$(dirname "$0")
 HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
 
+# Pull ranges from shared LAA IP ranges and then remove spaces,
+# replace linebreaks with commas, remove last comma, and escape commas for helm input
+SHARED_IP_RANGES_LAA=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
+
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
@@ -14,4 +18,5 @@ helm upgrade $RELEASE_NAME \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \
+  --set-string sharedIPRangesLAA=$SHARED_IP_RANGES_LAA \
   --install

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -4,6 +4,10 @@ set -e
 ROOT=$(dirname "$0")
 HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
 
+# Pull ranges from shared LAA IP ranges and then remove spaces,
+# replace linebreaks with commas, remove last comma, and escape commas for helm input
+SHARED_IP_RANGES_LAA=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
+
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
@@ -15,4 +19,5 @@ helm upgrade $RELEASE_NAME \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \
+  --set-string sharedIPRangesLAA=$SHARED_IP_RANGES_LAA \
   --install

--- a/bin/training_deploy.sh
+++ b/bin/training_deploy.sh
@@ -4,6 +4,10 @@ set -e
 ROOT=$(dirname "$0")
 HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
 
+# Pull ranges from shared LAA IP ranges and then remove spaces,
+# replace linebreaks with commas, remove last comma, and escape commas for helm input
+SHARED_IP_RANGES_LAA=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
+
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_TRAINING_NAMESPACE} \
@@ -15,4 +19,5 @@ helm upgrade $RELEASE_NAME \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \
+  --set-string sharedIPRangesLAA=$SHARED_IP_RANGES_LAA \
   --install

--- a/bin/uat_deploy.sh
+++ b/bin/uat_deploy.sh
@@ -11,6 +11,10 @@ fi
 
 echo "Using values file:$VALUES"
 
+# Pull ranges from shared LAA IP ranges and then remove spaces,
+# replace linebreaks with commas, remove last comma, and escape commas for helm input
+SHARED_IP_RANGES_LAA=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
+
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_UAT_NAMESPACE} \
@@ -23,4 +27,5 @@ helm upgrade $RELEASE_NAME \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \
+  --set-string sharedIPRangesLAA=$SHARED_IP_RANGES_LAA \
   --install

--- a/helm_deploy/cla-backend/templates/_helpers.tpl
+++ b/helm_deploy/cla-backend/templates/_helpers.tpl
@@ -13,7 +13,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "cla-backend.whitelist" -}}
-{{ join "," .Values.ingress.whitelist }},{{- .Values.pingdomIPs }}{{ include "cla-backend.whitelist_additional" . }}
+{{ join "," .Values.ingress.whitelist }},{{- .Values.pingdomIPs }}{{ include "cla-backend.whitelist_additional" . }},{{- .Values.sharedIPRangesLAA }}
 {{- end -}}
 
 {{/*

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -46,31 +46,10 @@ ingress:
     name: ~
     weight: ~
   whitelist:
-    # Cisco Anyconnect (Dom1) / ARK data centre
-    - 194.33.192.0/25
-    - 194.33.196.0/25
     # HGS
     - 84.43.86.100/32
     # CHS
     - 52.210.114.89/32
-    # GlobalProtect VPN (Digital Mac)
-    - 18.169.147.172/32
-    - 35.176.93.186/32
-    - 18.130.148.126/32
-    - 35.176.148.126/32
-    # MoJ Official
-    - 51.149.250.0/24
-    # DOM1 VPN Addresses
-    # ARK Corsham Internet Egress Exponential-E
-    - 51.149.249.0/29
-    # ARK Farnborough Internet Egress Exponential-E
-    - 51.149.249.32/29
-    # PRP DIA Sites
-    - 194.33.200.0/21
-    - 194.33.216.0/23
-    - 194.33.218.0/24
-    # Palo Alto Prisma Access Egress IP Addresses - Prisma_Access:
-    - 128.77.75.64/26
 
 localPostgres:
   enabled: false


### PR DESCRIPTION
## What does this pull request do?

- Pulls IP addresses, including the new Prisma VPN from the new LAA Shared IP list: [https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt](https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt)
- Removes IP addresses that would be duplicated

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
