### PR TITLE
Alerting fix: Add guard clause to GH action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,6 +133,7 @@ jobs:
     name: UAT static deploy
     runs-on: ubuntu-latest
     needs: [build-and-push]
+    if: github.event_name == 'pull_request'
     environment: uat-static
     permissions:
       contents: read


### PR DESCRIPTION
## What does this pull request do?

as per this slack thread https://mojdt.slack.com/archives/CFUESB43G/p1782911655175519?thread_ts=1782911325.867169&cid=CFUESB43G

we identified that this worklfow was running without a guard clause so it ran on all PR events, which led to multiple failed slack alerts as related PRs were closed/merged etc over 2 weeks ago. This PR adds a guard clause to limit when this is run to only on opening a PR. Added to the dev discussion to determine. how we want to handle uat-static-deploys going forward. This PR aims to reduce the noise in the alerts channel for now

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
