### PR TITLE
Callback capacity only include CB1

### DIFF
--- a/cla_backend/apps/checker/call_centre_availability.py
+++ b/cla_backend/apps/checker/call_centre_availability.py
@@ -86,6 +86,8 @@ def get_list_callback_times(start_dt, end_dt):
     """ Gets a list of requested callback times made via the web form within the given range.
         Excludes callbacks requested for a third party.
 
+        Only includes cases with an outcome code of CB1, i.e. First callback attempt is yet to occur.
+
     Args:
         start_dt (datetime.datetime): Start of time range
         end_dt (datetime.datetime): End of time range
@@ -94,7 +96,7 @@ def get_list_callback_times(start_dt, end_dt):
         list[datetime.datetime]: List of requested callback times.
     """
     callback_times = Case.objects.filter(
-        requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF
+        requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF, outcome_code="CB1"
     ).values_list("requires_action_at", flat=True)
     return callback_times
 

--- a/cla_backend/apps/checker/forms.py
+++ b/cla_backend/apps/checker/forms.py
@@ -17,7 +17,10 @@ class WebCallMeBackForm(BaseCallMeBackForm):
 
     def save(self, user):
         super(WebCallMeBackForm, self).save(user)
-        if callback_capacity_threshold_breached(self.case.requires_action_at):
+
+        # We only want to fire a notification email if this case could have subtracted from the slot capacity
+        should_case_contribute_to_cap = self.case.callback_type == "web_form_self" and self.case.outcome_code == "CB1"
+        if callback_capacity_threshold_breached(self.case.requires_action_at) and should_case_contribute_to_cap:
             callback_capacity_threshold_breach_send_notification(self.case.requires_action_at)
 
 

--- a/cla_backend/apps/checker/models.py
+++ b/cla_backend/apps/checker/models.py
@@ -290,12 +290,25 @@ class CallbackTimeSlot(TimeStampedModel):
 
     @staticmethod
     def get_remaining_capacity_by_range(capacity, start_dt, end_dt):
+        """ Gets a count of the remaining callback slots for callbacks booked via the webform for a given period of time.
+            Excludes callbacks requested for a third party.
+
+            Only includes cases with an outcome code of CB1, i.e. First callback attempt is yet to occur.
+
+            Args:
+                capacity (int): The capacity for a given time slot
+                start_dt (datetime.datetime): Start of time range
+                end_dt (datetime.datetime): End of time range
+
+            Returns:
+                list[datetime.datetime]: List of requested callback times.
+            """
         from legalaid.models import Case
 
         # otherwise this will match cases that have a requires_action_at of the end date(don't want it to be inclusive)
         end_dt = end_dt - datetime.timedelta(seconds=1)
         count = Case.objects.filter(
-            requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF
+            requires_action_at__range=(start_dt, end_dt), callback_type=CALLBACK_TYPES.CHECKER_SELF, outcome_code="CB1"
         ).count()
         return capacity - count
 

--- a/cla_backend/apps/checker/tests/api/test_callback_time_slots.py
+++ b/cla_backend/apps/checker/tests/api/test_callback_time_slots.py
@@ -36,7 +36,10 @@ class CallbackTimeSlotsTestCase(SimpleResourceAPIMixin, CLACheckerAuthBaseApiTes
         # Book a callback for 10am tomorrow. 10am slot only has a capacity of 1, after this it should not be available
         requires_action_at = dt.datetime.combine(tomorrow, dt.time(hour=10, minute=0))
         make_recipe(
-            self.LEGALAID_CASE, requires_action_at=requires_action_at, callback_type=CALLBACK_TYPES.CHECKER_SELF
+            self.LEGALAID_CASE,
+            requires_action_at=requires_action_at,
+            callback_type=CALLBACK_TYPES.CHECKER_SELF,
+            outcome_code="CB1",
         )
         slots = get_available_slots(num_days=2)
         self.assertIn(dt.datetime.combine(tomorrow, dt.time(hour=9, minute=0)), slots)
@@ -57,7 +60,10 @@ class CallbackTimeSlotsTestCase(SimpleResourceAPIMixin, CLACheckerAuthBaseApiTes
         requires_action_at = dt.datetime.combine(tomorrow, dt.time(hour=10, minute=0))
         for _ in range(2):
             make_recipe(
-                self.LEGALAID_CASE, requires_action_at=requires_action_at, callback_type=CALLBACK_TYPES.CHECKER_SELF
+                self.LEGALAID_CASE,
+                requires_action_at=requires_action_at,
+                callback_type=CALLBACK_TYPES.CHECKER_SELF,
+                outcome_code="CB1",
             )
         slots = get_available_slots(num_days=2)
         self.assertIn(dt.datetime.combine(tomorrow, dt.time(9, 0)), slots)
@@ -77,7 +83,10 @@ class CallbackTimeSlotsTestCase(SimpleResourceAPIMixin, CLACheckerAuthBaseApiTes
         # Book a callback for 10am tomorrow
         requires_action_at = dt.datetime.combine(tomorrow, dt.time(hour=10, minute=0))
         make_recipe(
-            self.LEGALAID_CASE, requires_action_at=requires_action_at, callback_type=CALLBACK_TYPES.CHECKER_SELF
+            self.LEGALAID_CASE,
+            requires_action_at=requires_action_at,
+            callback_type=CALLBACK_TYPES.CHECKER_SELF,
+            outcome_code="CB1",
         )
 
         slots = get_available_slots(num_days=2, is_third_party_callback=True)
@@ -114,7 +123,10 @@ class CallbackTimeSlotsTestCase(SimpleResourceAPIMixin, CLACheckerAuthBaseApiTes
         # Book a callback for 14:30 tomorrow.
         requires_action_at = dt.datetime.combine(tomorrow, dt.time(hour=14, minute=30))
         make_recipe(
-            self.LEGALAID_CASE, requires_action_at=requires_action_at, callback_type=CALLBACK_TYPES.CHECKER_SELF
+            self.LEGALAID_CASE,
+            requires_action_at=requires_action_at,
+            callback_type=CALLBACK_TYPES.CHECKER_SELF,
+            outcome_code="CB1",
         )
         slots = get_available_slots(num_days=2)
         self.assertIn(dt.datetime.combine(tomorrow, dt.time(hour=14, minute=0)), slots)
@@ -129,7 +141,12 @@ class TestGetListCallbackTimes(unittest.TestCase):
         start_dt = dt.datetime.now()
         timeslots = [start_dt + dt.timedelta(hours=i) for i in range(1, 12)]
         for timeslot in timeslots:
-            make_recipe(self.LEGALAID_CASE, requires_action_at=timeslot, callback_type=CALLBACK_TYPES.CHECKER_SELF)
+            make_recipe(
+                self.LEGALAID_CASE,
+                requires_action_at=timeslot,
+                callback_type=CALLBACK_TYPES.CHECKER_SELF,
+                outcome_code="CB1",
+            )
         actual_result = get_list_callback_times(start_dt, start_dt + dt.timedelta(days=1))
         assert len(actual_result) == len(timeslots)
         for timeslot in timeslots:
@@ -139,7 +156,12 @@ class TestGetListCallbackTimes(unittest.TestCase):
         start_dt = dt.datetime.now() + dt.timedelta(days=2)
         timeslots = [start_dt, start_dt, start_dt, start_dt + dt.timedelta(hours=1)]
         for timeslot in timeslots:
-            make_recipe(self.LEGALAID_CASE, requires_action_at=timeslot, callback_type=CALLBACK_TYPES.CHECKER_SELF)
+            make_recipe(
+                self.LEGALAID_CASE,
+                requires_action_at=timeslot,
+                callback_type=CALLBACK_TYPES.CHECKER_SELF,
+                outcome_code="CB1",
+            )
         actual_result = get_list_callback_times(start_dt, start_dt + dt.timedelta(days=1))
         count = 0
         for slot in actual_result:
@@ -150,7 +172,12 @@ class TestGetListCallbackTimes(unittest.TestCase):
     def test_out_of_range(self):
         timeslots = [dt.datetime(2024, 1, 1), dt.datetime(2024, 1, 3), dt.datetime(2024, 1, 5)]
         for timeslot in timeslots:
-            make_recipe(self.LEGALAID_CASE, requires_action_at=timeslot, callback_type=CALLBACK_TYPES.CHECKER_SELF)
+            make_recipe(
+                self.LEGALAID_CASE,
+                requires_action_at=timeslot,
+                callback_type=CALLBACK_TYPES.CHECKER_SELF,
+                outcome_code="CB1",
+            )
         actual_result = get_list_callback_times(dt.datetime(2024, 1, 2), dt.datetime(2024, 1, 4))
         assert len(actual_result) == 1
 

--- a/cla_backend/apps/checker/tests/helpers/test_helpers.py
+++ b/cla_backend/apps/checker/tests/helpers/test_helpers.py
@@ -107,4 +107,9 @@ class TestGetTimeslotOfDate(TestCase):
             make_recipe(self.CALLBACK_TIME_SLOT, **slot)
 
     def _create_callback(self, requires_action_at):
-        make_recipe("legalaid.case", requires_action_at=requires_action_at, callback_type=CALLBACK_TYPES.CHECKER_SELF)
+        make_recipe(
+            "legalaid.case",
+            requires_action_at=requires_action_at,
+            callback_type=CALLBACK_TYPES.CHECKER_SELF,
+            outcome_code="CB1",
+        )

--- a/cla_backend/apps/reports/tests/test_reports.py
+++ b/cla_backend/apps/reports/tests/test_reports.py
@@ -520,6 +520,7 @@ class TestCallbackTimeSlotReport(TestCase):
                     _quantity=callback["Used capacity"],
                     eligibility_check=None,
                     callback_type=CALLBACK_TYPES.CHECKER_SELF,
+                    outcome_code="CB1",
                     notes=interval,
                 )
 


### PR DESCRIPTION
## What does this pull request do?

- Alters the callback capacity algorithm to only include cases with an outcome code of CB1 when calculating used capacity.
- Only fire the callback threshold breached alert emails if the case which triggered the check could have reduced the capacity.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
