### PR TITLE
EL-2942: Filtering of event logs for MCC's detailed case

### DIFF
--- a/cla_backend/apps/cla_provider/tests/api/test_log_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_log_api.py
@@ -38,7 +38,7 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_codes = [log["code"] for log in response.data]
         self.assertIn(code_param, response_codes)
-        other_codes_in_response = set(response_codes) - set((code_param,))
+        other_codes_in_response = set(response_codes) - {code_param}
         self.assertEqual(len(other_codes_in_response), 0)
 
     def test_get_filtered_by_multiple_codes_parameter(self):

--- a/cla_backend/apps/cla_provider/tests/api/test_log_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_log_api.py
@@ -38,7 +38,7 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_codes = [log["code"] for log in response.data]
         self.assertIn(code_param, response_codes)
-        other_codes_in_response = set(response_codes) - set({code_param})
+        other_codes_in_response = set(response_codes) - set((code_param,))
         self.assertEqual(len(other_codes_in_response), 0)
 
     def test_get_filtered_by_multiple_codes_parameter(self):

--- a/cla_backend/apps/cla_provider/tests/api/test_log_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_log_api.py
@@ -5,6 +5,8 @@ from legalaid.tests.views.test_base import CLAProviderAuthBaseApiTestMixin
 
 from core.tests.mommy_utils import make_recipe
 from cla_common.constants import REQUIRES_ACTION_BY
+from cla_eventlog.constants import LOG_LEVELS, LOG_TYPES
+
 
 from cla_eventlog.tests.test_views import LogAPIMixin
 
@@ -28,7 +30,16 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
         Test that when the 'codes' GET parameter is specified,
         LogViewSet.get_queryset() filters logs by the specified codes.
         """
-        code_param = self.event_logs[0].code
+        code_param = "CASE_VIEWED"
+
+        make_recipe(
+            "cla_eventlog.log",
+            case=self.parent_resource,
+            level=LOG_LEVELS.HIGH,
+            type=LOG_TYPES.EVENT,
+            code=code_param,
+        )
+
         response = self.client.get(
             self.list_url,
             {"codes": code_param},
@@ -44,9 +55,25 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
     def test_get_filtered_by_multiple_codes_parameter(self):
         """
         Test that when multiple codes are specified in the 'codes' GET parameter
-        (comma-separated), LogViewSet.get_queryset() filters logs by all specified codes.
+        as a list of value (eg. ?codes=CODE1&codes=CODE2), LogViewSet.get_queryset() filters logs by all specified codes.
         """
-        codes_param = (self.event_logs[0].code, self.event_logs[1].code)
+        codes_param = ("CASE_VIEWED", "REOPENED")
+        make_recipe(
+            "cla_eventlog.log",
+            case=self.parent_resource,
+            level=LOG_LEVELS.HIGH,
+            type=LOG_TYPES.EVENT,
+            code=codes_param[0],
+        )
+
+        make_recipe(
+            "cla_eventlog.log",
+            case=self.parent_resource,
+            level=LOG_LEVELS.HIGH,
+            type=LOG_TYPES.EVENT,
+            code=codes_param[1],
+        )
+
         response = self.client.get(
             self.list_url,
             {"codes": codes_param},
@@ -55,7 +82,7 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_codes = [log["code"] for log in response.data]
-        self.assertIn(self.event_logs[0].code, response_codes)
-        self.assertIn(self.event_logs[1].code, response_codes)
+        self.assertIn(codes_param[0], response_codes)
+        self.assertIn(codes_param[1], response_codes)
         other_codes_in_response = set(response_codes) - set(codes_param)
         self.assertEqual(len(other_codes_in_response), 0)

--- a/cla_backend/apps/cla_provider/tests/api/test_log_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_log_api.py
@@ -22,3 +22,40 @@ class LogViewSetTestCase(CLAProviderAuthBaseApiTestMixin, LogAPIMixin, APITestCa
 
         response = self.client.get(self.list_url, HTTP_AUTHORIZATION=self.get_http_authorization())
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_filtered_by_codes_parameter(self):
+        """
+        Test that when the 'codes' GET parameter is specified,
+        LogViewSet.get_queryset() filters logs by the specified codes.
+        """
+        code_param = self.event_logs[0].code
+        response = self.client.get(
+            self.list_url,
+            {"codes": code_param},
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_codes = [log["code"] for log in response.data]
+        self.assertIn(code_param, response_codes)
+        other_codes_in_response = set(response_codes) - set({code_param})
+        self.assertEqual(len(other_codes_in_response), 0)
+
+    def test_get_filtered_by_multiple_codes_parameter(self):
+        """
+        Test that when multiple codes are specified in the 'codes' GET parameter
+        (comma-separated), LogViewSet.get_queryset() filters logs by all specified codes.
+        """
+        codes_param = (self.event_logs[0].code, self.event_logs[1].code)
+        response = self.client.get(
+            self.list_url,
+            {"codes": codes_param},
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_codes = [log["code"] for log in response.data]
+        self.assertIn(self.event_logs[0].code, response_codes)
+        self.assertIn(self.event_logs[1].code, response_codes)
+        other_codes_in_response = set(response_codes) - set(codes_param)
+        self.assertEqual(len(other_codes_in_response), 0)

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -351,13 +351,12 @@ class LogViewSet(CLAProviderPermissionViewSetMixin, BaseLogViewSet):
     def get_queryset(self):
         qs = super(LogViewSet, self).get_queryset()
         codes = self.request.query_params.getlist("codes")
-        
+
         if len(codes) > 0:
             qs = qs.filter(code__in=codes)
-        
+
         return qs
 
-    
 
 class FeedbackViewSet(CLAProviderPermissionViewSetMixin, BaseFeedbackViewSet, ClaCreateModelMixin):
     serializer_class = FeedbackSerializer

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -348,6 +348,16 @@ class ScopeTraversalViewSet(CLAProviderPermissionViewSetMixin, BaseScopeTraversa
 class LogViewSet(CLAProviderPermissionViewSetMixin, BaseLogViewSet):
     serializer_class = LogSerializer
 
+    def get_queryset(self):
+        qs = super(LogViewSet, self).get_queryset()
+        codes = self.request.query_params.getlist("codes")
+        
+        if len(codes) > 0:
+            qs = qs.filter(code__in=codes)
+        
+        return qs
+
+    
 
 class FeedbackViewSet(CLAProviderPermissionViewSetMixin, BaseFeedbackViewSet, ClaCreateModelMixin):
     serializer_class = FeedbackSerializer


### PR DESCRIPTION
## What does this pull request do?

It adds the ability for the client making the call to get event logs filtered.

Example: `GET /cla_provider/api/v1/case/FA-3465-9114/logs?codes=CASE_VIEWED&codes=MIS&codes=MIS-OOS`

This is necessary for MCC as it will be showing only these specific event logs:
- CASE_VIEWED
- MIS
- MIS-OOS
- MIS-MEANS
- COI
- SPOP
- REOPEN
- REF-INT
- CLSP

For more info and screenshots: https://dsdmoj.atlassian.net/browse/EL-2944

## Any other changes that would benefit highlighting?

No.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
