### PR TITLE
LGA-4214 - Add cloudfront for static assets

### DIFF
--- a/cla_backend/libs/aws/s3.py
+++ b/cla_backend/libs/aws/s3.py
@@ -3,14 +3,6 @@ from storages.backends.s3boto3 import S3Boto3Storage
 from botocore.exceptions import ClientError
 
 
-class ClientError(ClientError):
-    pass
-
-
-class StaticS3Storage(S3Boto3Storage):
-    default_acl = "public-read"
-
-
 class ReportsS3:
     @classmethod
     def clean_name(cls, name):

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -110,7 +110,7 @@ EXPORT_DIR = "/exports/"
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 if os.environ.get("STATIC_FILES_BACKEND") == "s3":
-    STATICFILES_STORAGE = "cla_backend.libs.aws.s3.StaticS3Storage"
+    STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "eu-west-1")
 AWS_DEFAULT_ACL = None
@@ -367,12 +367,11 @@ if "localhost" in ALLOWED_HOSTS:
 CSP_FONT_SRC = ["'self'", "data:"]
 CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
 
-if AWS_STORAGE_BUCKET_NAME:
-    AWS_STORAGE_BUCKET_HOSTNAME = AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com"
-    CSP_DEFAULT_SRC.append(AWS_STORAGE_BUCKET_HOSTNAME)
-    CSP_FONT_SRC.append(AWS_STORAGE_BUCKET_HOSTNAME)
-    CSP_STYLE_SRC.append(AWS_STORAGE_BUCKET_HOSTNAME)
-    CSP_SCRIPT_SRC.append(AWS_STORAGE_BUCKET_HOSTNAME)
+if AWS_S3_CUSTOM_DOMAIN:
+    CSP_DEFAULT_SRC.append(AWS_S3_CUSTOM_DOMAIN)
+    CSP_FONT_SRC.append(AWS_S3_CUSTOM_DOMAIN)
+    CSP_STYLE_SRC.append(AWS_S3_CUSTOM_DOMAIN)
+    CSP_SCRIPT_SRC.append(AWS_S3_CUSTOM_DOMAIN)
 
 # Django rest-framework-overrides
 REST_FRAMEWORK = {

--- a/cla_backend/settings/base.py
+++ b/cla_backend/settings/base.py
@@ -115,6 +115,7 @@ if os.environ.get("STATIC_FILES_BACKEND") == "s3":
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "eu-west-1")
 AWS_DEFAULT_ACL = None
 AWS_QUERYSTRING_AUTH = False
+AWS_S3_CUSTOM_DOMAIN = os.environ.get("CLOUDFRONT_URL", None)
 
 # This bucket needs to a private bucket as it will contain sensitive reports
 AWS_REPORTS_STORAGE_BUCKET_NAME = os.environ.get("AWS_REPORTS_STORAGE_BUCKET_NAME")

--- a/helm_deploy/cla-backend/values.yaml
+++ b/helm_deploy/cla-backend/values.yaml
@@ -173,6 +173,10 @@ envVars:
     secret:
       name: s3
       key: static_files_bucket_name
+  CLOUDFRONT_URL:
+    secret:
+      name: cloudfront-static-assets
+      key: cloudfront_url
   AWS_DELETED_OBJECTS_BUCKET_NAME:
     secret:
       name: s3


### PR DESCRIPTION
# What does this pull request do?

Use cloudfront to serve static assets instead of direct from S3 bucket

**Ticket:** LGA-4214

## Any other changes worth highlighting?

The S3  bucket will be changed from public-read to private in a separate cloud-platforms PR


## Checklist

- [x] Provided Jira ticket number in the PR title, e.g. `LGA-152: Sample title`
- [ ] Tested locally and verified the change works as expected
- [ ] Updated or added tests where appropriate
- [ ] Updated documentation / README if applicable