### PR TITLE
Fix alerts: add readiness probe and wait for db step

### DIFF
--- a/bin/delete_uat_release.sh
+++ b/bin/delete_uat_release.sh
@@ -2,6 +2,7 @@
 set -e
 
 RELEASE_NAME=$(echo $BRANCH_NAME | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
+APP_DEPLOYMENT_NAME="${RELEASE_NAME}-cla-backend-app"
 
 echo "Attempting to delete release $RELEASE_NAME"
 
@@ -12,8 +13,17 @@ echo "$RELEASES"
 
 if [[ $RELEASES == *"$RELEASE_NAME"* ]]
 then
+  echo "Scaling down app deployment before deleting release"
+  kubectl scale deployment "$APP_DEPLOYMENT_NAME" --replicas=0 --ignore-not-found=true
+
+  echo "Waiting for app pods to stop"
+  kubectl wait \
+    --for=delete pod \
+    -l "app=web,app.kubernetes.io/instance=$RELEASE_NAME" \
+    --timeout=90s || true
+
   echo "Deleting release $RELEASE_NAME"
-  helm delete $RELEASE_NAME
+  helm delete "$RELEASE_NAME" --wait --timeout=3m
 else
   echo "Release $RELEASE_NAME was not found"
 fi

--- a/helm_deploy/cla-backend/templates/deployment.yaml
+++ b/helm_deploy/cla-backend/templates/deployment.yaml
@@ -23,6 +23,18 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: 30
+      {{- if .Values.appWaitForDb.enabled }}
+      initContainers:
+        - name: wait-for-db
+          image: "bitnamilegacy/postgresql:14-debian-12"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - until pg_isready -h "${DB_HOST}" -p "${DB_PORT:-5432}" -U "${DB_USER:-postgres}" -d "${DB_NAME:-cla_backend}"; do echo "waiting for db"; sleep 2; done
+          env:
+            {{ include "cla-backend.app.vars" . | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -100,6 +112,26 @@ spec:
             - name: http
               containerPort: 5432
               protocol: TCP
+          {{- if .Values.localPostgresProbes.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -h 127.0.0.1 -p 5432 -U postgres -d cla_backend
+            periodSeconds: {{ .Values.localPostgresProbes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.localPostgresProbes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.localPostgresProbes.startup.failureThreshold }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -h 127.0.0.1 -p 5432 -U postgres -d cla_backend
+            periodSeconds: {{ .Values.localPostgresProbes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.localPostgresProbes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.localPostgresProbes.readiness.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/helm_deploy/cla-backend/values-uat.yaml
+++ b/helm_deploy/cla-backend/values-uat.yaml
@@ -10,6 +10,12 @@ replicaCount: 1
 localPostgres:
   enabled: true
 
+appWaitForDb:
+  enabled: true
+
+localPostgresProbes:
+  enabled: true
+
 queueWorkers:
   enabled: false
 

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -54,6 +54,20 @@ ingress:
 localPostgres:
   enabled: false
 
+appWaitForDb:
+  enabled: false
+
+localPostgresProbes:
+  enabled: false
+  startup:
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  readiness:
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 12
+
 metabase:
   enabled: true
   host: "cla-dashboard"


### PR DESCRIPTION
## What does this pull request do?

commit #1 addresses this alert https://mojdt.slack.com/archives/C04DPTTPE/p1782917920077869 when we deploy a new release to UAT it alerts because the DB is not ready when it is first checked. This now adds a wait and a readiness probe. So whe this PR was opened no alert appeared.

commit #3 addresses this type of alert https://mojdt.slack.com/archives/C04DPTTPE/p1782922072565309 which is the same alert triggered at another time, this happens when the PR is merged or closed. so now we tear down the kubernetes pods and thendelete the helm release. Which shoudl stop that alert being sent.

this doesn't delete the alert but just removes these 2 triggers so when we see the alert it should be a genuine DB issue


Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
