### PR TITLE
EL-3310: Update EligibilityChecker calculator for FE API calls

### DIFF
--- a/cla_backend/apps/checker/serializers.py
+++ b/cla_backend/apps/checker/serializers.py
@@ -26,6 +26,7 @@ from legalaid.serializers import (
 from legalaid.models import Case, EligibilityCheck
 from checker.models import ReasonForContacting, ReasonForContactingCategory, ScopeTraversal
 from core.serializers import ClaModelSerializer, JSONField
+from cla_backend.libs.eligibility_calculator.calculator import EligibilityChecker
 
 checker_graph = SimpleLazyObject(lambda: get_graph(file_name=settings.CHECKER_DIAGNOSIS_FILE_NAME))
 
@@ -125,6 +126,26 @@ class EligibilityCheckSerializer(EligibilityCheckSerializerBase):
     # TODO: DRF doesn't validate, fields that aren't REQ'd = True
     # we need to figure out a way to deal with it
 
+    is_gross_income_complete = serializers.SerializerMethodField()
+    is_disposable_income_complete = serializers.SerializerMethodField()
+    is_property_complete = serializers.SerializerMethodField()
+    is_savings_complete = serializers.SerializerMethodField()
+
+    def _get_case_data(self, obj):
+        return obj.to_case_data()
+
+    def get_is_gross_income_complete(self, obj):
+        return EligibilityChecker.is_gross_income_complete(self._get_case_data(obj))
+
+    def get_is_disposable_income_complete(self, obj):
+        return EligibilityChecker.is_disposable_income_complete(self._get_case_data(obj))
+
+    def get_is_property_complete(self, obj):
+        return EligibilityChecker.is_property_complete(self._get_case_data(obj))
+
+    def get_is_savings_complete(self, obj):
+        return EligibilityChecker._is_savings_complete(self._get_case_data(obj))
+
     class Meta(EligibilityCheckSerializerBase.Meta):
         fields = (
             "reference",
@@ -142,6 +163,10 @@ class EligibilityCheckSerializer(EligibilityCheckSerializerBase):
             "on_nass_benefits",
             "specific_benefits",
             "disregards",
+            "is_gross_income_complete",
+            "is_disposable_income_complete",
+            "is_property_complete",
+            "is_savings_complete",
         )
         writable_nested_fields = ["you", "partner", "property_set"]
 

--- a/cla_backend/libs/eligibility_calculator/calculator.py
+++ b/cla_backend/libs/eligibility_calculator/calculator.py
@@ -152,31 +152,32 @@ class EligibilityChecker(object):
 
     @staticmethod
     def _translate_section_gross_income(case_data, request_data):
-        def is_gross_income_complete(case_data):
-            if "you" not in case_data.__dict__:
-                return False
-            person = case_data.you
-            if "income" not in person.__dict__:
-                return False
-            income = person.income
-            income_keys_if_complete = set(income.PROPERTY_META.keys())
-            # cla_public will remove the `income.child_benefits` key from CaseDict if you submit /benefits without
-            # checking the child benefit checkbox (which doesn't even appear if dependants_young=0). So this key is not
-            # required for income to be considered complete
-            income_keys_if_complete.remove("child_benefits")
-            for key in income_keys_if_complete:
-                if key not in income.__dict__:
-                    return False
-
-            if "has_partner" not in case_data.facts.__dict__:
-                # If they have a partner then their deductions can lower the disposable income further,
-                # so this section is not complete until we know the partners' figures
-                return False
-
-            return True
-
-        if not is_gross_income_complete(case_data):
+        if not EligibilityChecker.is_gross_income_complete(case_data):
             request_data["assessment"]["section_gross_income"] = "incomplete"
+
+    @staticmethod
+    def is_gross_income_complete(case_data):
+        if "you" not in case_data.__dict__:
+            return False
+        person = case_data.you
+        if "income" not in person.__dict__:
+            return False
+        income = person.income
+        income_keys_if_complete = set(income.PROPERTY_META.keys())
+        # cla_public will remove the `income.child_benefits` key from CaseDict if you submit /benefits without
+        # checking the child benefit checkbox (which doesn't even appear if dependants_young=0). So this key is not
+        # required for income to be considered complete
+        income_keys_if_complete.remove("child_benefits")
+        for key in income_keys_if_complete:
+            if key not in income.__dict__:
+                return False
+
+        if "has_partner" not in case_data.facts.__dict__:
+            # If they have a partner then their deductions can lower the disposable income further,
+            # so this section is not complete until we know the partners' figures
+            return False
+
+        return True
 
     @staticmethod
     def _translate_section_disposable_income(case_data, request_data):
@@ -184,26 +185,26 @@ class EligibilityChecker(object):
         Determine if the questions for disposable income section of the test have been completed by the user yet,
         and put this in the CFE request.
         """
-
-        def is_disposable_income_complete(case_data):
-            if "you" not in case_data.__dict__:
-                return False
-            person = case_data.you
-            if "deductions" not in person.__dict__:
-                return False
-            deductions = case_data.you.deductions
-            for key in deductions.PROPERTY_META:
-                if key not in deductions.__dict__:
-                    return False
-
-            if "has_partner" not in case_data.facts.__dict__:
-                # If they have a partner then their deductions can lower the disposable income further,
-                # so this section is not complete until we know the partners' figures
-                return False
-            return True
-
-        if not is_disposable_income_complete(case_data):
+        if not EligibilityChecker.is_disposable_income_complete(case_data):
             request_data["assessment"]["section_disposable_income"] = "incomplete"
+
+    @staticmethod
+    def is_disposable_income_complete(case_data):
+        if "you" not in case_data.__dict__:
+            return False
+        person = case_data.you
+        if "deductions" not in person.__dict__:
+            return False
+        deductions = case_data.you.deductions
+        for key in deductions.PROPERTY_META:
+            if key not in deductions.__dict__:
+                return False
+
+        if "has_partner" not in case_data.facts.__dict__:
+            # If they have a partner then their deductions can lower the disposable income further,
+            # so this section is not complete until we know the partners' figures
+            return False
+        return True
 
     @staticmethod
     def is_property_complete(case_data):


### PR DESCRIPTION
## What does this pull request do?

If applied, this pulls out 
- `is_gross_income_complete`
- `is_disposable_income_complete`
- `is_property_complete`
- `is_savings_complete` 

from the EligibilityChecker calculator

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
