### PR TITLE
LGA-4089: new xml and entra token 

### DIFF
--- a/.ash_history
+++ b/.ash_history
@@ -1,5 +1,0 @@
-manage.py changepassword cla_admin
-python manage.py changepassword cla_admin
-python manage.py migrate
-python manage.py changepassword cla_admin
-python manage.py migrate

--- a/.ash_history
+++ b/.ash_history
@@ -1,0 +1,5 @@
+manage.py changepassword cla_admin
+python manage.py changepassword cla_admin
+python manage.py migrate
+python manage.py changepassword cla_admin
+python manage.py migrate

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'false'
   KUBE_CERT:
-    description: Kubernetes cluster certificate (base64 encoded)
+    description: Kubernetes cluster certificate
     required: true
   KUBE_CLUSTER:
     description: Kubernetes cluster hostname

--- a/.github/workflows/cleanup-release.yml
+++ b/.github/workflows/cleanup-release.yml
@@ -26,7 +26,7 @@ jobs:
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
         run: |
-          echo "$KUBE_CERT" | base64 -d > ca.crt
+          echo "$KUBE_CERT" > ca.crt
           kubectl config set-cluster "$KUBE_CLUSTER" \
             --certificate-authority=./ca.crt \
             --server="https://$KUBE_CLUSTER"

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ cla_backend/static/
 /celerybeat-schedule.dir
 /celerybeat-schedule.pag
 /.bash_history
+/.ash_history

--- a/cla_backend/apps/cla_provider/authentication.py
+++ b/cla_backend/apps/cla_provider/authentication.py
@@ -5,7 +5,6 @@ from rest_framework.exceptions import AuthenticationFailed
 from cla_provider.models import Staff
 
 
-
 # =======================================
 # To be retired once Entra auth is fully implemented and CHS auth is no longer used
 # =======================================

--- a/cla_backend/apps/cla_provider/authentication.py
+++ b/cla_backend/apps/cla_provider/authentication.py
@@ -5,6 +5,10 @@ from rest_framework.exceptions import AuthenticationFailed
 from cla_provider.models import Staff
 
 
+
+# =======================================
+# To be retired once Entra auth is fully implemented and CHS auth is no longer used
+# =======================================
 class LegacyCHSAuthentication(BaseAuthentication):
     def authenticate(self, request):
         """

--- a/cla_backend/apps/cla_provider/authentication.py
+++ b/cla_backend/apps/cla_provider/authentication.py
@@ -6,7 +6,7 @@ from cla_provider.models import Staff
 
 
 # =======================================
-# To be retired once Entra auth is fully implemented and CHS auth is no longer used
+# TODO: To be retired once Entra auth is fully implemented and CHS auth is no longer used
 # =======================================
 class LegacyCHSAuthentication(BaseAuthentication):
     def authenticate(self, request):

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -270,6 +270,7 @@ class SplitCaseForm(SplitBaseCaseForm):
 
 # TODO: To be retired once Entra auth is fully implemented and CHS auth is no longer used
 
+
 class ProviderExtractForm(Form):
     CHSUserName = forms.CharField(required=True)
     CHSOrganisationID = forms.CharField(required=True)

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -280,10 +280,11 @@ class ProviderExtractForm(Form):
         if data:
             data = data.strip().upper()
         return data
-    
+
+
 class ProviderExtractEntraForm(Form):
     CHSCRN = forms.CharField(required=True)
-    
+
     def clean_CHSCRN(self):
         data = self.cleaned_data["CHSCRN"]
         if data:

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -280,3 +280,12 @@ class ProviderExtractForm(Form):
         if data:
             data = data.strip().upper()
         return data
+    
+class ProviderExtractEntraForm(Form):
+    CHSCRN = forms.CharField(required=True)
+    
+    def clean_CHSCRN(self):
+        data = self.cleaned_data["CHSCRN"]
+        if data:
+            data = data.strip().upper()
+        return data

--- a/cla_backend/apps/cla_provider/forms.py
+++ b/cla_backend/apps/cla_provider/forms.py
@@ -268,6 +268,7 @@ class SplitCaseForm(SplitBaseCaseForm):
 
         return cleaned_data
 
+# TODO: To be retired once Entra auth is fully implemented and CHS auth is no longer used
 
 class ProviderExtractForm(Form):
     CHSUserName = forms.CharField(required=True)

--- a/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
@@ -61,10 +61,10 @@ class ProviderExtractEntraTests(EntraTokenGeneratorMixin, APITestCase):
     def auth_header(self, **token_kwargs):
         token_kwargs.setdefault("firm_name", self.FIRM_NAME)
         token_kwargs.setdefault("app_roles", PROVIDER_ROLE)
-        # EntraTokenGeneratorMixin.setUp() already creates a plain User for
-        # "test@example.com" (the _create_token default), which has no staff
-        # link - use a distinct email so get_or_create_user takes the
-        # "create a new provider/staff" branch instead of finding that stub.
+        # Use a distinct email from the mixin's default ("test@example.com").
+        # The mixin creates a bare User with that email but no Staff link;
+        # get_or_create_user would return it early, skipping _create_provider(),
+        # leaving us with a user that fails IsProviderPermission.
         token_kwargs.setdefault("email", "new-provider-staff@example.com")
         token = self._create_token(**token_kwargs)
         return {"HTTP_AUTHORIZATION": "Bearer %s" % token}

--- a/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
@@ -97,6 +97,20 @@ class ProviderExtractEntraTests(EntraTokenGeneratorMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_response_is_xml_with_key_fields(self):
+        response = self.client.post(
+            self.detail_url, data={"CHSCRN": self.case.reference}, **self.auth_header()
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/xml", response["Content-Type"])
+        o = objectify.fromstring(response.content)
+        self.assertIn("CRN", o.attrib)
+        self.assertIn("CaseCreated", o.attrib)
+        self.assertEqual(str(o.attrib["CRN"]), str(self.case.laa_reference))
+        self.assertTrue(hasattr(o, "MeansTestResult"))
+        self.assertTrue(hasattr(o, "ReferredOrganisation"))
+        self.assertEqual(str(o.ReferredOrganisation.Organisation), self.FIRM_NAME)
+
     def test_entra_post_does_not_require_legacy_chs_fields(self):
         """No CHSOrganisationID/CHSUserName/CHSPassword needed for the Entra path."""
         response = self.client.post(

--- a/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
+++ b/cla_backend/apps/cla_provider/tests/api/test_provider_extract_api.py
@@ -1,10 +1,18 @@
+from mock import patch
 from lxml import objectify
+from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from cla_common.constants import REQUIRES_ACTION_BY
+from core.tests.mommy_utils import make_recipe
 
 from legalaid.tests.views.test_base import CLAProviderAuthBaseApiTestMixin
 
 from legalaid.tests.views.mixins.provider_extract_api import ProviderExtractAPIMixin
+
+from cla_auth.constants import PROVIDER_ROLE
+from cla_auth.tests.test_authentication import EntraTokenGeneratorMixin
 
 
 class ProviderExtractTests(CLAProviderAuthBaseApiTestMixin, ProviderExtractAPIMixin, APITestCase):
@@ -19,3 +27,79 @@ class ProviderExtractTests(CLAProviderAuthBaseApiTestMixin, ProviderExtractAPIMi
         o = objectify.fromstring(response.content)
 
         self.assertListEqual(o.attrib.keys(), ["CRN", "CaseCreated"])
+
+
+class ProviderExtractEntraTests(EntraTokenGeneratorMixin, APITestCase):
+    """
+    Covers the ProviderExtractEntraForm path: Entra-authenticated providers only
+    need to send CHSCRN, none of the legacy CHS credential fields.
+    """
+
+    FIRM_NAME = "THE FIRM NAME LTD"
+
+    def setUp(self):
+        super(ProviderExtractEntraTests, self).setUp()
+
+        self.settings_override = self.settings(
+            ENTRA_TENANT_ID="test-tenant-id", ENTRA_EXPECTED_AUDIENCE="test-audience"
+        )
+        self.settings_override.enable()
+
+        self.public_keys_patcher = patch("cla_auth.authentication.EntraAccessTokenAuthentication._public_keys")
+        self.public_keys_mock = self.public_keys_patcher.start()
+        self.public_keys_mock.return_value = self.mock_jwks["keys"]
+
+        self.provider = make_recipe("cla_provider.provider", name=self.FIRM_NAME, active=True)
+        self.case = make_recipe(
+            "legalaid.case", provider=self.provider, requires_action_by=REQUIRES_ACTION_BY.PROVIDER
+        )
+        self.detail_url = reverse("cla_provider:provider-extract")
+
+    def tearDown(self):
+        self.public_keys_patcher.stop()
+
+    def auth_header(self, **token_kwargs):
+        token_kwargs.setdefault("firm_name", self.FIRM_NAME)
+        token_kwargs.setdefault("app_roles", PROVIDER_ROLE)
+        # EntraTokenGeneratorMixin.setUp() already creates a plain User for
+        # "test@example.com" (the _create_token default), which has no staff
+        # link - use a distinct email so get_or_create_user takes the
+        # "create a new provider/staff" branch instead of finding that stub.
+        token_kwargs.setdefault("email", "new-provider-staff@example.com")
+        token = self._create_token(**token_kwargs)
+        return {"HTTP_AUTHORIZATION": "Bearer %s" % token}
+
+    def test_valid_entra_post_returns_extract(self):
+        response = self.client.post(
+            self.detail_url, data={"CHSCRN": self.case.reference}, **self.auth_header()
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        o = objectify.fromstring(response.content)
+        self.assertEqual(o.attrib["CRN"], str(self.case.laa_reference))
+
+    def test_entra_post_missing_chscrn_is_bad_request(self):
+        response = self.client.post(self.detail_url, data={}, **self.auth_header())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_entra_post_unknown_crn_not_found(self):
+        response = self.client.post(
+            self.detail_url, data={"CHSCRN": "NONEXISTENT-CRN"}, **self.auth_header()
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_entra_post_case_belongs_to_other_provider_is_forbidden(self):
+        other_provider = make_recipe("cla_provider.provider", name="OTHER FIRM LTD", active=True)
+        other_case = make_recipe(
+            "legalaid.case", provider=other_provider, requires_action_by=REQUIRES_ACTION_BY.PROVIDER
+        )
+        response = self.client.post(
+            self.detail_url, data={"CHSCRN": other_case.reference}, **self.auth_header()
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_entra_post_does_not_require_legacy_chs_fields(self):
+        """No CHSOrganisationID/CHSUserName/CHSPassword needed for the Entra path."""
+        response = self.client.post(
+            self.detail_url, data={"CHSCRN": self.case.reference}, **self.auth_header()
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -1,7 +1,6 @@
 import logging
 
-from requests import request
-from cla_backend.apps.cla_auth.authentication import EntraAccessTokenAuthentication
+from cla_auth.authentication import EntraAccessTokenAuthentication
 from cla_provider.authentication import LegacyCHSAuthentication
 from cla_provider.forms import ProviderExtractForm
 from cla_provider.helpers import ProviderExtractFormatter
@@ -254,7 +253,7 @@ class ProviderExtract(APIView):
             form = ProviderExtractEntraForm(request.data)
         else:
             # Legacy CHS auth - keep backward compatibility
-            data = request.data.copy()
+            data = request.POST.copy()
             if "CHSOrganisationID" not in data:
                 data["CHSOrganisationID"] = data.get("CHSOrgansationID")
             form = ProviderExtractForm(data)

--- a/cla_backend/apps/cla_provider/views.py
+++ b/cla_backend/apps/cla_provider/views.py
@@ -1,4 +1,7 @@
 import logging
+
+from requests import request
+from cla_backend.apps.cla_auth.authentication import EntraAccessTokenAuthentication
 from cla_provider.authentication import LegacyCHSAuthentication
 from cla_provider.forms import ProviderExtractForm
 from cla_provider.helpers import ProviderExtractFormatter
@@ -61,7 +64,7 @@ from .serializers import (
     CSVUploadDetailSerializer,
     ProviderSerializer,
 )
-from .forms import RejectCaseForm, AcceptCaseForm, OpenCaseForm, CloseCaseForm, SplitCaseForm, ReopenCaseForm
+from .forms import ProviderExtractEntraForm, RejectCaseForm, AcceptCaseForm, OpenCaseForm, CloseCaseForm, SplitCaseForm, ReopenCaseForm
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +232,7 @@ class CaseViewSet(CLAProviderPermissionViewSetMixin, FullCaseViewSet):
 
 class ProviderExtract(APIView):
     permission_classes = (IsProviderPermission,)
-    authentication_classes = (LegacyCHSAuthentication,)
+    authentication_classes = (LegacyCHSAuthentication, EntraAccessTokenAuthentication,)
 
     http_method_names = [u"post", "options"]
 
@@ -246,16 +249,19 @@ class ProviderExtract(APIView):
         )
 
     def post(self, request):
-        # this is to keep backward compatibility with the old system
-        data = request.POST.copy()
-        if "CHSOrganisationID" not in data:
-            data["CHSOrganisationID"] = data.get("CHSOrgansationID")
+        # Entra auth - only needs case reference, token contains provider info
+        if isinstance(request.successful_authenticator, EntraAccessTokenAuthentication):
+            form = ProviderExtractEntraForm(request.data)
+        else:
+            # Legacy CHS auth - keep backward compatibility
+            data = request.data.copy()
+            if "CHSOrganisationID" not in data:
+                data["CHSOrganisationID"] = data.get("CHSOrgansationID")
+            form = ProviderExtractForm(data)
 
-        form = ProviderExtractForm(data)
         if form.is_valid():
-            data = form.cleaned_data
             try:
-                case = Case.objects.get(reference__iexact=data["CHSCRN"])
+                case = Case.objects.get(reference__iexact=form.cleaned_data["CHSCRN"])
             except Case.DoesNotExist:
                 return DRFResponse(
                     {"detail": "Not found"},


### PR DESCRIPTION
## What does this pull request do?

This is the backend part for this ticket: https://dsdmoj.atlassian.net/browse/LGA-4089

And this is the [frontend PR](https://github.com/ministryofjustice/cla_frontend/pull/1087)


### Backend changes
Updated ProviderExtract to support EntraAccessTokenAuthentication alongside the existing LegacyCHSAuthentication, enabling both auth flows on the same endpoint
Added ProviderExtractEntraForm — a simplified form requiring only CHSCRN, since user identity comes from the Entra token rather than CHS credentials
The view branches automatically based on request.successful_authenticator — no feature flag or separate URL needed

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
