### PR TITLE
EL-3227: Add change category end point

### DIFF
--- a/cla_backend/apps/legalaid/models.py
+++ b/cla_backend/apps/legalaid/models.py
@@ -977,6 +977,30 @@ class Case(TimeStampedModel):
         self.provider_closed = None
         self.save(update_fields=["provider_closed"])
 
+    def change_category(self, category, note, user=None):
+        old = self.diagnosis
+        if old:
+            old.delete()
+
+        diagnosis = DiagnosisTraversal.objects.create_eligible(category)
+
+        if note:
+            diagnosis.nodes = diagnosis.nodes or []
+            diagnosis.nodes.append({
+                "title": category.name,
+                "label": note,
+            })
+            diagnosis.save()
+
+        if self.eligibility_check:
+            self.eligibility_check.category = category
+            self.eligibility_check.save(update_fields=["category"])
+
+        self.diagnosis = diagnosis
+
+        self.save(update_fields=["diagnosis", "modified"])
+        return self
+
     def assign_alternative_help(self, user, articles):
         self.alternative_help_articles.clear()
         for article in articles:

--- a/cla_backend/apps/mcc/events.py
+++ b/cla_backend/apps/mcc/events.py
@@ -4,6 +4,9 @@ from cla_eventlog.events import BaseEvent
 
 
 class ChangeCategoryEvent(BaseEvent):
+    """
+    Custom event for MCC to log category changes
+    """
     key = "change_category"
 
     codes = {

--- a/cla_backend/apps/mcc/events.py
+++ b/cla_backend/apps/mcc/events.py
@@ -1,0 +1,20 @@
+from cla_eventlog import event_registry
+from cla_eventlog.constants import LOG_TYPES, LOG_LEVELS
+from cla_eventlog.events import BaseEvent
+
+
+class ChangeCategoryEvent(BaseEvent):
+    key = "change_category"
+
+    codes = {
+        "MCC": {
+            "type": LOG_TYPES.OUTCOME,
+            "level": LOG_LEVELS.HIGH,
+            "selectable_by": [],
+            "description": "Category changed via MCC",
+            "stops_timer": False,
+        }
+    }
+
+
+event_registry.register(ChangeCategoryEvent)

--- a/cla_backend/apps/mcc/forms.py
+++ b/cla_backend/apps/mcc/forms.py
@@ -54,7 +54,7 @@ class ChangeCategoryForm(BaseCaseLogForm):
 
         if non_field_errors:
             self._errors[NON_FIELD_ERRORS] = ErrorList(non_field_errors)
- 
+
         return cleaned_data
 
     @transaction.atomic

--- a/cla_backend/apps/mcc/forms.py
+++ b/cla_backend/apps/mcc/forms.py
@@ -1,6 +1,65 @@
 from cla_backend.apps.cla_provider.forms import SplitBaseCaseForm
+from cla_eventlog.forms import BaseCaseLogForm
+from django import forms
+from legalaid.models import Category
+from django.db import transaction
+from django.forms.util import ErrorList
+from django.core.exceptions import NON_FIELD_ERRORS
 
 
 class SplitMCCCaseForm(SplitBaseCaseForm):
     # Doesn't care about an `already split` case or if case is being split by `same-category`
     pass
+
+
+class ChangeCategoryForm(BaseCaseLogForm):
+    """
+    MCC: Change category
+    """
+
+    LOG_EVENT_KEY = "change_category"
+
+    category = forms.ModelChoiceField(
+        queryset=Category.objects.all(),
+        to_field_name="code",
+        required=True
+    )
+    NOTES_MANDATORY = True
+
+    def get_context(self):
+        old_category = self.case.eligibility_check.category if self.case.eligibility_check else None
+        new_category = self.cleaned_data["category"]
+
+        return {
+            "old_category": old_category.code if old_category else None,
+            "new_category": new_category.code if new_category else None,
+        }
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super(ChangeCategoryForm, self).__init__(*args, **kwargs)
+        self._old_category = (
+            self.case.diagnosis.category
+            if getattr(self.case, "diagnosis", None)
+            else None)
+
+    def clean(self):
+        cleaned_data = super(ChangeCategoryForm, self).clean()
+
+        if self._errors:
+            return cleaned_data
+
+        # Ensure provider owns the case (same pattern as split)
+        if self.case.provider != self.request.user.staff.provider:
+            self._errors[NON_FIELD_ERRORS] = ErrorList([
+                "Only Providers assigned to the Case can change its category."
+            ])
+        return cleaned_data
+
+    @transaction.atomic
+    def save(self, user):
+        category = self.cleaned_data["category"]
+        note = self.cleaned_data["notes"]
+        super(ChangeCategoryForm, self).save(user)
+        self.case.change_category(category, note, user=user)
+        return self.case

--- a/cla_backend/apps/mcc/forms.py
+++ b/cla_backend/apps/mcc/forms.py
@@ -46,14 +46,15 @@ class ChangeCategoryForm(BaseCaseLogForm):
     def clean(self):
         cleaned_data = super(ChangeCategoryForm, self).clean()
 
-        if self._errors:
-            return cleaned_data
+        # collect non-field errors (same pattern as SplitBaseCaseForm)
+        non_field_errors = []
 
-        # Ensure provider owns the case (same pattern as split)
         if self.case.provider != self.request.user.staff.provider:
-            self._errors[NON_FIELD_ERRORS] = ErrorList([
-                "Only Providers assigned to the Case can change its category."
-            ])
+            non_field_errors.append("Only Providers assigned to the Case can change its category.")
+
+        if non_field_errors:
+            self._errors[NON_FIELD_ERRORS] = ErrorList(non_field_errors)
+ 
         return cleaned_data
 
     @transaction.atomic

--- a/cla_backend/apps/mcc/tests/api/test_case_api.py
+++ b/cla_backend/apps/mcc/tests/api/test_case_api.py
@@ -1,3 +1,4 @@
+from diagnosis.models import DiagnosisTraversal
 from django.core.urlresolvers import reverse
 
 from rest_framework import status
@@ -84,3 +85,82 @@ class MCCSplitCaseTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase):
         )
 
         self.assertIn(response.status_code, [status.HTTP_200_OK, status.HTTP_204_NO_CONTENT])
+
+
+class MCCChangeCategoryTestCase(CLAProviderAuthBaseApiTestMixin, APITestCase):
+    def setUp(self):
+        super(MCCChangeCategoryTestCase, self).setUp()
+
+        self.case_category = make_recipe("legalaid.category")
+        self.new_category = make_recipe("legalaid.category")
+
+        self.resource = make_recipe(
+            "legalaid.case",
+            reference="AA-9999-9999",
+            provider=self.provider,
+            requires_action_by=REQUIRES_ACTION_BY.PROVIDER,
+            eligibility_check=make_recipe(
+                "legalaid.eligibility_check",
+                category=self.case_category
+            )
+        )
+
+        self.resource.diagnosis = DiagnosisTraversal.objects.create_eligible(self.case_category)
+        self.resource.save()
+
+        self.url = self.get_url()
+
+    def get_url(self, reference=None):
+        reference = reference or self.resource.reference
+        return reverse("mcc:case-category-change", kwargs={"reference": reference})
+
+    def test_change_category_success(self):
+        self.assertEqual(Log.objects.count(), 0)
+
+        response = self.client.patch(
+            self.url,
+            data={
+                "category": self.new_category.code,
+                "notes": "Changing category via MCC"
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.resource.refresh_from_db()
+        eligibility = self.resource.eligibility_check
+        eligibility.refresh_from_db()
+        self.assertEqual(
+            eligibility.category,
+            self.new_category
+        )
+
+        self.assertIsNotNone(self.resource.diagnosis)
+
+        logs = Log.objects.filter(case=self.resource)
+        self.assertEqual(logs.count(), 1)
+        log = logs.first()
+
+        self.assertEqual(log.code, "MCC")
+        self.assertEqual(log.notes, "Changing category via MCC")
+        self.assertEqual(
+            log.context,
+            {
+                "old_category": self.case_category.code,
+                "new_category": self.new_category.code,
+            }
+        )
+
+    def test_change_category_requires_note(self):
+        response = self.client.patch(
+            self.url,
+            data={
+                "category": self.new_category.code
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.get_http_authorization(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/cla_backend/apps/mcc/urls.py
+++ b/cla_backend/apps/mcc/urls.py
@@ -6,9 +6,11 @@ from .views import MCCCaseViewSet
 
 case_split = MCCCaseViewSet.as_view({"post": "split"})
 case_detailed = MCCCaseViewSet.as_view({"get": "detailed"})
+case_category_change = MCCCaseViewSet.as_view({"patch": "change_category"})
 
 urlpatterns = patterns(
     "",
     url(r"^case/(?P<reference>[A-Z\d]{2}-\d{4}-\d{4})/split/$", case_split, name="case-split"),
     url(r"^case/(?P<reference>[A-Z\d]{2}-\d{4}-\d{4})/detailed/$", case_detailed, name="case-detailed"),
+    url(r"^case/(?P<reference>[A-Z\d]{2}-\d{4}-\d{4})/category-change/$", case_category_change, name="case-category-change"),
 )

--- a/cla_backend/apps/mcc/views.py
+++ b/cla_backend/apps/mcc/views.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response as DRFResponse
 
-from mcc.forms import SplitMCCCaseForm
+from mcc.forms import SplitMCCCaseForm, ChangeCategoryForm
 from cla_provider.views import CaseViewSet
 
 from mcc import serializers
@@ -22,3 +22,11 @@ class MCCCaseViewSet(CaseViewSet):
         case = self.get_object()
         serializer = serializers.DetailedCaseSerializer(instance=case)
         return DRFResponse(serializer.data)
+
+    @detail_route(methods=["patch"])
+    def change_category(self, request, reference=None, **kwargs):
+        return self._form_action(
+            request,
+            Form=ChangeCategoryForm,
+            form_kwargs={"request": request}
+        )

--- a/cla_backend/apps/mcc/views.py
+++ b/cla_backend/apps/mcc/views.py
@@ -25,6 +25,9 @@ class MCCCaseViewSet(CaseViewSet):
 
     @detail_route(methods=["patch"])
     def change_category(self, request, reference=None, **kwargs):
+        """
+        Updates only the category for a case
+        """
         return self._form_action(
             request,
             Form=ChangeCategoryForm,


### PR DESCRIPTION
## What does this pull request do?

Adds new endpoint to allow mcc to update category of law for cases. 
Old category of law is saved in event log.
This [ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/EL/boards/802?selectedIssue=EL-3228) ensures providers can only change to a category of law assigned to them.

## Any other changes that would benefit highlighting?

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
