### PR TITLE
infra: update kubectl scale command

### DIFF
--- a/bin/delete_uat_release.sh
+++ b/bin/delete_uat_release.sh
@@ -14,7 +14,7 @@ echo "$RELEASES"
 if [[ $RELEASES == *"$RELEASE_NAME"* ]]
 then
   echo "Scaling down app deployment before deleting release"
-  kubectl scale deployment "$APP_DEPLOYMENT_NAME" --replicas=0 --ignore-not-found=true
+  kubectl scale deployment "$APP_DEPLOYMENT_NAME" --replicas=0 || true
 
   echo "Waiting for app pods to stop"
   kubectl wait \


### PR DESCRIPTION
## What does this pull request do?

`Cleanup UAT` job was failing due to wrong flag being used for kubectl. `--ignore-not-found` is not usable with `scale` but only `get` or `edit` 

<img width="1133" height="794" alt="image" src="https://github.com/user-attachments/assets/c6b0830f-b7a0-407f-898f-90808d61f7a9" />


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
