### PR TITLE
The $KUBE_CERT secret is no longer base64 decoded

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -45,7 +45,7 @@ runs:
         KUBE_TOKEN: ${{ inputs.KUBE_TOKEN }}
         KUBE_NAMESPACE: ${{ inputs.KUBE_NAMESPACE }}
       run: |
-        echo "$KUBE_CERT" | base64 -d > ca.crt
+        echo "$KUBE_CERT" > ca.crt
         kubectl config set-cluster "$KUBE_CLUSTER" \
           --certificate-authority=./ca.crt \
           --server="https://$KUBE_CLUSTER"


### PR DESCRIPTION
## What does this pull request do?

The $KUBE_CERT secret is no longer base64 decoded.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
