### PR TITLE
LGA-4216: return mobile_phone in search body without modifying models

### DIFF
--- a/cla_backend/apps/call_centre/serializers.py
+++ b/cla_backend/apps/call_centre/serializers.py
@@ -330,6 +330,12 @@ class CaseSerializer(CaseSerializerFull):
 
 
 class CaseListSerializer(CaseSerializer):
+    mobile_phone = serializers.CharField(
+        source="personal_details.mobile_phone",
+        read_only=True,
+        allow_null=True,
+    )
+
     class Meta(CaseSerializer.Meta):
         fields = (
             "reference",
@@ -353,6 +359,7 @@ class CaseListSerializer(CaseSerializer):
             "flagged_with_eod",
             "is_urgent",
             "organisation_name",
+            "mobile_phone",
         )
 
 


### PR DESCRIPTION
# What does this pull request do?

<!-- Briefly describe the change and why it's needed. -->

**Ticket:** [LGA-4216](https://dsdmoj.atlassian.net/browse/LGA-4216)

As part of connecting `laa-cla-operator-app` to the backend, we need the phone numbers to be returned in the search function. Instead of migrating DBs and altering Models, I've simply fetch those and returned them as read-only get values

## Any other changes worth highlighting?

<!-- Note any side effects, refactors, or related changes that reviewers should be aware of. Remove this section if not applicable. -->

None.

## Screenshots / evidence

<!-- If this includes UI changes, add before/after screenshots. Remove this section if not applicable. -->

## Checklist

- [ ] Provided Jira ticket number in the PR title, e.g. `LGA-152: Sample title`
- [ ] Tested locally and verified the change works as expected
- [ ] Updated or added tests where appropriate
- [ ] Updated documentation / README if applicable

[LGA-4216]: https://dsdmoj.atlassian.net/browse/LGA-4216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ