### PR TITLE
fix: bump metabase

### DIFF
--- a/helm_deploy/cla-backend/templates/metabase/deployment.yaml
+++ b/helm_deploy/cla-backend/templates/metabase/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: metabase
-        image: metabase/metabase:v0.49.7
+        image: metabase/metabase:v0.63.5
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
           - containerPort: 3000


### PR DESCRIPTION
# What does this pull request do?

<!-- Briefly describe the change and why it's needed. -->

Bumping `metabase` image to a safe version as per https://www.metabase.com/blog/security-update

Althought, we used a very old version and it wouldn't be affected by this vuln, the fact that is so old may mean no longer support for it and likely to be affected by other vulns. 

Slack: https://mojdt.slack.com/archives/C7KCVJZSQ/p1786692872573769

## Any other changes worth highlighting?

<!-- Note any side effects, refactors, or related changes that reviewers should be aware of. Remove this section if not applicable. -->

None.

## Screenshots / evidence

<!-- If this includes UI changes, add before/after screenshots. Remove this section if not applicable. -->

## Checklist

- [ ] Provided Jira ticket number in the PR title, e.g. `LGA-152: Sample title`
- [ ] Tested locally and verified the change works as expected
- [ ] Updated or added tests where appropriate
- [ ] Updated documentation / README if applicable