### PR TITLE
Remove false ModSec rule

### DIFF
--- a/helm_deploy/cla-backend/templates/ingress_v122.yaml
+++ b/helm_deploy/cla-backend/templates/ingress_v122.yaml
@@ -28,6 +28,8 @@ metadata:
       # This rule is triggering false positives when trying to save guidance notes that contain markdown.
       # See LGA-3333 for more details.
       SecRuleRemoveById 933210
+      # This rule is triggering false positives when trying to upload CSV files
+      SecRuleRemoveById 932130
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
## What does this pull request do?

Removes rule ID 932130 from the ModSec ingress which is triggering false positives on the CSV import.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
