### PR TITLE
EL-3115: Remove unused endpoints

### DIFF
--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -269,11 +269,6 @@ class SplitCaseForm(SplitBaseCaseForm):
         return cleaned_data
 
 
-class SplitMCCCaseForm(SplitBaseCaseForm):
-    # Doesn't care about an `already split` case or if case is being split by `same-category`
-    pass
-
-
 class ProviderExtractForm(Form):
     CHSUserName = forms.CharField(required=True)
     CHSOrganisationID = forms.CharField(required=True)

--- a/cla_backend/apps/cla_provider/tests/api/test_case_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_case_api.py
@@ -611,34 +611,6 @@ class CaseStateTestCase(BaseCaseTestCase):
         )
         self.assertEqual(case.state, 'rejected')
 
-    def test_api_returns_state_field(self):
-        """Test that the detailed API endpoint includes the state field"""
-        detailed_url = "{0}detailed/".format(self.get_url(self.resource.reference))
-        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.assertIn('state', response.data)
-        self.assertEqual(response.data['state'], 'new')  # Default state for test case
-
-        # Test that regular endpoint does NOT include state field
-        response = self.client.get(self.get_url(self.resource.reference), HTTP_AUTHORIZATION=self.get_http_authorization())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertNotIn('state', response.data)
-
-    def test_detailed_endpoint_excludes_eligibility_check(self):
-        """Test that the detailed endpoint does NOT include eligibility_check reference"""
-        detailed_url = "{0}detailed/".format(self.get_url(self.resource.reference))
-        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Detailed endpoint should NOT have eligibility_check reference
-        self.assertNotIn('eligibility_check', response.data)
-
-        # Regular endpoint should still have eligibility_check reference
-        response = self.client.get(self.get_url(self.resource.reference), HTTP_AUTHORIZATION=self.get_http_authorization())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('eligibility_check', response.data)
-
     def test_case_state_note_prefers_non_minor_case_viewed_log(self):
         """State note should ignore minor CASE_VIEWED logs and use the visible log entry."""
         self._set_case_as_opened()
@@ -647,15 +619,3 @@ class CaseStateTestCase(BaseCaseTestCase):
         self.assertEqual(self.resource.state, "opened")
         self.assertIsNotNone(self.resource.state_note)
         self.assertEqual(self.resource.state_note.notes, "Not ready for determination")
-
-    def test_detailed_endpoint_state_note_ignores_minor_case_viewed_log(self):
-        """Detailed endpoint state_note should match visible logs endpoint behaviour."""
-        self._set_case_as_opened()
-        self._create_case_viewed_logs()
-
-        detailed_url = "{0}detailed/".format(self.get_url(self.resource.reference))
-        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["state"], "opened")
-        self.assertEqual(response.data["state_note"]["notes"], "Not ready for determination")

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -61,7 +61,7 @@ from .serializers import (
     CSVUploadDetailSerializer,
     ProviderSerializer,
 )
-from .forms import RejectCaseForm, AcceptCaseForm, OpenCaseForm, CloseCaseForm, SplitCaseForm, ReopenCaseForm, SplitMCCCaseForm
+from .forms import RejectCaseForm, AcceptCaseForm, OpenCaseForm, CloseCaseForm, SplitCaseForm, ReopenCaseForm
 
 logger = logging.getLogger(__name__)
 
@@ -222,24 +222,9 @@ class CaseViewSet(CLAProviderPermissionViewSetMixin, FullCaseViewSet):
         }
         return DRFResponse(data)
 
-    @detail_route()
-    def detailed(self, *args, **kwargs):
-        """
-        Returns case with all nested details in a single call
-        """
-        from mcc.serializers import DetailedCaseSerializer
-
-        case = self.get_object()
-        serializer = DetailedCaseSerializer(instance=case)
-        return DRFResponse(serializer.data)
-
     @detail_route(methods=["post"])
     def split(self, request, reference=None, **kwargs):
         return self._form_action(request, Form=SplitCaseForm, form_kwargs={"request": request})
-
-    @detail_route(methods=["post"])
-    def mcc_split(self, request, reference=None, **kwargs):
-        return self._form_action(request, Form=SplitMCCCaseForm, form_kwargs={"request": request})
 
 
 class ProviderExtract(APIView):

--- a/cla_backend/apps/mcc/forms.py
+++ b/cla_backend/apps/mcc/forms.py
@@ -1,0 +1,6 @@
+from cla_backend.apps.cla_provider.forms import SplitBaseCaseForm
+
+
+class SplitMCCCaseForm(SplitBaseCaseForm):
+    # Doesn't care about an `already split` case or if case is being split by `same-category`
+    pass

--- a/cla_backend/apps/mcc/tests/api/test_case_detailed_api.py
+++ b/cla_backend/apps/mcc/tests/api/test_case_detailed_api.py
@@ -4,12 +4,16 @@ from __future__ import unicode_literals
 import mock
 
 from django.core.urlresolvers import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase
 from rest_framework import status
 
 from core.tests.mommy_utils import make_recipe
 from legalaid.tests.views.test_base import CLAProviderAuthBaseApiTestMixin
 from mcc.serializers import DetailedCaseSerializer, CaseSerializer
+
+from cla_eventlog.models import Log
+from cla_eventlog.constants import LOG_LEVELS, LOG_TYPES
 
 
 class DetailedCaseSerializerTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase):
@@ -88,15 +92,43 @@ class DetailedCaseEndpointTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase)
 
     def setUp(self):
         super(DetailedCaseEndpointTestCase, self).setUp()
-        self.case = make_recipe("legalaid.case", provider=self.provider)
+        self.case = make_recipe("legalaid.case", provider=self.provider, reference="AA-1234-5678")
+
+    def _set_case_as_opened(self):
+        self.case.provider_viewed = timezone.now()
+        self.case.save(update_fields=["provider_viewed", "modified"])
+
+    def _create_case_viewed_logs(self):
+        created_by = self.case.created_by or self.user
+
+        Log.objects.create(
+            case=self.case,
+            code="CASE_VIEWED",
+            created_by=created_by,
+            notes="Not ready for determination",
+            type=LOG_TYPES.OUTCOME,
+            level=LOG_LEVELS.HIGH,
+        )
+        Log.objects.create(
+            case=self.case,
+            code="CASE_VIEWED",
+            created_by=created_by,
+            notes="Case viewed",
+            type=LOG_TYPES.SYSTEM,
+            level=LOG_LEVELS.MINOR,
+        )
 
     def get_detailed_url(self, reference=None):
         reference = reference or self.case.reference
-        return reverse("cla_provider:case-detailed", args=(), kwargs={"reference": reference})
+        return reverse("mcc:case-detailed", args=(), kwargs={"reference": reference})
+
+    def get_case_url(self, reference=None):
+        reference = reference or self.case.reference
+        return reverse("cla_provider:case-detail", args=(), kwargs={"reference": reference})
 
     def test_detailed_endpoint_exists_and_uses_correct_serializer(self):
         """Test that the detailed endpoint exists and uses DetailedCaseSerializer"""
-        url = self.get_detailed_url()
+        url = self.get_detailed_url("AA-1234-5678")
 
         # Test without auth first
         response = self.client.get(url)
@@ -120,7 +152,7 @@ class DetailedCaseEndpointTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase)
         """Test that detailed endpoint respects case ownership"""
         # Case not owned by provider
         other_provider = make_recipe("cla_provider.provider")
-        other_case = make_recipe("legalaid.case", provider=other_provider)
+        other_case = make_recipe("legalaid.case", provider=other_provider, reference="BB-1234-5678")
 
         url = self.get_detailed_url(other_case.reference)
         response = self.client.get(url, HTTP_AUTHORIZATION=self.get_http_authorization())
@@ -129,7 +161,7 @@ class DetailedCaseEndpointTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase)
     @mock.patch("mcc.serializers.DetailedCaseSerializer")
     def test_detailed_endpoint_uses_detailed_serializer(self, mock_serializer):
         """Test that the endpoint specifically uses DetailedCaseSerializer"""
-        url = self.get_detailed_url()
+        url = self.get_detailed_url("AA-1234-5678")
         mock_instance = mock_serializer.return_value
         mock_instance.data = {"reference": self.case.reference}
 
@@ -139,3 +171,43 @@ class DetailedCaseEndpointTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase)
             mock_serializer.assert_called_once()
             call_args = mock_serializer.call_args
             self.assertEqual(call_args[1]["instance"], self.case)
+
+    def test_detailed_endpoint_excludes_eligibility_check(self):
+        """Test that the detailed endpoint does NOT include eligibility_check reference"""
+        detailed_url = self.get_detailed_url(self.case.reference)
+        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Detailed endpoint should NOT have eligibility_check reference
+        self.assertNotIn('eligibility_check', response.data)
+
+        # Regular endpoint should still have eligibility_check reference
+        response = self.client.get(self.get_case_url(self.case.reference), HTTP_AUTHORIZATION=self.get_http_authorization())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('eligibility_check', response.data)
+
+    def test_detailed_endpoint_state_note_ignores_minor_case_viewed_log(self):
+        """Detailed endpoint state_note should match visible logs endpoint behaviour."""
+        self._set_case_as_opened()
+        self._create_case_viewed_logs()
+
+        detailed_url = self.get_detailed_url(self.case.reference)
+        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["state"], "opened")
+        self.assertEqual(response.data["state_note"]["notes"], "Not ready for determination")
+
+    def test_api_returns_state_field(self):
+        """Test that the detailed API endpoint includes the state field"""
+        detailed_url = self.get_detailed_url(self.case.reference)
+        response = self.client.get(detailed_url, HTTP_AUTHORIZATION=self.get_http_authorization())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertIn('state', response.data)
+        self.assertEqual(response.data['state'], 'new')  # Default state for test case
+
+        # Test that regular endpoint does NOT include state field
+        response = self.client.get(self.get_case_url(self.case.reference), HTTP_AUTHORIZATION=self.get_http_authorization())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn('state', response.data)

--- a/cla_backend/apps/mcc/tests/test_forms.py
+++ b/cla_backend/apps/mcc/tests/test_forms.py
@@ -5,7 +5,8 @@ from cla_common.constants import REQUIRES_ACTION_BY
 
 from core.tests.mommy_utils import make_recipe, make_user
 
-from cla_provider.forms import SplitCaseForm, SplitMCCCaseForm
+from cla_provider.forms import SplitCaseForm
+from mcc.forms import SplitMCCCaseForm
 
 
 class SplitMCCCaseFormTestCase(TestCase):

--- a/cla_backend/apps/mcc/views.py
+++ b/cla_backend/apps/mcc/views.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response as DRFResponse
 
-from cla_provider.forms import SplitMCCCaseForm
+from mcc.forms import SplitMCCCaseForm
 from cla_provider.views import CaseViewSet
 
 from mcc import serializers


### PR DESCRIPTION
Jira ticket: https://dsdmoj.atlassian.net/browse/EL-3115

## What does this pull request do?

This is a cleanup task related to #1404. That PR was meant to move the endpoints to `/mcc`. However, in order to avoid deploying a breaking change, the work has been split into task 1 "copy them over" and task 2 "clean up". This PR is task 2.

Changes made:
1. Removed the two endpoints that were added specifically for MCC's use:
- `/cla_provider/api/v1/case/{{case_reference}}/mcc_split/`
- `/cla_provider/api/v1/case/{{case_reference}}/detailed`
2. Moved `SplitMCCCaseForm` that had been left behind in the `cla_provider` package.
3. Moved tests also had been left behind in the `cla_provider` package.


## Any other changes that would benefit highlighting?

None.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
