### PR TITLE
spike/LGA-3974: Route education dummy-provider assignments to EDFF alternative help

### DIFF
--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -1,4 +1,5 @@
 import datetime
+from django.test.utils import override_settings
 
 from dateutil.parser import parse
 from django.core.urlresolvers import reverse
@@ -519,6 +520,58 @@ class AssignCaseTestCase(BaseCaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["provider"], None)
+
+    @override_settings(
+        EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA=True,
+        EDUCATION_DUMMY_PROVIDER_SHORT_CODE="EDFF_DUMMY",
+    )
+    @mock.patch("cla_provider.models.timezone.now")
+    @mock.patch("cla_provider.helpers.timezone.now")
+    def test_assign_education_dummy_provider_routes_to_edff(self, tz_model_mock, tz_helper_tz):
+        fake_day = datetime.datetime(2014, 1, 2, 9, 1, 0).replace(tzinfo=timezone.get_current_timezone())
+        tz_model_mock.return_value = fake_day
+        tz_helper_tz.return_value = fake_day
+
+        case = make_recipe("legalaid.case")
+        education_category = make_recipe("legalaid.category", code="education")
+        case.eligibility_check.category = education_category
+        case.eligibility_check.save()
+
+        case.matter_type1 = make_recipe("legalaid.matter_type1", category=education_category)
+        case.matter_type2 = make_recipe("legalaid.matter_type2", category=education_category)
+        case.save()
+
+        dummy_provider = make_recipe(
+            "cla_provider.provider",
+            name="Education Dummy Provider",
+            active=True,
+            short_code="EDFF_DUMMY",
+        )
+        make_recipe(
+            "cla_provider.provider_allocation",
+            weighted_distribution=0.6,
+            provider=dummy_provider,
+            category=education_category,
+        )
+
+        url = reverse("call_centre:case-assign", kwargs={"reference": case.reference})
+        data = {"suggested_provider": dummy_provider.pk, "provider_id": dummy_provider.pk, "is_manual": False}
+        response = self.client.post(url, data=data, HTTP_AUTHORIZATION="Bearer %s" % self.token, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["rerouted_to_alternative_help"])
+        self.assertEqual(response.data["outcome_code"], "EDFF")
+        self.assertEqual(response.data["selected_provider"]["id"], dummy_provider.id)
+        self.assertIn("banner_message", response.data)
+
+        case = Case.objects.get(pk=case.pk)
+        self.assertIsNone(case.provider)
+        self.assertEqual(case.outcome_code, "EDFF")
+        self.assertEqual(case.requires_action_by, None)
+
+        edff_logs = Log.objects.filter(case=case, code="EDFF")
+        self.assertEqual(edff_logs.count(), 1)
+        self.assertTrue("AUTO_EDFF_ROUTE" in edff_logs.first().notes)
 
 
 class DeferAssignmentTestCase(ImplicitEventCodeViewTestCaseMixin, BaseCaseTestCase):

--- a/cla_backend/apps/call_centre/tests/api/test_case_api.py
+++ b/cla_backend/apps/call_centre/tests/api/test_case_api.py
@@ -522,7 +522,6 @@ class AssignCaseTestCase(BaseCaseTestCase):
         self.assertEqual(response.data["provider"], None)
 
     @override_settings(
-        EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA=True,
         EDUCATION_DUMMY_PROVIDER_SHORT_CODE="EDFF_DUMMY",
     )
     @mock.patch("cla_provider.models.timezone.now")
@@ -559,16 +558,8 @@ class AssignCaseTestCase(BaseCaseTestCase):
         response = self.client.post(url, data=data, HTTP_AUTHORIZATION="Bearer %s" % self.token, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data["rerouted_to_alternative_help"])
-        self.assertEqual(response.data["outcome_code"], "EDFF")
-        self.assertEqual(response.data["selected_provider"]["id"], dummy_provider.id)
-        self.assertIn("banner_message", response.data)
-
         case = Case.objects.get(pk=case.pk)
-        self.assertIsNone(case.provider)
         self.assertEqual(case.outcome_code, "EDFF")
-        self.assertEqual(case.requires_action_by, None)
-
         edff_logs = Log.objects.filter(case=case, code="EDFF")
         self.assertEqual(edff_logs.count(), 1)
         self.assertTrue("AUTO_EDFF_ROUTE" in edff_logs.first().notes)

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -329,13 +329,11 @@ class CaseViewSet(
         return DRFResponse(suggestions)
 
     def _is_education_dummy_provider(self, case, provider):
-       
         category = case.eligibility_check.category if case.eligibility_check else None
         if not category or category.code != "education" or not provider:
             return False
-        
-        return provider.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
 
+        return provider.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
 
     @detail_route(methods=["post"])
     def assign(self, request, reference=None, **kwargs):
@@ -381,13 +379,12 @@ class CaseViewSet(
                     getattr(case_obj.personal_details, "postcode", "") or "",
                 )
 
-            if self._is_education_dummy_provider(case=obj, provider=provider):      
+            if self._is_education_dummy_provider(case=obj, provider=provider):
                 alt_form = AlternativeHelpForm(case=obj, data={"event_code": "EDFF", "notes": _build_edff_auto_notes(obj, provider)})
                 if alt_form.is_valid():
                     alt_form.save(request.user)
                 else:
                     return DRFResponse({"error": "Could not save EDFF for dummy provider"}, status=status.HTTP_400_BAD_REQUEST)
-
 
             return DRFResponse(data=provider_serialised.data)
 

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -335,6 +335,15 @@ class CaseViewSet(
 
         return provider.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
 
+    def _build_edff_auto_notes(self, provider_obj):
+        return (
+            u"AUTO_EDFF_ROUTE: selected_provider_id={};"
+            u"selected_provider_name={};"
+        ).format(
+            provider_obj.id,
+            provider_obj.name,
+        )
+
     @detail_route(methods=["post"])
     def assign(self, request, reference=None, **kwargs):
         """
@@ -368,19 +377,9 @@ class CaseViewSet(
             provider_serialised = ProviderSerializer(provider)
             self.set_case_organisation(self.get_object())
 
-            def _build_edff_auto_notes(case_obj, provider_obj):
-                return (
-                    u"AUTO_EDFF_ROUTE: selected_provider_id={}; "
-                    u"selected_provider_name={}; "
-                    u"postcode={}"
-                ).format(
-                    provider_obj.id,
-                    provider_obj.name,
-                    getattr(case_obj.personal_details, "postcode", "") or "",
-                )
-
+            # https://dsdmoj.atlassian.net/browse/LGA-3974
             if self._is_education_dummy_provider(case=obj, provider=provider):
-                alt_form = AlternativeHelpForm(case=obj, data={"event_code": "EDFF", "notes": _build_edff_auto_notes(obj, provider)})
+                alt_form = AlternativeHelpForm(case=obj, data={"event_code": "EDFF", "notes": self._build_edff_auto_notes(provider)})
                 if alt_form.is_valid():
                     alt_form.save(request.user)
                 else:

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -328,27 +328,14 @@ class CaseViewSet(
 
         return DRFResponse(suggestions)
 
-    def _is_education_dummy_provider(self, case_obj, provider_obj):
-        category = case_obj.eligibility_check.category if case_obj.eligibility_check else None
-        if not category or category.code != "education":
+    def _is_education_dummy_provider(self, case, provider):
+       
+        category = case.eligibility_check.category if case.eligibility_check else None
+        if not category or category.code != "education" or not provider:
             return False
-        return (
-            settings.EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA
-            and provider_obj.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
-        )
+        
+        return provider.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
 
-    def _build_edff_auto_notes(self, case_obj, provider_obj):
-        postcode = ""
-        if case_obj.personal_details and case_obj.personal_details.postcode:
-            postcode = case_obj.personal_details.postcode
-        return (
-            u"AUTO_EDFF_ROUTE: selected_provider_id={provider_id}; selected_provider_name={provider_name}; "
-            u"postcode={postcode}"
-        ).format(
-            provider_id=provider_obj.id,
-            provider_name=provider_obj.name,
-            postcode=postcode,
-        )
 
     @detail_route(methods=["post"])
     def assign(self, request, reference=None, **kwargs):
@@ -370,37 +357,6 @@ class CaseViewSet(
         else:
             raise ValueError("Provider not found")
 
-        # Route education dummy provider to alternative help (EDFF) instead of assigning a specialist.
-        if self._is_education_dummy_provider(obj, p):
-            alt_data = request.data.copy()
-
-            alt_data.update({"event_code": "EDFF", "notes": self._build_edff_auto_notes(obj, p)})
-
-            alt_form = AlternativeHelpForm(case=obj, data=alt_data)
-            if alt_form.is_valid():
-                alt_form.save(request.user)
-
-                ProviderPreAllocation.objects.clear(case=obj)
-                self.set_case_organisation(self.get_object())
-
-                logger.warning(
-                    "Education case routed to FALA via EDFF (case_reference=%s, provider_id=%s)",
-                    obj.reference,
-                    p.id,
-                )
-
-                return DRFResponse(
-                    data={
-                        "rerouted_to_alternative_help": True,
-                        "selected_provider": ProviderSerializer(p).data,
-                        "banner_message": settings.EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE,
-                        "outcome_code": "EDFF",
-                    },
-                    status=status.HTTP_200_OK,
-                )
-
-            return DRFResponse(dict(alt_form.errors), status=status.HTTP_400_BAD_REQUEST)
-
         data = request.data.copy()
         data["provider"] = p.pk
         form = ProviderAllocationForm(case=obj, data=data, providers=suitable_providers)
@@ -413,6 +369,26 @@ class CaseViewSet(
 
             provider_serialised = ProviderSerializer(provider)
             self.set_case_organisation(self.get_object())
+
+            def _build_edff_auto_notes(case_obj, provider_obj):
+                return (
+                    u"AUTO_EDFF_ROUTE: selected_provider_id={}; "
+                    u"selected_provider_name={}; "
+                    u"postcode={}"
+                ).format(
+                    provider_obj.id,
+                    provider_obj.name,
+                    getattr(case_obj.personal_details, "postcode", "") or "",
+                )
+
+            if self._is_education_dummy_provider(case=obj, provider=provider):      
+                alt_form = AlternativeHelpForm(case=obj, data={"event_code": "EDFF", "notes": _build_edff_auto_notes(obj, provider)})
+                if alt_form.is_valid():
+                    alt_form.save(request.user)
+                else:
+                    return DRFResponse({"error": "Could not save EDFF for dummy provider"}, status=status.HTTP_400_BAD_REQUEST)
+
+
             return DRFResponse(data=provider_serialised.data)
 
         return DRFResponse(dict(form.errors), status=status.HTTP_400_BAD_REQUEST)

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -373,11 +373,8 @@ class CaseViewSet(
         # Route education dummy provider to alternative help (EDFF) instead of assigning a specialist.
         if self._is_education_dummy_provider(obj, p):
             alt_data = request.data.copy()
-            
-            alt_data.update({
-            "event_code": "EDFF",
-            "notes": self._build_edff_auto_notes(obj, p),
-            })
+
+            alt_data.update({"event_code": "EDFF", "notes": self._build_edff_auto_notes(obj, p)})
 
             alt_form = AlternativeHelpForm(case=obj, data=alt_data)
             if alt_form.is_valid():

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from uuid import UUID
 
 from dateutil import parser
@@ -102,6 +103,8 @@ from .models import Operator
 from .utils.organisation import CaseOrganisationAssignCurrentOrganisationMixin
 
 from cla_auditlog.models import AuditLog
+
+logger = logging.getLogger(__name__)
 
 
 class CallCentrePermissionsViewSetMixin(object):
@@ -325,6 +328,28 @@ class CaseViewSet(
 
         return DRFResponse(suggestions)
 
+    def _is_education_dummy_provider(self, case_obj, provider_obj):
+        category = case_obj.eligibility_check.category if case_obj.eligibility_check else None
+        if not category or category.code != "education":
+            return False
+        return (
+            settings.EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA
+            and provider_obj.short_code == settings.EDUCATION_DUMMY_PROVIDER_SHORT_CODE
+        )
+
+    def _build_edff_auto_notes(self, case_obj, provider_obj):
+        postcode = ""
+        if case_obj.personal_details and case_obj.personal_details.postcode:
+            postcode = case_obj.personal_details.postcode
+        return (
+            u"AUTO_EDFF_ROUTE: selected_provider_id={provider_id}; selected_provider_name={provider_name}; "
+            u"postcode={postcode}"
+        ).format(
+            provider_id=provider_obj.id,
+            provider_name=provider_obj.name,
+            postcode=postcode,
+        )
+
     @detail_route(methods=["post"])
     def assign(self, request, reference=None, **kwargs):
         """
@@ -345,9 +370,37 @@ class CaseViewSet(
         else:
             raise ValueError("Provider not found")
 
-        # if we're inside office hours then:
-        # Randomly assign to provider who offers this category of service
-        # else it should be the on duty provider
+        # Route education dummy provider to alternative help (EDFF) instead of assigning a specialist.
+        if self._is_education_dummy_provider(obj, p):
+            alt_data = request.data.copy()
+            alt_data["event_code"] = "EDFF"
+            alt_data["notes"] = self._build_edff_auto_notes(obj, p)
+
+            alt_form = AlternativeHelpForm(case=obj, data=alt_data)
+            if alt_form.is_valid():
+                alt_form.save(request.user)
+
+                ProviderPreAllocation.objects.clear(case=obj)
+                self.set_case_organisation(self.get_object())
+
+                logger.warning(
+                    "Education case routed to FALA via EDFF (case_reference=%s, provider_id=%s)",
+                    obj.reference,
+                    p.id,
+                )
+
+                return DRFResponse(
+                    data={
+                        "rerouted_to_alternative_help": True,
+                        "selected_provider": ProviderSerializer(p).data,
+                        "banner_message": settings.EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE,
+                        "outcome_code": "EDFF",
+                    },
+                    status=status.HTTP_200_OK,
+                )
+
+            return DRFResponse(dict(alt_form.errors), status=status.HTTP_400_BAD_REQUEST)
+
         data = request.data.copy()
         data["provider"] = p.pk
         form = ProviderAllocationForm(case=obj, data=data, providers=suitable_providers)

--- a/cla_backend/apps/call_centre/views.py
+++ b/cla_backend/apps/call_centre/views.py
@@ -373,8 +373,11 @@ class CaseViewSet(
         # Route education dummy provider to alternative help (EDFF) instead of assigning a specialist.
         if self._is_education_dummy_provider(obj, p):
             alt_data = request.data.copy()
-            alt_data["event_code"] = "EDFF"
-            alt_data["notes"] = self._build_edff_auto_notes(obj, p)
+            
+            alt_data.update({
+            "event_code": "EDFF",
+            "notes": self._build_edff_auto_notes(obj, p),
+            })
 
             alt_form = AlternativeHelpForm(case=obj, data=alt_data)
             if alt_form.is_valid():

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -502,10 +502,6 @@ EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA = (
     os.environ.get("EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA", "False") == "True"
 )
 EDUCATION_DUMMY_PROVIDER_SHORT_CODE = os.environ.get("EDUCATION_DUMMY_PROVIDER_SHORT_CODE", "EDFF_DUMMY")
-EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE = os.environ.get(
-    "EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE",
-    "Clients cannot currently be assigned to this provider. Referred to FALA for face-to-face support.",
-)
 
 # A notification will be sent for callback time slot if its remaining capacity drops below this threshold
 CALLBACK_CAPPING_THRESHOLD = os.environ.get("CALLBACK_CAPPING_THRESHOLD", 0)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -498,6 +498,15 @@ CFE_URL = (
 
 EDUCATION_ALLOCATION_FEATURE_FLAG = os.environ.get("EDUCATION_ALLOCATION_FEATURE_FLAG", "False") == "True"
 
+EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA = (
+    os.environ.get("EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA", "False") == "True"
+)
+EDUCATION_DUMMY_PROVIDER_SHORT_CODE = os.environ.get("EDUCATION_DUMMY_PROVIDER_SHORT_CODE", "EDFF_DUMMY")
+EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE = os.environ.get(
+    "EDUCATION_DUMMY_PROVIDER_BANNER_MESSAGE",
+    "Clients cannot currently be assigned to this provider. Referred to FALA for face-to-face support.",
+)
+
 # A notification will be sent for callback time slot if its remaining capacity drops below this threshold
 CALLBACK_CAPPING_THRESHOLD = os.environ.get("CALLBACK_CAPPING_THRESHOLD", 0)
 CALLBACK_CAPPING_THRESHOLD_NOTIFICATION = os.environ.get("CALLBACK_CAPPING_THRESHOLD_NOTIFICATION", None)

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -498,9 +498,7 @@ CFE_URL = (
 
 EDUCATION_ALLOCATION_FEATURE_FLAG = os.environ.get("EDUCATION_ALLOCATION_FEATURE_FLAG", "False") == "True"
 
-EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA = (
-    os.environ.get("EDUCATION_DUMMY_PROVIDER_ROUTE_TO_FALA", "False") == "True"
-)
+
 EDUCATION_DUMMY_PROVIDER_SHORT_CODE = os.environ.get("EDUCATION_DUMMY_PROVIDER_SHORT_CODE", "EDFF_DUMMY")
 
 # A notification will be sent for callback time slot if its remaining capacity drops below this threshold


### PR DESCRIPTION
## What does this pull request do?

[LGA-3974](https://dsdmoj.atlassian.net/browse/LGA-3974)

This PR adds a feature flag path to reroute education cases to alternative help when the configured dummy provider is selected, instead of assigning a specialist provider.

**What changed**

1. Added config flags for dummy-provider routing and banner messaging.
2. Updated case assignment flow to:
- detect the education dummy provider
- create an EDFF alternative help outcome
- return a banner message and reroute metadata in the API response
- log the reroute for monitoring
3. Added API test for the dummy provider assignment / EDFF reroute behaviour.

**Why**
This supports the provider exit by redirecting impacted education cases to FALA facing alternative help while keeping the change controlled via settings.

[LGA-3974]: https://dsdmoj.atlassian.net/browse/LGA-3974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ