### PR TITLE
Add additional logging to determine what is causing users to be locked out

### DIFF
--- a/cla_backend/apps/cla_auth/authentication.py
+++ b/cla_backend/apps/cla_auth/authentication.py
@@ -155,10 +155,12 @@ class EntraAccessTokenAuthentication(authentication.BaseAuthentication):
     def get_or_create_user(self, payload):
         email = payload.get("USER_EMAIL")
         if not email:
+            logger.error("Token payload is missing USER_EMAIL", exc_info=True)
             raise exceptions.AuthenticationFailed("Token payload is missing USER_EMAIL")
 
         raw_roles = payload.get("APP_ROLES")
         if not raw_roles:
+            logger.error("ENTRA: Token payload is missing APP_ROLES", exc_info=True)
             raise exceptions.AuthenticationFailed("Token payload is missing APP_ROLES")
 
         app_role = raw_roles if isinstance(raw_roles, list) else [raw_roles]
@@ -213,7 +215,7 @@ class EntraAccessTokenAuthentication(authentication.BaseAuthentication):
                     user.groups.add(group)
             return True
         except Exception as e:
-            logger.error("Failed to update groups for user %s: %s" % (user.email, e))
+            logger.error("ENTRA: Failed to update groups for user %s: %s" % (user.email, e), exc_info=True)
             return None
 
     def authenticate(self, request, retried=False):
@@ -233,15 +235,18 @@ class EntraAccessTokenAuthentication(authentication.BaseAuthentication):
         app_role, user = self.get_or_create_user(payload)
 
         if not user:
+            logger.error("ENTRA: Could not find or create user for token payload", exc_info=True)
             raise exceptions.AuthenticationFailed("Could not find or create user for token payload")
 
         if not self.user_has_role(user, app_role):
             if retried:
+                logger.error("ENTRA: User %s group does not match expected role %s after update" % (user.email, app_role), exc_info=True)
                 raise exceptions.AuthenticationFailed(
                     "User %s group does not match expected role %s after update" % (user.email, app_role)
                 )
             change_app_role = self.change_user_group(app_role, user)
             if not change_app_role:
+                logger.error("ENTRA: Failed to update group for user %s with roles %s" % (user.email, app_role), exc_info=True)
                 raise exceptions.AuthenticationFailed(
                     "Failed to update group for user %s with roles %s" % (user.email, app_role)
                 )

--- a/cla_backend/apps/cla_auth/views.py
+++ b/cla_backend/apps/cla_auth/views.py
@@ -64,6 +64,11 @@ class AccessTokenView(Oauth2AccessTokenView):
                 response["X-Throttle-Wait-Seconds"] = "%d" % exc.wait
             return response
         except OAuth2Error as exc:
+            if exc.description == "invalid_grant":
+                logger.error("31-03-2026: Investigate invalid_grant. USER: {} AND CLIENT_ID {}".format(
+                    request.POST.get("username"),
+                    request.POST.get("client_id")
+                ), exc_info=True)
             logger.info("User: {}; Error: {}".format(request.POST.get("username"), exc.description))
             response = self.error_response({"error": exc.description}, status=401)
             return response
@@ -125,6 +130,7 @@ class AccessTokenView(Oauth2AccessTokenView):
         try:
             assert class_name.objects.get(user__username=request.POST.get("username"))
         except class_name.DoesNotExist:
+            logger.error("User {} does not exist on client {}".format(request.POST.get("username"), request.POST.get("client_id")), exc_info=True)
             raise OAuth2Error("invalid_grant")
 
     def get_user_model(self, client_name):
@@ -137,6 +143,7 @@ class AccessTokenView(Oauth2AccessTokenView):
         elif client_name == "staff":
             class_name = Staff
         else:
+            logger.error("Unknown client {}".format(client_name), exc_info=True)
             raise OAuth2Error("invalid_grant")
 
         return class_name


### PR DESCRIPTION
## What does this pull request do?

Add additional logging to determine what is causing users to be locked out

## Any other changes that would benefit highlighting?

On 2026-03-31 multiple users reported being locked after the deployment of https://github.com/ministryofjustice/cla_backend/pull/1375 and https://github.com/ministryofjustice/cla_frontend/pull/1055

This PR adds additional logging around both entra and legacy authentication.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
