### PR TITLE
Fix callback capping

### DIFF
--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -14,7 +14,7 @@ class CheckerOpeningHours(OpeningHours):
         otherwise the capacity will be based from the set of cases in range.
 
         Args:
-            callback_times (List): List callback times
+            callback_times (List): List of callback date times
             day (datetime.date, optional): Date to get slots for. Defaults to None.
             is_third_party_callback (bool, optional): Is the callback for a third party. Defaults to False.
 

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -127,7 +127,9 @@ def get_available_slots(num_days=7, is_third_party_callback=False):
         Dict: Dictionary of callback slots in the form: {"YYYYMMDD":  {"HHMM": {"start": datetime, "end": datetime}}}
     """
     start_dt = current_datetime()
-    end_dt = start_dt + datetime.timedelta(days=num_days)
+    end_dt = start_dt + datetime.timedelta(
+        days=num_days + 1
+    )  # +1 to ensure we capture callbacks from the final full day
     days = [start_dt]
     # Generate time slots options for call on another day select options
     if num_days > 1:

--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -14,7 +14,7 @@ class CheckerOpeningHours(OpeningHours):
         otherwise the capacity will be based from the set of cases in range.
 
         Args:
-            cases_in_range (QuerySet): Set of cases with callbacks
+            callback_times (List): List callback times
             day (datetime.date, optional): Date to get slots for. Defaults to None.
             is_third_party_callback (bool, optional): Is the callback for a third party. Defaults to False.
 
@@ -127,13 +127,15 @@ def get_available_slots(num_days=7, is_third_party_callback=False):
         Dict: Dictionary of callback slots in the form: {"YYYYMMDD":  {"HHMM": {"start": datetime, "end": datetime}}}
     """
     start_dt = current_datetime()
-    end_dt = start_dt + datetime.timedelta(
-        days=num_days + 1
-    )  # +1 to ensure we capture callbacks from the final full day
     days = [start_dt]
     # Generate time slots options for call on another day select options
     if num_days > 1:
-        days.extend(CALL_CENTER_HOURS.available_days(num_days - 1))
+        # available_days gives us all call centre working days meaning Sundays and bank holidays are excluded.
+        days.extend(CALL_CENTER_HOURS.available_days(num_days - 1))  # days will always have length = num_days
+
+    end_dt = datetime.datetime.combine(
+        date=days[-1].date(), time=datetime.datetime.max.time()
+    )  # 23:59:59 on the final date of relevant time period.
 
     # As making a Case query is expensive, we want to make a single query for relevant callback times and compare all time slots to this set of times.
     callback_times = get_list_callback_times(start_dt, end_dt)


### PR DESCRIPTION
## What does this pull request do?

### Problem
When the callback capacity was calculated we queried the database with for all cases with callbacks between now and `num_days` later. This means if the calculation was ran at 14:15 on the 1st of January 2025 with `num days = 7` we would look for all callbacks between 14:15 on the 1st of January 2025 and 14:15 on the 7th of January 2025.

However, the callback capacity API returns data on all callbacks between the 1st of January 2025 00:00:00 and the 7th of January 2025 23:59:59 regardless of when in the day the calculation was run.

This resulted in the system allowing callbacks to be booked 7 days in advance, ignoring the callback cap, assuming the callback time was later in the day than when the booking was being made.

### Solution
Ensure we capture callback information for the entire relevant time period by setting the `end_dt` to `23:59:59` of the final day we return information for.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
