### PR TITLE
Fix Ambiguous timezone error

### DIFF
--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -23,6 +23,12 @@ class CheckerOpeningHours(OpeningHours):
         """
         slots = super(CheckerOpeningHours, self).time_slots(day)
 
+        # cla_common gives all valid time slots from 00:00 to 23:30
+        # The call centre doesn't work before 5AM, this allows us to check far fewer time slots and
+        # also fix an ambiguous time error where 01:00:00 on a DST switchover date could belong to multiple
+        # timezones.
+        slots = filter(lambda dt: dt.hour > 5, slots)
+
         if is_third_party_callback:  # Third party callbacks always have capacity.
             return slots
 


### PR DESCRIPTION
## What does this pull request do?

Fixes a bug where we were converting from an unaware timezone at 01:00:00 on the 27th of October 2024 to a London timezone.

This time technically occurs twice due to switching off daylight savings time, so the date time module didn't know what timezone it belonged to, and raised an error.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
