### PR TITLE
EL-3011: MCC: Case flags backend setup for your cases

### DIFF
--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -308,6 +308,14 @@ class DetailedCaseSerializer(CaseSerializer):
 class CaseListSerializer(CaseSerializer):
     safe_to_contact = serializers.CharField(source='personal_details.safe_to_contact', read_only=True)
     phone_number = serializers.CharField(source='personal_details.mobile_phone', read_only=True)
+    vulnerable_user = serializers.BooleanField(source='personal_details.vulnerable_user', read_only=True)
+    language = serializers.CharField(source='adaptation_details.language', read_only=True, allow_null=True)
+    bsl_webcam = serializers.BooleanField(source='adaptation_details.bsl_webcam', read_only=True)
+    text_relay = serializers.BooleanField(source='adaptation_details.text_relay', read_only=True)
+    thirdparty = serializers.SerializerMethodField()
+
+    def get_thirdparty(self, obj):
+        return obj.thirdparty_details is not None
 
     class Meta(CaseSerializer.Meta):
         fields = (
@@ -333,6 +341,11 @@ class CaseListSerializer(CaseSerializer):
             "is_urgent",
             "safe_to_contact",
             "phone_number",
+            "vulnerable_user",
+            "thirdparty",
+            "bsl_webcam",
+            "text_relay",
+            "language"
         )
 
 

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -312,13 +312,18 @@ class CaseListSerializer(CaseSerializer):
 
     def get_mcc_case_flags(self, obj):
         try:
+            thirdparty = obj.thirdparty_details.reference
+        except obj.__class__.thirdparty_details.RelatedObjectDoesNotExist:
+            thirdparty = None
+
+        try:
             adaptation = obj.adaptation_details
-        except Exception:
+        except obj.__class__.adaptation_details.RelatedObjectDoesNotExist:
             adaptation = None
 
         return {
             "vulnerable_user": getattr(obj.personal_details, "vulnerable_user", None),
-            "thirdparty": hasattr(obj, "thirdparty_details"),
+            "thirdparty_details": thirdparty,
             "bsl_webcam": getattr(adaptation, "bsl_webcam", None),
             "text_relay": getattr(adaptation, "text_relay", None),
             "language": getattr(adaptation, "language", None),

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -323,7 +323,7 @@ class CaseListSerializer(CaseSerializer):
 
         return {
             "vulnerable_user": getattr(obj.personal_details, "vulnerable_user", None),
-            "thirdparty_details": thirdparty_obj,
+            "thirdparty_details": thirdparty_obj is not None,
             "bsl_webcam": getattr(adaptation, "bsl_webcam", None),
             "text_relay": getattr(adaptation, "text_relay", None),
             "language": getattr(adaptation, "language", None),

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -308,14 +308,21 @@ class DetailedCaseSerializer(CaseSerializer):
 class CaseListSerializer(CaseSerializer):
     safe_to_contact = serializers.CharField(source='personal_details.safe_to_contact', read_only=True)
     phone_number = serializers.CharField(source='personal_details.mobile_phone', read_only=True)
-    vulnerable_user = serializers.BooleanField(source='personal_details.vulnerable_user', read_only=True)
-    language = serializers.CharField(source='adaptation_details.language', read_only=True, allow_null=True)
-    bsl_webcam = serializers.BooleanField(source='adaptation_details.bsl_webcam', read_only=True)
-    text_relay = serializers.BooleanField(source='adaptation_details.text_relay', read_only=True)
-    thirdparty = serializers.SerializerMethodField()
+    mcc_case_flags = serializers.SerializerMethodField()
 
-    def get_thirdparty(self, obj):
-        return obj.thirdparty_details is not None
+    def get_mcc_case_flags(self, obj):
+        try:
+            adaptation = obj.adaptation_details
+        except Exception:
+            adaptation = None
+
+        return {
+            "vulnerable_user": getattr(obj.personal_details, "vulnerable_user", None),
+            "thirdparty": hasattr(obj, "thirdparty_details"),
+            "bsl_webcam": getattr(adaptation, "bsl_webcam", None),
+            "text_relay": getattr(adaptation, "text_relay", None),
+            "language": getattr(adaptation, "language", None),
+        }
 
     class Meta(CaseSerializer.Meta):
         fields = (
@@ -341,11 +348,7 @@ class CaseListSerializer(CaseSerializer):
             "is_urgent",
             "safe_to_contact",
             "phone_number",
-            "vulnerable_user",
-            "thirdparty",
-            "bsl_webcam",
-            "text_relay",
-            "language"
+            "mcc_case_flags",
         )
 
 

--- a/cla_backend/apps/cla_provider/serializers.py
+++ b/cla_backend/apps/cla_provider/serializers.py
@@ -312,9 +312,9 @@ class CaseListSerializer(CaseSerializer):
 
     def get_mcc_case_flags(self, obj):
         try:
-            thirdparty = obj.thirdparty_details.reference
+            thirdparty_obj = obj.thirdparty_details
         except obj.__class__.thirdparty_details.RelatedObjectDoesNotExist:
-            thirdparty = None
+            thirdparty_obj = None
 
         try:
             adaptation = obj.adaptation_details
@@ -323,7 +323,7 @@ class CaseListSerializer(CaseSerializer):
 
         return {
             "vulnerable_user": getattr(obj.personal_details, "vulnerable_user", None),
-            "thirdparty_details": thirdparty,
+            "thirdparty_details": thirdparty_obj,
             "bsl_webcam": getattr(adaptation, "bsl_webcam", None),
             "text_relay": getattr(adaptation, "text_relay", None),
             "language": getattr(adaptation, "language", None),

--- a/cla_backend/apps/cla_provider/tests/api/test_detailed_serializer.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_detailed_serializer.py
@@ -28,6 +28,14 @@ class SerializerConfigurationTest(TestCase):
         self.assertNotIn('eligibility_check', list_fields)
         self.assertIn('safe_to_contact', list_fields)
         self.assertIn('phone_number', list_fields)
+        self.assertIn("mcc_case_flags", list_fields)
+        
+        # Not at top-level on CaseListSerializer
+        self.assertNotIn("vulnerable_user", list_fields)
+        self.assertNotIn("thirdparty_details", list_fields)
+        self.assertNotIn("bsl_webcam", list_fields)
+        self.assertNotIn("text_relay", list_fields)
+        self.assertNotIn("language", list_fields)
 
         # DetailedCaseSerializer
         self.assertIn('state', detailed_fields)

--- a/cla_backend/apps/cla_provider/tests/api/test_detailed_serializer.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_detailed_serializer.py
@@ -29,7 +29,7 @@ class SerializerConfigurationTest(TestCase):
         self.assertIn('safe_to_contact', list_fields)
         self.assertIn('phone_number', list_fields)
         self.assertIn("mcc_case_flags", list_fields)
-        
+
         # Not at top-level on CaseListSerializer
         self.assertNotIn("vulnerable_user", list_fields)
         self.assertNotIn("thirdparty_details", list_fields)

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -111,7 +111,7 @@ class CaseViewSet(CLAProviderPermissionViewSetMixin, FullCaseViewSet):
     serializer_detail_class = CaseSerializer
 
     queryset = Case.objects.exclude(provider=None).select_related(
-        "diagnosis", "eligibility_check", "personal_details", "scope_traversal"
+        "diagnosis", "eligibility_check", "personal_details", "scope_traversal", "adaptation_details", "thirdparty_details"
     )
     queryset_detail = Case.objects.exclude(provider=None).select_related(
         "eligibility_check",


### PR DESCRIPTION
## What does this pull request do?

- Add additional case flags to existing `GET /cla_provider/api/v1/case/` endpoint
- This adds `vulnerable_user`, `language`, `bsl_webcam`, `text_relay` & `thirdparty` to endpoint

## Any other changes that would benefit highlighting?

 Returned API call will look like this;

```
"reference": "VW-0000",
"created": "2026-03-16T10:04:22.017Z",
"modified": "2026-03-16T10:04:22.058Z",
"full_name": "John Smith",
"laa_reference": 007,
"eligibility_state": "yes",
"personal_details": "cb000000",
"requires_action_by": "2_provider",
"postcode": "SE18",
"diagnosis_state": "INSCOPE",
"date_of_birth": "1975-08-04",
"category": "Discrimination, disability and other issues",
outcome_code": "REF-INT",
"outcome_description": "Referred internally",
"case_count": 21,
 "provider_viewed": null,
"provider_accepted": null,
"provider_closed": null,
"provider_assigned_at": "2026-03-05T16:40:13.354Z",
"is_urgent": false,
"safe_to_contact": "SAFE",
"phone_number": "07777777779",
"mcc_case_flags": {
  "language": "BURMESE",
  "text_relay": false,
  "thirdparty": true,
  "vulnerable_user": null,
  "bsl_webcam": false
} 
```

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
